### PR TITLE
fix: inactive all shapes on brush start

### DIFF
--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -94,6 +94,9 @@ export function styler(obj, { context, data, style }) {
       nodes[i].__style = nodes[i].__style || {};
       styleProps.forEach((s) => {
         nodes[i].__style[s] = nodes[i][s]; // store original value
+        if (s in inactive) {
+          nodes[i][s] = inactive[s];
+        }
       });
     }
     globalActivation = true;

--- a/packages/picasso.js/test/unit/core/component/brushing.spec.js
+++ b/packages/picasso.js/test/unit/core/component/brushing.spec.js
@@ -289,9 +289,7 @@ describe('Brushing', () => {
       brusherStub.trigger('start');
 
       dummyComponent.renderer.render.args[0][0].forEach((node) => {
-        expect(node.style).to.deep.equal({
-          fill: 'inactiveFill'
-        });
+        expect(node.fill).to.deep.equal('inactiveFill');
       });
     });
 

--- a/packages/picasso.js/test/unit/core/component/brushing.spec.js
+++ b/packages/picasso.js/test/unit/core/component/brushing.spec.js
@@ -284,6 +284,17 @@ describe('Brushing', () => {
       });
     });
 
+    it('start should inactive all nodes', () => {
+      styler(dummyComponent, consume);
+      brusherStub.trigger('start');
+
+      dummyComponent.renderer.render.args[0][0].forEach((node) => {
+        expect(node.style).to.deep.equal({
+          fill: 'inactiveFill'
+        });
+      });
+    });
+
     it('end should restore all original styling values', () => {
       styler(dummyComponent, consume);
       brusherStub.trigger('start');
@@ -370,7 +381,7 @@ describe('Brushing', () => {
 
       const output = dummyComponent.renderer.render.args[0][0];
       expect(output[0].stroke).to.equal('doNotUpdate'); // No data attr
-      expect(output[0].fill).to.equal('doNotUpdate');
+      expect(output[0].fill).to.equal('inactiveFill');
       expect(output[1].fill).to.equal('inactiveFill'); // Inactive
     });
   });


### PR DESCRIPTION
Changes the behavior for the default brush start listener. Now all shapes becomes inactive by default.

```js
chart.brush('myContext').start(); // will now inactive all shapes and trigger their consume action.
```

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
