### PR TITLE
chore: update ref to private packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run build
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -101,11 +97,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run build:dev
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -135,11 +127,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run lint
     
   test-unit:
@@ -147,11 +135,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run test:unit:coverage
       - run: 
           name: Publish coverage
@@ -164,11 +148,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run test:component:coverage
 
   test-integration:
@@ -176,11 +156,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - run: npm run bootstrap
       - run: npm run test:integration:local
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,13 @@ defaults: &defaults
   docker:
     - image: circleci/node:8.9.4-browsers
 
+restore_cache: &restore_cache
+  # Force restore cache here to enable symlinked packages
+  restore_cache:
+    key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+  restore_cache:
+    key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+
 jobs:
   install:
     <<: *defaults
@@ -79,10 +86,7 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - <<: *restore_cache
       - run: npm run build
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -102,10 +106,7 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - restore_cache:
-          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-      - restore_cache:
-          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
+      - <<: *restore_cache
       - run: npm run build:dev
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -135,6 +136,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - <<: *restore_cache
       - run: npm run lint
     
   test-unit:
@@ -142,6 +145,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - <<: *restore_cache
       - run: npm run test:unit:coverage
       - run: 
           name: Publish coverage
@@ -154,6 +159,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - <<: *restore_cache
       - run: npm run test:component:coverage
 
   test-integration:
@@ -161,6 +168,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - <<: *restore_cache
       - run: npm run test:integration:local
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,6 @@ defaults: &defaults
   docker:
     - image: circleci/node:8.9.4-browsers
 
-restore_cache: &restore_cache
-  # Force restore cache here to enable symlinked packages
-  restore_cache:
-    key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
-  restore_cache:
-    key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
-
 jobs:
   install:
     <<: *defaults
@@ -86,7 +79,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run build
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -106,7 +102,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run build:dev
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -137,7 +136,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run lint
     
   test-unit:
@@ -146,7 +148,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run test:unit:coverage
       - run: 
           name: Publish coverage
@@ -160,7 +165,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run test:component:coverage
 
   test-integration:
@@ -169,7 +177,10 @@ jobs:
       - attach_workspace:
           at: ~/picassojs
       # Force restore cache here to enable symlinked packages
-      - <<: *restore_cache
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run test:integration:local
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run build
       - store_artifacts:
           path: packages/picasso.js/dist
@@ -96,6 +101,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
+      # Force restore cache here to enable symlinked packages
+      - restore_cache:
+          key: v1-cache-picasso.js-{{ checksum "packages/picasso.js/package-lock.json" }}
+      - restore_cache:
+          key: v1-cache-hammer-{{ checksum "plugins/hammer/package-lock.json" }}
       - run: npm run build:dev
       - store_artifacts:
           path: packages/picasso.js/dist

--- a/packages/picasso.js/package-lock.json
+++ b/packages/picasso.js/package-lock.json
@@ -253,6 +253,15 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path2d-polyfill": {
+      "version": "file:../path2d-polyfill",
+      "dependencies": {
+        "npxc": {
+          "version": "0.0.3",
+          "bundled": true
+        }
+      }
+    },
     "requizzle": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
@@ -290,6 +299,9 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+    },
+    "test-utils": {
+      "version": "file:../test-utils"
     },
     "underscore": {
       "version": "1.8.3",

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -55,9 +55,9 @@
     "jsdoc": "^3.4.0",
     "node-event-emitter": "0.0.1",
     "npxc": "^0.0.3",
-    "path2d-polyfill": "^0.1.0",
+    "path2d-polyfill": "../path2d-polyfill",
     "rimraf": "^2.5.2",
     "snabbdom": "^0.5.4",
-    "test-utils": "*"
+    "test-utils": "../test-utils"
   }
 }

--- a/plugins/hammer/package-lock.json
+++ b/plugins/hammer/package-lock.json
@@ -6,6 +6,9 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/npxc/-/npxc-0.0.3.tgz",
       "integrity": "sha512-f6x780LugNc6ZtzyeEb6RKCXQZOzZKmHRa/Oa8XI/Lux0pQQi+8h1d16QkJam9oBj3F7OEsWO8bI/JH8DdOqTQ=="
+    },
+    "test-utils": {
+      "version": "file:../../packages/test-utils"
     }
   }
 }

--- a/plugins/hammer/package.json
+++ b/plugins/hammer/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "npxc": "^0.0.3",
-    "test-utils": "*"
+    "test-utils": "../../packages/test-utils"
   }
 }


### PR DESCRIPTION
`persist_to_workspace` and `restore_cache` command don't handle symlinked packages (the private packages), so had to resort to `bootstrap`ing on each job to recreate the the symlink.