### PR TITLE
fix: getAffectedShapes should not return duplicates

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -440,17 +440,21 @@ function componentFactory(definition, options = {}) {
 
   fn.getBrushedShapes = function getBrushedShapes(context, mode, props) {
     const shapes = [];
-    if (settings.brush && settings.brush.trigger) {
+    if (settings.brush && settings.brush.consume) {
       const brusher = chart.brush(context);
       const sceneNodes = rend.findShapes('*');
-      settings.brush.trigger.forEach((b) => {
-        sceneNodes.forEach((node) => {
-          const nodeData = node.data;
-          if (nodeData && brusher.containsMappedData(nodeData, props || b.data, mode)) {
-            shapes.push(node);
+      settings.brush.consume
+        .filter(t => t.context === context)
+        .forEach((consume) => {
+          for (let i = 0; i < sceneNodes.length; i++) {
+            const node = sceneNodes[i];
+            if (node.data && brusher.containsMappedData(node.data, props || consume.data, mode)) {
+              shapes.push(node);
+              sceneNodes.splice(i, 1);
+              i--;
+            }
           }
         });
-      });
     }
     return shapes;
   };


### PR DESCRIPTION
BREAKING CHANGE

getAffectedShapes no longer returns each matching shape multiple times for each trigger in the related component.

Also changed (breaking) so that a affected shape is defined by the consume configuration instead of the trigger config.

```js
// Before
{
	trigger: [{
		contexts: ['test']
	}]
}

// After
{
	consume: [{
		context: 'test'
	}]
}
```

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
