### PR TITLE
fix(legend-seq): Title use fallback from majorScale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,11 +116,15 @@ jobs:
           name: website
           command: |
             cd ./website
-            npm build
+            npm run build
       - store_artifacts:
           path: docs/spec.json
       - store_artifacts:
           path: website/build
+      - persist_to_workspace:
+          root: ~/picassojs
+          paths:
+            - website/build/
 
   lint:
     <<: *defaults
@@ -158,7 +162,17 @@ jobs:
           at: ~/picassojs
       - run: npm run bootstrap
       - run: npm run test:integration:local
-
+      
+  deploy-docs:
+    docker:
+      - image: cibuilds/aws:1.14.38
+    working_directory: ~/picassojs
+    steps:
+      - attach_workspace:
+          at: ~/picassojs
+      - run:
+          name: Deploy to S3 ...
+          command: aws s3 sync website/build/picasso.js/ s3://picassojs.com/ --delete
 
 workflows:
   version: 2
@@ -186,3 +200,15 @@ workflows:
       - test-integration:
           requires:
             - build
+      - deploy-docs:
+          requires:
+            - docs-website
+            - lint
+            - test-unit
+            - test-component
+            - test-integration
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/

--- a/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
@@ -196,7 +196,7 @@ function initState(ctx) {
  * @property {number} [tick.padding=5] - padding in pixels to the legend node
  * @property {object} [title] - Title settings
  * @property {boolean} [title.show=true] - Toggle title on/off
- * @property {string} [title.text=''] - The value of the title
+ * @property {string} [title.text=''] - Title text. Defaults to the title of the provided data field
  * @property {string} [title.fill='#595959']
  * @property {string} [title.fontSize='12px']
  * @property {string} [title.fontFamily='Arial']

--- a/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
@@ -92,11 +92,23 @@ function getTicks(ctx, majorScale) {
 function initState(ctx) {
   const isVertical = ctx.settings.dock !== 'top' && ctx.settings.dock !== 'bottom';
   const titleStgns = ctx.stgns.title;
+
+  const fillScale = ctx.chart.scale(ctx.stgns.fill);
+  const majorScale = ctx.chart.scale(ctx.stgns.major);
+  const tickValues = getTicks(ctx, majorScale);
+  const tickAnchor = resolveTickAnchor(ctx.settings);
+
+  if (typeof titleStgns.text === 'undefined') {
+    const fields = majorScale.data().fields;
+    titleStgns.text = fields && fields[0] ? fields[0].title() : '';
+  }
+
   const titleTextMetrics = ctx.renderer.measureText({
     text: titleStgns.text,
     fontSize: titleStgns.fontSize,
     fontFamily: titleStgns.fontFamily
   });
+
   const titleTextBounds = ctx.renderer.textBounds({
     text: titleStgns.text,
     fontSize: titleStgns.fontSize,
@@ -107,11 +119,6 @@ function initState(ctx) {
     hyphens: titleStgns.hyphens,
     lineHeight: titleStgns.lineHeight
   });
-
-  const fillScale = ctx.chart.scale(ctx.stgns.fill);
-  const majorScale = ctx.chart.scale(ctx.stgns.major);
-  const tickValues = getTicks(ctx, majorScale);
-  const tickAnchor = resolveTickAnchor(ctx.settings);
 
   const state = {
     isVertical,
@@ -230,7 +237,7 @@ const legendDef = {
       },
       title: {
         show: true,
-        text: '',
+        text: undefined,
         fill: '#595959',
         fontSize: '12px',
         fontFamily: 'Arial',

--- a/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
@@ -50,6 +50,7 @@ export function createTitleNode(ctx) {
   }
 
   const node = {
+    id: 'legend-title',
     type: 'text',
     x,
     y: Math.min(y, state.rect.y + state.rect.height),

--- a/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
@@ -50,7 +50,7 @@ export function createTitleNode(ctx) {
   }
 
   const node = {
-    id: 'legend-title',
+    tag: 'legend-title',
     type: 'text',
     x,
     y: Math.min(y, state.rect.y + state.rect.height),

--- a/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
@@ -6,7 +6,7 @@ import linearScale from '../../../../../src/core/scales/linear';
 describe('Legend Sequential', () => {
   const ticksSelector = '[id="legend-seq-ticks"] text';
   const tickFillBoundarySelector = '[id="legend-seq-ticks"] rect';
-  const titleSelector = '[tag="legend-title"]';
+  const titleSelector = '.legend-title';
   let componentFixture;
   let userDef;
   let container;

--- a/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
@@ -6,7 +6,7 @@ import linearScale from '../../../../../src/core/scales/linear';
 describe('Legend Sequential', () => {
   const ticksSelector = '[id="legend-seq-ticks"] text';
   const tickFillBoundarySelector = '[id="legend-seq-ticks"] rect';
-  const titleSelector = '[id="legend-title"]';
+  const titleSelector = '[tag="legend-title"]';
   let componentFixture;
   let userDef;
   let container;

--- a/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/legend-seq/legend-seq.spec.js
@@ -6,7 +6,7 @@ import linearScale from '../../../../../src/core/scales/linear';
 describe('Legend Sequential', () => {
   const ticksSelector = '[id="legend-seq-ticks"] text';
   const tickFillBoundarySelector = '[id="legend-seq-ticks"] rect';
-  const titleSelector = '[text="testing"]';
+  const titleSelector = '[id="legend-title"]';
   let componentFixture;
   let userDef;
   let container;
@@ -48,7 +48,7 @@ describe('Legend Sequential', () => {
     chartMock.scale.withArgs('fillScale').returns(seqScale);
     const linScale = linearScale();
     linScale.data = () => ({
-      fields: [{ formatter: () => undefined }]
+      fields: [{ formatter: () => undefined, title: () => 'scaleTitle' }]
     });
     chartMock.scale.withArgs('majorScale').returns(linScale);
   });
@@ -81,7 +81,8 @@ describe('Legend Sequential', () => {
     expect(title).to.include({
       x: 5,
       y: 10,
-      anchor: 'start'
+      anchor: 'start',
+      text: 'testing'
     });
 
     expect(gradientNode).to.include({
@@ -89,6 +90,22 @@ describe('Legend Sequential', () => {
       y: 15,
       width: 15,
       height: 35
+    });
+
+    expect(componentFixture.simulateLayout(container)).to.equal(31);
+  });
+
+  it('should support titles from scales', () => {
+    userDef.settings.title = {};
+    render();
+
+    const title = componentFixture.findNodes(titleSelector)[0];
+
+    expect(title).to.include({
+      x: 5,
+      y: 10,
+      anchor: 'start',
+      text: 'scaleTitle'
     });
 
     expect(componentFixture.simulateLayout(container)).to.equal(31);


### PR DESCRIPTION
## What has been done
Introduced fallback to title from majorScale data in legend-seq similar to how legend-cat works

## Checklist
- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
