### PR TITLE
docs: fix typos in plugin-q

### DIFF
--- a/docs/dist/plugin-q.md
+++ b/docs/dist/plugin-q.md
@@ -16,7 +16,7 @@ npm install picasso-plugin-q
 import picasso from 'picasso.js';
 import picassoQ from 'picasso-plugin-q';
 
-picasso.use(pluginQ); // register
+picasso.use(picassoQ); // register
 ```
 
 ## `q` dataset
@@ -28,7 +28,7 @@ This dataset type understands the QIX hypercube format and its internals, making
 ```js
 const ds = picasso.data('q')({
   key: 'qHyperCube', // path to the hypercube from the layout
-  data: layout.qHypercube
+  data: layout.qHyperCube
 });
 ```
 

--- a/docs/src/input/plugin-q.md
+++ b/docs/src/input/plugin-q.md
@@ -16,7 +16,7 @@ npm install picasso-plugin-q
 import picasso from 'picasso.js';
 import picassoQ from 'picasso-plugin-q';
 
-picasso.use(pluginQ); // register
+picasso.use(picassoQ); // register
 ```
 
 ## `q` dataset
@@ -28,7 +28,7 @@ This dataset type understands the QIX hypercube format and its internals, making
 ```js
 const ds = picasso.data('q')({
   key: 'qHyperCube', // path to the hypercube from the layout
-  data: layout.qHypercube
+  data: layout.qHyperCube
 });
 ```
 

--- a/plugins/q/README.md
+++ b/plugins/q/README.md
@@ -14,7 +14,7 @@ npm install picasso-plugin-q
 import picasso from 'picasso.js';
 import picassoQ from 'picasso-plugin-q';
 
-picasso.use(pluginQ); // register
+picasso.use(picassoQ); // register
 ```
 
 ## `q` dataset
@@ -24,7 +24,7 @@ This dataset type understands the QIX hypercube format and its internals, making
 ```js
 const ds = picasso.data('q')({
   key: 'qHyperCube', // path to the hypercube from the layout
-  data: layout.qHypercube
+  data: layout.qHyperCube
 });
 ```
 


### PR DESCRIPTION
Closes #23
Closes #24 