### PR TITLE
fix: band scale datum method returns undefined

### DIFF
--- a/packages/picasso.js/src/core/scales/band.js
+++ b/packages/picasso.js/src/core/scales/band.js
@@ -69,6 +69,7 @@ export default function scaleBand(settings = {}, data = {}) {
     if (values.indexOf(v) === -1) {
       values.push(v);
       labels.push(labelFn(items[i]));
+      domainToDataMapping[v] = i;
     }
   }
 

--- a/packages/picasso.js/test/unit/core/scales/band.spec.js
+++ b/packages/picasso.js/test/unit/core/scales/band.spec.js
@@ -46,6 +46,14 @@ describe('OrdinalScale', () => {
       expect(scale('C')).to.equal(2 / 3);
     });
 
+    it('should return mapped datum values', () => {
+      items = ['A', 'B', 'C'].map(v => ({ value: v, id: v }));
+      scale = band(settings, { fields: [], items });
+      expect(scale.datum('B')).to.eql({
+        value: 'B', id: 'B'
+      });
+    });
+
     describe('with maxPxStep', () => {
       it('with start align should adjust correctly', () => {
         items = ['A', 'B'].map(v => ({ value: v, id: v }));


### PR DESCRIPTION
Fixes band scale's `.datum()` method, which probably degraded during refactoring