### PR TITLE
 fix: possible mismatch between value/label in legend-cat

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
@@ -129,15 +129,20 @@ export default function resolveSettings(comp) {
     }
   } else {
     const labels = comp.scale.labels ? comp.scale.labels() : null;
+    const labelFn = typeof comp.scale.label === 'function' ? comp.scale.label : null;
     data.items = domain.map((d, idx) => {
       let datum = comp.scale.datum ? extend({}, comp.scale.datum(d)) : { value: d };
       if (comp.scale.datum) {
         datum = extend({}, comp.scale.datum(d));
         datum.value = d;
       }
-      if (labels) {
+
+      if (labelFn) {
+        datum.label = labelFn(d);
+      } else if (labels) {
         datum.label = labels[idx];
       }
+
       return datum;
     });
   }

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
@@ -129,7 +129,6 @@ export default function resolveSettings(comp) {
     }
   } else {
     const labels = comp.scale.labels ? comp.scale.labels() : null;
-    const labelFn = typeof comp.scale.label === 'function' ? comp.scale.label : null;
     data.items = domain.map((d, idx) => {
       let datum = comp.scale.datum ? extend({}, comp.scale.datum(d)) : { value: d };
       if (comp.scale.datum) {
@@ -137,8 +136,8 @@ export default function resolveSettings(comp) {
         datum.value = d;
       }
 
-      if (labelFn) {
-        datum.label = labelFn(d);
+      if (comp.scale.label) {
+        datum.label = comp.scale.label(d);
       } else if (labels) {
         datum.label = labels[idx];
       }

--- a/packages/picasso.js/test/unit/core/chart-components/legend-cat/legend-resolver.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/legend-cat/legend-resolver.spec.js
@@ -68,8 +68,9 @@ describe('legend-resolver', () => {
 
   describe('resolveSettings', () => {
     let resolved;
+    let settings;
     beforeEach(() => {
-      resolved = resolveSettings({
+      settings = {
         scale: {
           data: () => ({ fields: [{}] }),
           domain: () => ['a', 'b'],
@@ -96,8 +97,11 @@ describe('legend-resolver', () => {
         resolver: {
           resolve: x => x // return param - a simple way to test what params are passed in (and avoid spies)
         }
-      });
+      };
+
+      resolved = resolveSettings(settings);
     });
+
     it('should resolve labels per datum', () => {
       expect(resolved.labels).to.eql({
         data: { items: [{ value: 'a' }, { value: 'b' }] },
@@ -112,6 +116,24 @@ describe('legend-resolver', () => {
         },
         settings: { font: 'Arial' }
       });
+    });
+
+    it('should resolve labels by `label` function if available', () => {
+      settings.scale.label = d => `label ${d}`;
+      settings.scale.domain = () => ['b', 'a'];
+      resolved = resolveSettings(settings);
+
+      expect(resolved.labels.data.items[0]).to.eql({ value: 'b', label: 'label b' });
+      expect(resolved.labels.data.items[1]).to.eql({ value: 'a', label: 'label a' });
+    });
+
+    it('should resolve labels by `labels` function if available', () => {
+      settings.scale.labels = () => ['1', '2']; // Resolved by index
+      settings.scale.domain = () => ['b', 'a'];
+      resolved = resolveSettings(settings);
+
+      expect(resolved.labels.data.items[0]).to.eql({ value: 'b', label: '1' });
+      expect(resolved.labels.data.items[1]).to.eql({ value: 'a', label: '2' });
     });
 
     it('should resolve items per datum', () => {


### PR DESCRIPTION
If the categorical scale for the `legend-cat` component have a discrepancy between the data mapping and its domain, ex. the domain is ordered differently or contains a different number of items. The `legend-cat` would base the datum `value` from the data and the datum `label` from the domain. 

This fix ensures that both value and label use the domain to resolve a proper datum.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
