### PR TITLE
fix(renderer): reset scene when clearing render

### DIFF
--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -201,6 +201,7 @@ export function renderer(sceneFn = sceneFactory) {
     if (el) {
       el.width = el.width;
     }
+    scene = null;
 
     return canvasRenderer;
   };

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -116,6 +116,7 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     if (!group) {
       return svg;
     }
+    scene = null;
     const g = group.cloneNode(false);
     el.replaceChild(g, group);
     group = g;

--- a/packages/picasso.js/test/unit/web/renderer/canvas-renderer/canvas-renderer.spec.js
+++ b/packages/picasso.js/test/unit/web/renderer/canvas-renderer/canvas-renderer.spec.js
@@ -42,6 +42,27 @@ describe('canvas renderer', () => {
     expect(r.render()).to.equal(true);
   });
 
+  it('should not render if scene and size has not changed', () => {
+    r.appendTo(element('div'));
+    scene.returns({
+      children: [],
+      equals: () => true
+    });
+    expect(r.render()).to.equal(true);
+    expect(r.render()).to.equal(false);
+  });
+
+  it('should render if scene has been cleared', () => {
+    r.appendTo(element('div'));
+    scene.returns({
+      children: [],
+      equals: () => true
+    });
+    expect(r.render()).to.equal(true);
+    r.clear();
+    expect(r.render()).to.equal(true);
+  });
+
   it('should return zero size when canvas is not initiated', () => {
     expect(r.size()).to.deep.equal({ x: 0, y: 0, width: 0, height: 0, scaleRatio: { x: 1, y: 1 }, margin: { left: 0, top: 0 } });
   });

--- a/packages/picasso.js/test/unit/web/renderer/svg-renderer/svg-renderer.spec.js
+++ b/packages/picasso.js/test/unit/web/renderer/svg-renderer/svg-renderer.spec.js
@@ -127,6 +127,16 @@ describe('svg renderer', () => {
       svg.appendTo(element('div'));
       expect(svg.render).to.not.throw();
     });
+
+    it('should not render if scene and size has not changed', () => {
+      svg.appendTo(element('div'));
+      scene.returns({
+        children: [],
+        equals: () => true
+      });
+      expect(svg.render()).to.equal(true);
+      expect(svg.render()).to.equal(false);
+    });
   });
 
   describe('clear', () => {
@@ -139,6 +149,17 @@ describe('svg renderer', () => {
       svg.clear();
 
       expect(svg.root().children.length).to.equal(0);
+    });
+
+    it('should render if scene has been cleared', () => {
+      svg.appendTo(element('div'));
+      scene.returns({
+        children: [],
+        equals: () => true
+      });
+      expect(svg.render()).to.equal(true);
+      svg.clear();
+      expect(svg.render()).to.equal(true);
     });
   });
 


### PR DESCRIPTION
This fixes an issue where rendering did not occur after a clear due the scene being the same.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] ~documentation updated~
