### PR TITLE
chore: enforce marked@^0.3.9 for security reasons

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1109,7 +1109,7 @@
         "espree": "3.1.7",
         "js2xmlparser": "1.0.0",
         "klaw": "1.3.1",
-        "marked": "0.3.6",
+        "marked": "0.3.12",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -1316,9 +1316,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
     },
     "mem": {
       "version": "1.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "jsdoc": "3.4.3",
     "jsdoc-json": "^2.0.0",
     "jsdoc2spec": "^0.6.0",
+    "marked": "^0.3.12",
     "rimraf": "^2.5.4",
     "striptags": "2.1.1"
   }


### PR DESCRIPTION
enforce marked@^0.3.9 in package.json in docs 