### PR TITLE
docs: Website static scroll effect

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -21,6 +21,26 @@ code {
   box-shadow: 0 0 12px rgba(100, 100, 100, 0.1);
 }
 
+.homeContainer {
+  height: 320px;
+}
+
+.homeContainer .homeSplashFade {
+  position: fixed;
+  width: 100%;
+  z-index: 1;
+}
+
+.mainContainer {
+  position: relative;
+  z-index: 2;
+}
+
+footer {
+  position: relative;
+  z-index: 2;
+}
+
 .homeContainer, .fixedHeaderContainer {
   background: linear-gradient(90deg, #9ecc4c 0%, #45B3B2 100%);
 }


### PR DESCRIPTION
![static-scroll](https://user-images.githubusercontent.com/734718/36098820-aea10df8-1000-11e8-8f7f-2296e4ac7f54.gif)

Logo "stays" behind and you only scroll the main page when you go up, like a... curtain? 

Almost like a parallax effect :)