### PR TITLE
feat: sort extracted data

### DIFF
--- a/docs/dist/data.md
+++ b/docs/dist/data.md
@@ -140,6 +140,20 @@ data: {
 }
 ```
 
+### Sorting
+
+A `sort` function can be used to sort the _extracted_ data items:
+
+```js
+data: {
+  extract: [{
+    source: 'Products',
+    field: 'Product',
+  }],
+  sort: (a, b) => a.label > b.label ? -1 : 1 // sort descending
+}
+```
+
 ### Stacking
 
 Extracted items can be stacked using a `stack` configuration:

--- a/docs/src/input/data.md
+++ b/docs/src/input/data.md
@@ -140,6 +140,20 @@ data: {
 }
 ```
 
+### Sorting
+
+A `sort` function can be used to sort the _extracted_ data items:
+
+```js
+data: {
+  extract: [{
+    source: 'Products',
+    field: 'Product',
+  }],
+  sort: (a, b) => a.label > b.label ? -1 : 1 // sort descending
+}
+```
+
 ### Stacking
 
 Extracted items can be stacked using a `stack` configuration:

--- a/packages/picasso.js/src/core/data/extractor.js
+++ b/packages/picasso.js/src/core/data/extractor.js
@@ -94,5 +94,8 @@ export default function extract(dataConfig, data = {}, opts = {}) {
   if (dataConfig && dataConfig.stack) {
     stack(extracted, dataConfig.stack, data.dataset);
   }
+  if (dataConfig && !Array.isArray(dataConfig) && typeof dataConfig.sort === 'function' && extracted.items) {
+    extracted.items = extracted.items.sort(dataConfig.sort);
+  }
   return extracted;
 }

--- a/packages/picasso.js/test/unit/core/data/extractor.spec.js
+++ b/packages/picasso.js/test/unit/core/data/extractor.spec.js
@@ -183,4 +183,17 @@ describe('extract data', () => {
       expect(d).to.equal('my collection');
     });
   });
+
+  describe('with sort config', () => {
+    it('should sort values', () => {
+      expect(extract({
+        items: ['A', 'B', 'C'],
+        sort: (a, b) => (b.value > a.value ? 1 : -1)
+      }).items).to.eql([
+        { value: 'C', label: 'C' },
+        { value: 'B', label: 'B' },
+        { value: 'A', label: 'A' }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Add support for sorting extracted data items by adding a `sort`
option to the `data` config

Solves #50


**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
