### PR TITLE
chore: Simplify rollup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-dist/*
+**/dist/*
 test/unit/coverage/*
 test/component/coverage/*
 docs/node_modules/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9530,6 +9530,15 @@
         "rollup-pluginutils": "1.5.2"
       }
     },
+    "rollup-plugin-clean": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-clean/-/rollup-plugin-clean-1.0.0.tgz",
+      "integrity": "sha512-om3+UsHOFMsB/StS2vxZcwq0Poqcx6SP7Aw/AtXXPr7yEybC6GW6IUHQANWOEop0fiuVteq2goxeC5UPRASFGg==",
+      "dev": true,
+      "requires": {
+        "rimraf": "2.6.2"
+      }
+    },
     "rollup-plugin-commonjs": {
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rimraf": "^2.5.2",
     "rollup": "^0.43.0",
     "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-clean": "^1.0.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-filesize": "^1.4.2",
     "rollup-plugin-license": "^0.4.0",

--- a/packages/path2d-polyfill/package.json
+++ b/packages/path2d-polyfill/package.json
@@ -4,9 +4,9 @@
   "description": "Path2D polyfill",
   "private": true,
   "scripts": {
-    "build": "npxc rollup -c ../../rollup.config.js --name path2dPolyfill --environment BUILD:production",
-    "build:dev": "npxc rollup -c ../../rollup.config.js --name path2dPolyfill",
-    "build:watch": "npxc rollup -c ../../rollup.config.js --name path2dPolyfill -w",
+    "build": "npxc rollup -c ../../rollup.config.js --name path2dPolyfill",
+    "build:dev": "npm run build",
+    "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test:unit": "npxc aw -c aw.config.js",
     "test:unit:watch": "npm run test:unit -- -w",

--- a/packages/path2d-polyfill/package.json
+++ b/packages/path2d-polyfill/package.json
@@ -14,7 +14,7 @@
   "files": [
     "/dist"
   ],
-  "main": "dist/path2d-polyfill.min.js",
+  "main": "dist/path2d-polyfill.js",
   "module": "src/index.js",
   "devDependencies": {
     "npxc": "^0.0.3"

--- a/packages/path2d-polyfill/package.json
+++ b/packages/path2d-polyfill/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js --name path2dPolyfill",
-    "build:dev": "npm run build",
     "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test:unit": "npxc aw -c aw.config.js",

--- a/packages/picasso.js/package-lock.json
+++ b/packages/picasso.js/package-lock.json
@@ -1,26 +1,32 @@
 {
-  "requires": true,
+  "name": "picasso.js",
+  "version": "0.6.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "babylon": {
       "version": "7.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -30,6 +36,7 @@
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
       "requires": {
         "underscore-contrib": "0.3.0"
       }
@@ -37,42 +44,50 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "d3-array": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
+      "dev": true
     },
     "d3-collection": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-      "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+      "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI=",
+      "dev": true
     },
     "d3-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
+      "dev": true
     },
     "d3-ease": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-      "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
+      "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4=",
+      "dev": true
     },
     "d3-format": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.1.tgz",
-      "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
+      "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w==",
+      "dev": true
     },
     "d3-hierarchy": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-      "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
+      "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY=",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
       "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+      "dev": true,
       "requires": {
         "d3-color": "1.0.3"
       }
@@ -80,12 +95,14 @@
     "d3-path": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
+      "dev": true
     },
     "d3-scale": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
       "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dev": true,
       "requires": {
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",
@@ -100,6 +117,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
       "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+      "dev": true,
       "requires": {
         "d3-path": "1.0.5"
       }
@@ -107,12 +125,14 @@
     "d3-time": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ==",
+      "dev": true
     },
     "d3-time-format": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
       "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+      "dev": true,
       "requires": {
         "d3-time": "1.0.8"
       }
@@ -120,22 +140,26 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -148,17 +172,20 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -167,12 +194,14 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "js2xmlparser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
       "requires": {
         "xmlcreate": "1.0.2"
       }
@@ -181,6 +210,7 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
         "bluebird": "3.5.1",
@@ -200,6 +230,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -207,12 +238,14 @@
     "marked": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ=="
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -220,12 +253,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -233,17 +268,20 @@
     "node-event-emitter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/node-event-emitter/-/node-event-emitter-0.0.1.tgz",
-      "integrity": "sha1-i1lzd9eaHZdvfUX5FtPTZD1z+M4="
+      "integrity": "sha1-i1lzd9eaHZdvfUX5FtPTZD1z+M4=",
+      "dev": true
     },
     "npxc": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/npxc/-/npxc-0.0.3.tgz",
-      "integrity": "sha512-f6x780LugNc6ZtzyeEb6RKCXQZOzZKmHRa/Oa8XI/Lux0pQQi+8h1d16QkJam9oBj3F7OEsWO8bI/JH8DdOqTQ=="
+      "integrity": "sha512-f6x780LugNc6ZtzyeEb6RKCXQZOzZKmHRa/Oa8XI/Lux0pQQi+8h1d16QkJam9oBj3F7OEsWO8bI/JH8DdOqTQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -251,10 +289,12 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path2d-polyfill": {
       "version": "file:../path2d-polyfill",
+      "dev": true,
       "dependencies": {
         "npxc": {
           "version": "0.0.3",
@@ -266,6 +306,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
       "requires": {
         "underscore": "1.6.0"
       },
@@ -273,7 +314,8 @@
         "underscore": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
@@ -281,6 +323,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -288,30 +331,36 @@
     "snabbdom": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.5.4.tgz",
-      "integrity": "sha1-gtcm/UlYQ9iSDVSsPKZwt+UDN14="
+      "integrity": "sha1-gtcm/UlYQ9iSDVSsPKZwt+UDN14=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
     },
     "test-utils": {
-      "version": "file:../test-utils"
+      "version": "file:../test-utils",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
       "requires": {
         "underscore": "1.6.0"
       },
@@ -319,19 +368,22 @@
         "underscore": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8="
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "dev": true
     }
   }
 }

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -22,7 +22,7 @@
   "files": [
     "/dist"
   ],
-  "main": "dist/picasso.min.js",
+  "main": "dist/picasso.js",
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js",

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -25,9 +25,9 @@
   "main": "dist/picasso.min.js",
   "module": "src/index.js",
   "scripts": {
-    "build": "npxc rollup -c ../../rollup.config.js --environment BUILD:production",
-    "build:dev": "npxc rollup -c ../../rollup.config.js",
-    "build:watch": "npxc rollup -c ../../rollup.config.js -w",
+    "build": "npxc rollup -c ../../rollup.config.js",
+    "build:dev": "npm run build",
+    "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "lint:fix": "npm run lint -- --fix",
     "lint:recommended": "npm run lint -- --config .eslintrc-recommended.json",

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -26,7 +26,6 @@
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js",
-    "build:dev": "npm run build",
     "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -40,7 +40,7 @@
     "test:integration:local": "npxc webdriver-manager update --versions.chrome 2.34 --gecko false && npxc aw protractor -c aw.config.js --require babel-register --require babel-helpers",
     "fixture:server": "npxc aw serve -c aw.webserver.config.js",
     "version": "node scripts/version.js && git add src/about.js",
-    "prepublishOnly": "rm -rf dist && npm run build && npm run build:dev"
+    "prepublishOnly": "rm -rf dist && npm run build"
   },
   "devDependencies": {
     "d3-ease": "^1.0.3",

--- a/packages/picasso.js/test/integration/chart/brushing/over.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/over.fix.html
@@ -1,89 +1,89 @@
 <html lang="en">
-<head>
+  <head>
     <title>Component Test</title>
     <meta charset="utf-8">
-  <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <base href="/">
+    <script src="/packages/picasso.js/dist/picasso.js"></script>
     <style>
-        #container {
-            width: 100%;
-            height: 100%;
-        }
+      #container {
+        width: 100%;
+        height: 100%;
+      }
     </style>
-</head>
+  </head>
 
-<body>
-    <div id="container" ></div>
+  <body>
+    <div id="container"></div>
 
-  <script>
-  let data = {
-    data: [
-      ['Product', 'Cost'],
-      ['Cars', 150000],
-      ['Trucks', 450000]
-    ]
-  };
+    <script>
+      let data = {
+        data: [
+          ['Product', 'Cost'],
+          ['Cars', 150000],
+          ['Trucks', 450000]
+        ]
+      };
 
-  let brush = {
-    trigger: [
-      {
-        on: 'over',
-        contexts: ['test']
-      }
-    ],
-    consume: [{
-      context: 'test',
-        style: {
-          inactive: {
-            fill: 'red'
-        }
-      }
-    }]
-  };
-
-  let pointMarker = {
-    type: 'point',
-      data: {
-        extract: {
-          field: 0,
-          props: {
-            x: { field: 0 },
-            y: { field: 1 }
+      let brush = {
+        trigger: [
+          {
+            on: 'over',
+            contexts: ['test']
           }
-        }
-      },
-      settings: {
-        x: {
-          scale: 'd0',
-          ref: 'x'
-        },
-        y: {
-          scale: 'm0',
-          ref: 'y'
-        }
-      },
-      brush
-    };
+        ],
+        consume: [{
+          context: 'test',
+            style: {
+              inactive: {
+                fill: 'red'
+            }
+          }
+        }]
+      };
 
-  let settings = {
-    scales: {
-      d0: {
-        data: { field: 0 }
-      },
-      m0: {
-        data: { field: 1 },
-        expand: 1 // Expand so that shapes dont end up at the boundaries
-      }
-    },
-    components: [pointMarker]
-  };
-  let element = document.getElementById("container");
-  window.fixture = picasso.chart({
-    element,
-    data,
-    settings
-  });
-  </script>
-</body>
+      let pointMarker = {
+        type: 'point',
+          data: {
+            extract: {
+              field: 0,
+              props: {
+                x: { field: 0 },
+                y: { field: 1 }
+              }
+            }
+          },
+          settings: {
+            x: {
+              scale: 'd0',
+              ref: 'x'
+            },
+            y: {
+              scale: 'm0',
+              ref: 'y'
+            }
+          },
+          brush
+        };
+
+      let settings = {
+        scales: {
+          d0: {
+            data: { field: 0 }
+          },
+          m0: {
+            data: { field: 1 },
+            expand: 1 // Expand so that shapes dont end up at the boundaries
+          }
+        },
+        components: [pointMarker]
+      };
+      let element = document.getElementById("container");
+      window.fixture = picasso.chart({
+        element,
+        data,
+        settings
+      });
+    </script>
+  </body>
 
 </html>

--- a/packages/picasso.js/test/integration/chart/brushing/over.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/over.fix.html
@@ -1,19 +1,19 @@
 <html lang="en">
 <head>
-	<title>Component Test</title>
-	<meta charset="utf-8">
+    <title>Component Test</title>
+    <meta charset="utf-8">
   <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.min.js"></script>
-	<style>
-		#container {
-			width: 100%;
-			height: 100%;
-		}
-	</style>
+  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <style>
+        #container {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
 </head>
 
 <body>
-	<div id="container" ></div>
+    <div id="container" ></div>
 
   <script>
   let data = {

--- a/packages/picasso.js/test/integration/chart/brushing/tap.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/tap.fix.html
@@ -1,89 +1,88 @@
 <html lang="en">
-<head>
+  <head>
     <title>Component Test</title>
     <meta charset="utf-8">
-  <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <base href="/">
+    <script src="/packages/picasso.js/dist/picasso.js"></script>
     <style>
         #container {
-            width: 100%;
-            height: 100%;
+          width: 100%;
+          height: 100%;
         }
     </style>
-</head>
+  </head>
 
-<body>
-    <div id="container" ></div>
+  <body>
+    <div id="container"></div>
 
-  <script>
-  let data = {
-    data: [
-      ['Product', 'Cost'],
-      ['Cars', 150000],
-      ['Trucks', 450000]
-    ]
-  };
+    <script>
+      let data = {
+        data: [
+          ['Product', 'Cost'],
+          ['Cars', 150000],
+          ['Trucks', 450000]
+        ]
+      };
 
-  let brush = {
-    trigger: [
-      {
-        on: 'tap',
-        contexts: ['test']
-      }
-    ],
-    consume: [{
-      context: 'test',
-        style: {
-          inactive: {
-            fill: 'red'
-        }
-      }
-    }]
-  };
-
-  let pointMarker = {
-    type: 'point',
-      data: {
-        extract: {
-          field: 0,
-          props: {
-            x: { field: 0 },
-            y: { field: 1 }
+      let brush = {
+        trigger: [
+          {
+            on: 'tap',
+            contexts: ['test']
           }
-        }
-      },
-      settings: {
-        x: {
-          scale: 'd0',
-          ref: 'x'
+        ],
+        consume: [{
+          context: 'test',
+            style: {
+              inactive: {
+                fill: 'red'
+            }
+          }
+        }]
+      };
+
+      let pointMarker = {
+        type: 'point',
+          data: {
+            extract: {
+              field: 0,
+              props: {
+                x: { field: 0 },
+                y: { field: 1 }
+              }
+            }
+          },
+          settings: {
+            x: {
+              scale: 'd0',
+              ref: 'x'
+            },
+            y: {
+              scale: 'm0',
+              ref: 'y'
+            }
+          },
+          brush
+        };
+
+      let settings = {
+        scales: {
+          d0: {
+            data: { field: 0 }
+          },
+          m0: {
+            data: { field: 1 },
+            expand: 1 // Expand so that shapes dont end up at the boundaries
+          }
         },
-        y: {
-          scale: 'm0',
-          ref: 'y'
-        }
-      },
-      brush
-    };
-
-  let settings = {
-    scales: {
-      d0: {
-        data: { field: 0 }
-      },
-      m0: {
-        data: { field: 1 },
-        expand: 1 // Expand so that shapes dont end up at the boundaries
-      }
-    },
-    components: [pointMarker]
-  };
-  let element = document.getElementById("container");
-  window.fixture = picasso.chart({
-    element,
-    data,
-    settings
-  });
-  </script>
-</body>
-
+        components: [pointMarker]
+      };
+      let element = document.getElementById("container");
+      window.fixture = picasso.chart({
+        element,
+        data,
+        settings
+      });
+    </script>
+  </body>
 </html>

--- a/packages/picasso.js/test/integration/chart/brushing/tap.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/tap.fix.html
@@ -1,19 +1,19 @@
 <html lang="en">
 <head>
-	<title>Component Test</title>
-	<meta charset="utf-8">
+    <title>Component Test</title>
+    <meta charset="utf-8">
   <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.min.js"></script>
-	<style>
-		#container {
-			width: 100%;
-			height: 100%;
-		}
-	</style>
+  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <style>
+        #container {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
 </head>
 
 <body>
-	<div id="container" ></div>
+    <div id="container" ></div>
 
   <script>
   let data = {

--- a/packages/picasso.js/test/integration/chart/brushing/tap_scroll.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/tap_scroll.fix.html
@@ -1,92 +1,93 @@
 <html lang="en">
-<head>
+  <head>
     <title>Component Test</title>
     <meta charset="utf-8">
-  <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <base href="/">
+    <script src="/packages/picasso.js/dist/picasso.js"></script>
     <style>
-        #container {
-            width: 100%;
-            height: 100%;
-      position: relative;
-      top: 1000px;
-      overflow: auto
-        }
+      #container {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        top: 1000px;
+        overflow: auto
+      }
     </style>
-</head>
+  </head>
 
-<body>
-    <div id="container" ></div>
+  <body>
+    <div id="container"></div>
 
-  <script>
-  let data = {
-    data: [
-      ['Product', 'Cost'],
-      ['Cars', 150000],
-      ['Trucks', 450000]
-    ]
-  };
+    <script>
+      let data = {
+        data: [
+          ['Product', 'Cost'],
+          ['Cars', 150000],
+          ['Trucks', 450000]
+        ]
+      };
 
-  let brush = {
-    trigger: [
-      {
-        on: 'tap',
-        contexts: ['test']
-      }
-    ],
-    consume: [{
-      context: 'test',
-        style: {
-          inactive: {
-          fill: 'red'
-        }
-      }
-    }]
-  };
-
-  let pointMarker = {
-    type: 'point',
-      data: {
-        extract: {
-          field: 0,
-          props: {
-            x: { field: 0 },
-            y: { field: 1 }
+      let brush = {
+        trigger: [
+          {
+            on: 'tap',
+            contexts: ['test']
           }
-        }
-      },
-      settings: {
-        x: {
-          scale: 'd0',
-          ref: 'x'
+        ],
+        consume: [{
+          context: 'test',
+            style: {
+              inactive: {
+              fill: 'red'
+            }
+          }
+        }]
+      };
+
+      let pointMarker = {
+        type: 'point',
+          data: {
+            extract: {
+              field: 0,
+              props: {
+                x: { field: 0 },
+                y: { field: 1 }
+              }
+            }
+          },
+          settings: {
+            x: {
+              scale: 'd0',
+              ref: 'x'
+            },
+            y: {
+              scale: 'm0',
+              ref: 'y'
+            }
+          },
+          brush
+        };
+
+      let settings = {
+        scales: {
+          d0: {
+            data: { field: 0 }
+          },
+          m0: {
+            data: { field: 1 },
+            expand: 1 // Expand so that shapes dont end up at the boundaries
+          }
         },
-        y: {
-          scale: 'm0',
-          ref: 'y'
-        }
-      },
-      brush
-    };
+        components: [pointMarker]
+      };
 
-  let settings = {
-    scales: {
-      d0: {
-        data: { field: 0 }
-      },
-      m0: {
-        data: { field: 1 },
-        expand: 1 // Expand so that shapes dont end up at the boundaries
-      }
-    },
-    components: [pointMarker]
-  };
-  let element = document.getElementById("container");
-  window.fixture = picasso.chart({
-    element,
-    data,
-    settings
-  });
-  </script>
-</body>
+      let element = document.getElementById("container");
 
+      window.fixture = picasso.chart({
+        element,
+        data,
+        settings
+      });
+    </script>
+  </body>
 </html>

--- a/packages/picasso.js/test/integration/chart/brushing/tap_scroll.fix.html
+++ b/packages/picasso.js/test/integration/chart/brushing/tap_scroll.fix.html
@@ -1,22 +1,22 @@
 <html lang="en">
 <head>
-	<title>Component Test</title>
-	<meta charset="utf-8">
+    <title>Component Test</title>
+    <meta charset="utf-8">
   <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.min.js"></script>
-	<style>
-		#container {
-			width: 100%;
-			height: 100%;
+  <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <style>
+        #container {
+            width: 100%;
+            height: 100%;
       position: relative;
       top: 1000px;
       overflow: auto
-		}
-	</style>
+        }
+    </style>
 </head>
 
 <body>
-	<div id="container" ></div>
+    <div id="container" ></div>
 
   <script>
   let data = {

--- a/packages/picasso.js/test/integration/plugins/hammer.fix.html
+++ b/packages/picasso.js/test/integration/plugins/hammer.fix.html
@@ -1,83 +1,83 @@
 <html lang="en">
-<head>
+  <head>
     <title>Component Test</title>
     <meta charset="utf-8">
-  <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.js"></script>
-  <script src="/packages/picasso.js/node_modules/hammerjs/hammer.min.js"></script>
-  <script src="/plugins/hammer/dist/picasso-hammer.js"></script>
+    <base href="/">
+    <script src="/packages/picasso.js/dist/picasso.js"></script>
+    <script src="/packages/picasso.js/node_modules/hammerjs/hammer.min.js"></script>
+    <script src="/plugins/hammer/dist/picasso-hammer.js"></script>
     <style>
-        #container {
-            width: 100%;
-            height: 100%;
-        }
-    </style>
-</head>
-
-<body>
-    <div id="container" ></div>
-
-  <script>
-    window.picasso.use(window.picassoHammer);
-
-    window.tapCount = 0;
-
-    const element = document.getElementById('container');
-    window.picasso.chart({
-      element,
-      data: {
-        data: [
-          ['Product', 'Cost'],
-          ['Cars', 150000],
-          ['Trucks', 450000]
-        ]
-      },
-      settings: {
-        scales: {
-          d0: {
-            data: { field: 0 }
-          },
-          m0: {
-            data: { field: 1 },
-            expand: 1 // Expand so that shapes dont end up at the boundaries
-          }
-        },
-        components: [{
-          type: 'point',
-          data: {
-            extract: {
-              field: 0,
-              props: {
-                x: { field: 0 },
-                y: { field: 1 }
-              }
-            }
-          },
-          settings: {
-            x: {
-              scale: 'd0',
-              ref: 'x'
-            },
-            y: {
-              scale: 'm0',
-              ref: 'y'
-            }
-          }
-        }],
-        interactions: [{
-          type: 'hammer',
-          gestures: [{
-            type: 'Tap',
-            events: {
-              tap(e) {
-                window.tapCount++;
-              }
-            }
-          }]
-        }]
+      #container {
+        width: 100%;
+        height: 100%;
       }
-    });
-  </script>
-</body>
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+
+    <script>
+      window.picasso.use(window.picassoHammer);
+
+      window.tapCount = 0;
+
+      const element = document.getElementById('container');
+      window.picasso.chart({
+        element,
+        data: {
+          data: [
+            ['Product', 'Cost'],
+            ['Cars', 150000],
+            ['Trucks', 450000]
+          ]
+        },
+        settings: {
+          scales: {
+            d0: {
+              data: { field: 0 }
+            },
+            m0: {
+              data: { field: 1 },
+              expand: 1 // Expand so that shapes dont end up at the boundaries
+            }
+          },
+          components: [{
+            type: 'point',
+            data: {
+              extract: {
+                field: 0,
+                props: {
+                  x: { field: 0 },
+                  y: { field: 1 }
+                }
+              }
+            },
+            settings: {
+              x: {
+                scale: 'd0',
+                ref: 'x'
+              },
+              y: {
+                scale: 'm0',
+                ref: 'y'
+              }
+            }
+          }],
+          interactions: [{
+            type: 'hammer',
+            gestures: [{
+              type: 'Tap',
+              events: {
+                tap(e) {
+                  window.tapCount++;
+                }
+              }
+            }]
+          }]
+        }
+      });
+    </script>
+  </body>
 
 </html>

--- a/packages/picasso.js/test/integration/plugins/hammer.fix.html
+++ b/packages/picasso.js/test/integration/plugins/hammer.fix.html
@@ -1,21 +1,21 @@
 <html lang="en">
 <head>
-	<title>Component Test</title>
-	<meta charset="utf-8">
+    <title>Component Test</title>
+    <meta charset="utf-8">
   <base href="/">
-  <script src="/packages/picasso.js/dist/picasso.min.js"></script>
+  <script src="/packages/picasso.js/dist/picasso.js"></script>
   <script src="/packages/picasso.js/node_modules/hammerjs/hammer.min.js"></script>
-  <script src="/plugins/hammer/dist/picasso-hammer.min.js"></script>
-	<style>
-		#container {
-			width: 100%;
-			height: 100%;
-		}
-	</style>
+  <script src="/plugins/hammer/dist/picasso-hammer.js"></script>
+    <style>
+        #container {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
 </head>
 
 <body>
-	<div id="container" ></div>
+    <div id="container" ></div>
 
   <script>
     window.picasso.use(window.picassoHammer);

--- a/plugins/hammer/package.json
+++ b/plugins/hammer/package.json
@@ -11,7 +11,7 @@
   "files": [
     "/dist"
   ],
-  "main": "dist/picasso-hammer.min.js",
+  "main": "dist/picasso-hammer.js",
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js --name picassoHammer",

--- a/plugins/hammer/package.json
+++ b/plugins/hammer/package.json
@@ -15,7 +15,6 @@
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js --name picassoHammer",
-    "build:dev": "npm run build",
     "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test": "npxc aw -c aw.config.js",

--- a/plugins/hammer/package.json
+++ b/plugins/hammer/package.json
@@ -14,9 +14,9 @@
   "main": "dist/picasso-hammer.min.js",
   "module": "src/index.js",
   "scripts": {
-    "build": "npxc rollup -c ../../rollup.config.js --name picassoHammer --environment BUILD:production",
-    "build:dev": "npxc rollup -c ../../rollup.config.js --name picassoHammer",
-    "build:watch": "npxc rollup -c ../../rollup.config.js --name picassoHammer -w",
+    "build": "npxc rollup -c ../../rollup.config.js --name picassoHammer",
+    "build:dev": "npm run build",
+    "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test": "npxc aw -c aw.config.js",
     "prepublishOnly": "rm -rf dist && npm run build && npm run build:dev"

--- a/plugins/hammer/package.json
+++ b/plugins/hammer/package.json
@@ -18,7 +18,7 @@
     "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test": "npxc aw -c aw.config.js",
-    "prepublishOnly": "rm -rf dist && npm run build && npm run build:dev"
+    "prepublishOnly": "rm -rf dist && npm run build"
   },
   "devDependencies": {
     "npxc": "^0.0.3",

--- a/plugins/q/package.json
+++ b/plugins/q/package.json
@@ -14,9 +14,9 @@
   "main": "dist/picasso-q.min.js",
   "module": "src/index.js",
   "scripts": {
-    "build": "npxc rollup -c ../../rollup.config.js --name picassoQ --environment BUILD:production",
-    "build:dev": "npxc rollup -c ../../rollup.config.js --name picassoQ",
-    "build:watch": "npxc rollup -c ../../rollup.config.js --name picassoQ -w",
+    "build": "npxc rollup -c ../../rollup.config.js --name picassoQ",
+    "build:dev": "npm run build",
+    "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test": "npm run test:unit",
     "test:unit": "npxc aw -c aw.config.js",

--- a/plugins/q/package.json
+++ b/plugins/q/package.json
@@ -15,7 +15,6 @@
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js --name picassoQ",
-    "build:dev": "npm run build",
     "build:watch": "npm run build -- -w",
     "lint": "npxc eslint src test",
     "test": "npm run test:unit",

--- a/plugins/q/package.json
+++ b/plugins/q/package.json
@@ -21,7 +21,7 @@
     "test:unit": "npxc aw -c aw.config.js",
     "test:unit:watch": "npm run test:unit -- -w",
     "test:unit:coverage": "npm run test:unit -- --coverage",
-    "prepublishOnly": "rm -rf dist && npm run build && npm run build:dev"
+    "prepublishOnly": "rm -rf dist && npm run build"
   },
   "devDependencies": {
     "d3-hierarchy": "^1.1.5",

--- a/plugins/q/package.json
+++ b/plugins/q/package.json
@@ -11,7 +11,7 @@
   "files": [
     "/dist"
   ],
-  "main": "dist/picasso-q.min.js",
+  "main": "dist/picasso-q.js",
   "module": "src/index.js",
   "scripts": {
     "build": "npxc rollup -c ../../rollup.config.js --name picassoQ",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,9 +15,11 @@ const hasName = process.argv.indexOf('--name') + 1 || process.argv.indexOf('-n')
 const name = hasName ? process.argv[hasName] : 'picasso';
 const fileName = name.replace(/([A-Z])/g, (m, s) => `-${s.toLowerCase()}`);
 
+const isWatch = process.argv.indexOf('--w') + 1 || process.argv.indexOf('-w') + 1;
+
 const config = {
   entry: 'src/index.js',
-  dest: `dist/${fileName}.min.js`,
+  dest: `dist/${fileName}.js`,
   moduleName: name,
   format: 'umd',
   sourceMap: true,
@@ -29,10 +31,13 @@ const config = {
       plugins: ['external-helpers']
     }),
     commonjs(),
-    filesize(),
-    uglify()
+    filesize()
   ]
 };
+
+if (!isWatch) {
+  config.plugins.push(uglify());
+}
 
 config.plugins.push(license({
   banner: `

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ const config = {
   format: 'umd',
   sourceMap: true,
   plugins: [
+    clean(),
     resolve({ jsnext: true, preferBuiltins: false }),
     babel({
       exclude: 'node_modules/**',
@@ -32,8 +33,7 @@ const config = {
       plugins: ['external-helpers']
     }),
     commonjs(),
-    filesize(),
-    clean()
+    filesize()
   ]
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ const hasName = process.argv.indexOf('--name') + 1 || process.argv.indexOf('-n')
 const name = hasName ? process.argv[hasName] : 'picasso';
 const fileName = name.replace(/([A-Z])/g, (m, s) => `-${s.toLowerCase()}`);
 
-const isWatch = process.argv.indexOf('--w') + 1 || process.argv.indexOf('-w') + 1;
+const isWatch = process.argv.indexOf('--watch') + 1 || process.argv.indexOf('-w') + 1;
 
 const config = {
   entry: 'src/index.js',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 import license from 'rollup-plugin-license';
+import clean from 'rollup-plugin-clean';
 
 import path from 'path';
 
@@ -31,7 +32,8 @@ const config = {
       plugins: ['external-helpers']
     }),
     commonjs(),
-    filesize()
+    filesize(),
+    clean()
   ]
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,18 +11,16 @@ import path from 'path';
 
 const pkg = require(path.join(process.cwd(), 'package.json')); // eslint-disable-line
 
-const isProduction = process.env.BUILD === 'production';
-
 const hasName = process.argv.indexOf('--name') + 1 || process.argv.indexOf('-n') + 1;
 const name = hasName ? process.argv[hasName] : 'picasso';
 const fileName = name.replace(/([A-Z])/g, (m, s) => `-${s.toLowerCase()}`);
 
 const config = {
   entry: 'src/index.js',
-  dest: `dist/${fileName}.js`,
+  dest: `dist/${fileName}.min.js`,
   moduleName: name,
   format: 'umd',
-  sourceMap: !isProduction,
+  sourceMap: true,
   plugins: [
     resolve({ jsnext: true, preferBuiltins: false }),
     babel({
@@ -31,14 +29,10 @@ const config = {
       plugins: ['external-helpers']
     }),
     commonjs(),
-    filesize()
+    filesize(),
+    uglify()
   ]
 };
-
-if (isProduction) {
-  config.dest = config.dest.replace(/js$/, 'min.js');
-  config.plugins.push(uglify());
-}
 
 config.plugins.push(license({
   banner: `


### PR DESCRIPTION
## What has been done?
* Sourcemaps are now always built
* Only one file is outputted instead of two, `dist/picasso.js` (this is minifed on build, but still mapped to the sourcemap)
* Introduced rollup-plugin-clean for `dist` folder so the .min. file does not keep laying around
* On watch it skips uglifying to build faster
* `npm run build:dev` removed

## Checklist
- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
