### PR TITLE
fix(scene-node): append all component meta

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -254,6 +254,11 @@ function componentFactory(definition, options = {}) {
   };
   updateDockConfig(dockConfig, settings);
 
+  const appendComponentMeta = (node) => {
+    node.key = settings.key;
+    node.element = rend.element();
+  };
+
   const fn = () => {};
 
   fn.dockConfig = dockConfig;
@@ -450,6 +455,7 @@ function componentFactory(definition, options = {}) {
           for (let i = 0; i < sceneNodes.length; i++) {
             const node = sceneNodes[i];
             if (node.data && brusher.containsMappedData(node.data, props || consume.data, mode)) {
+              appendComponentMeta(node);
               shapes.push(node);
               sceneNodes.splice(i, 1);
               i--;
@@ -463,7 +469,7 @@ function componentFactory(definition, options = {}) {
   fn.findShapes = (selector) => {
     const shapes = rend.findShapes(selector);
     for (let i = 0, num = shapes.length; i < num; i++) {
-      shapes[i].key = settings.key;
+      appendComponentMeta(shapes[i]);
     }
 
     return shapes;
@@ -480,7 +486,7 @@ function componentFactory(definition, options = {}) {
     }
 
     for (let i = 0, num = shapes.length; i < num; i++) {
-      shapes[i].key = settings.key;
+      appendComponentMeta(shapes[i]);
     }
 
     return shapes;

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -183,17 +183,9 @@ export function renderer(sceneFn = sceneFactory) {
     return doRender;
   };
 
-  canvasRenderer.itemsAt = options => (scene ? scene.getItemsFrom(options) : []);
+  canvasRenderer.itemsAt = input => (scene ? scene.getItemsFrom(input) : []);
 
-  canvasRenderer.findShapes = (selector) => {
-    if (scene) {
-      return scene.findShapes(selector).map((s) => {
-        s.element = canvasRenderer.element();
-        return s;
-      });
-    }
-    return [];
-  };
+  canvasRenderer.findShapes = selector => (scene ? scene.findShapes(selector) : []);
 
   canvasRenderer.clear = () => {
     if (el) {

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -98,17 +98,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     return doRender;
   };
 
-  svg.itemsAt = options => (scene ? scene.getItemsFrom(options) : []);
+  svg.itemsAt = input => (scene ? scene.getItemsFrom(input) : []);
 
-  svg.findShapes = (selector) => {
-    if (scene) {
-      return scene.findShapes(selector).map((s) => {
-        s.element = svg.element();
-        return s;
-      });
-    }
-    return [];
-  };
+  svg.findShapes = selector => (scene ? scene.findShapes(selector) : []);
 
   svg.clear = () => {
     if (!group) {

--- a/packages/picasso.js/test/unit/core/component/component-factory.spec.js
+++ b/packages/picasso.js/test/unit/core/component/component-factory.spec.js
@@ -122,6 +122,71 @@ describe('Component', () => {
   });
   */
 
+  describe('findShapes', () => {
+    let instance;
+    let config;
+    let shapes;
+
+    beforeEach(() => {
+      shapes = [{ data: 0 }, { data: 1 }, { data: 2 }];
+      renderer.findShapes = () => shapes;
+      config = {
+        key: 'myKey'
+      };
+
+      instance = createAndRenderComponent(config);
+    });
+
+    it('should return matching shapes', () => {
+      const s = instance.findShapes('*');
+
+      expect(s).to.deep.equal([
+        { data: 0, key: 'myKey', element: 'elm' },
+        { data: 1, key: 'myKey', element: 'elm' },
+        { data: 2, key: 'myKey', element: 'elm' }
+      ]);
+    });
+  });
+
+  describe('shapesAt', () => {
+    let instance;
+    let config;
+    let shapes;
+
+    beforeEach(() => {
+      shapes = [
+        { node: { data: 0 } },
+        { node: { data: 1 } },
+        { node: { data: 2 } }
+      ];
+      renderer.itemsAt = () => shapes;
+      config = {
+        key: 'myKey'
+      };
+
+      instance = createAndRenderComponent(config);
+    });
+
+    it('should return matching shapes', () => {
+      const s = instance.shapesAt({ x: 0, y: 0 }); // Input doesn't matter as output is mocked
+
+      expect(s).to.deep.equal([
+        { data: 0, key: 'myKey', element: 'elm' },
+        { data: 1, key: 'myKey', element: 'elm' },
+        { data: 2, key: 'myKey', element: 'elm' }
+      ]);
+    });
+
+    it('propagation option should return last shape', () => {
+      // Last shape is the shape that is visibly "on top"
+      const s = instance.shapesAt({ x: 0, y: 0 }, { propagation: 'stop' });
+
+      expect(s).to.deep.equal([
+        { data: 2, key: 'myKey', element: 'elm' }
+      ]);
+    });
+  });
+
   describe('getBrushedShapes', () => {
     let instance;
     let config;

--- a/packages/picasso.js/test/unit/core/component/component-factory.spec.js
+++ b/packages/picasso.js/test/unit/core/component/component-factory.spec.js
@@ -51,7 +51,8 @@ describe('Component', () => {
     renderer = {
       appendTo: () => {},
       render: () => ({}),
-      size: () => {}
+      size: () => {},
+      element: () => 'elm'
     };
   });
 
@@ -131,6 +132,7 @@ describe('Component', () => {
       renderer.findShapes = () => shapes;
       chart.brush = () => ({ containsMappedData: d => d === 1 || d === 2 });
       config = {
+        key: 'myKey',
         brush: {
           consume: [
             {
@@ -148,7 +150,10 @@ describe('Component', () => {
       expect(rNoMatch).to.be.empty;
 
       const rMatch = instance.getBrushedShapes('test');
-      expect(rMatch).to.deep.equal([{ data: 1 }, { data: 2 }]);
+      expect(rMatch).to.deep.equal([
+        { data: 1, key: 'myKey', element: 'elm' },
+        { data: 2, key: 'myKey', element: 'elm' }
+      ]);
     });
 
     it('should not return duplicate shapes', () => {
@@ -156,7 +161,10 @@ describe('Component', () => {
       config.brush.consume.push({ context: 'test' });
 
       instance = createAndRenderComponent(config);
-      expect(instance.getBrushedShapes('test')).to.deep.equal([{ data: 1 }, { data: 2 }]);
+      expect(instance.getBrushedShapes('test')).to.deep.equal([
+        { data: 1, key: 'myKey', element: 'elm' },
+        { data: 2, key: 'myKey', element: 'elm' }
+      ]);
     });
 
     it('should use data props parameter if submitted', () => {


### PR DESCRIPTION
There was a inconsistency in which some methods exposed meta data on the scene node. Now all APIs that return a collection of scene nodes, contains the key (given the component has a key) and element property.

This affects the following methods:
- `chartInstance.findShapes`
- `chartInstance.shapesAt`
- `chartInstance.getBrushedShapes`

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
