### PR TITLE
feat(scenegraph): add default collider on text nodes

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -25,11 +25,12 @@ export default class Circle extends DisplayObject {
     }, collider);
 
     super.set(v);
-    super.collider(opts);
 
     this.attrs.cx = cx;
     this.attrs.cy = cy;
     this.attrs.r = r;
+
+    super.collider(opts);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/display-object.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/display-object.js
@@ -81,7 +81,7 @@ class DisplayObject extends Node {
     } else if (type === 'frontChild') {
       this._collider = c;
     } else if (type === 'bounds') {
-      c.fn = geometry('rect', opts);
+      c.fn = geometry('rect', this.boundingRect());
       this._collider = c;
     } else if (['line', 'rect', 'circle', 'polygon', 'polyline'].indexOf(type) !== -1) {
       c.fn = geometry(type, opts);

--- a/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
@@ -29,7 +29,6 @@ export default class Rect extends DisplayObject {
     }, collider);
 
     super.set(v);
-    super.collider(opts);
 
     if (width >= 0) {
       this.attrs.x = x;
@@ -46,6 +45,8 @@ export default class Rect extends DisplayObject {
       this.attrs.y = y + height;
       this.attrs.height = -height;
     }
+
+    super.collider(opts);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -1,8 +1,13 @@
+import extend from 'extend';
 import DisplayObject from './display-object';
 import {
   rectToPoints,
   getMinMax
 } from '../../geometry/util';
+
+function hasData({ data, _boundingRect, _textBoundsFn }) {
+  return typeof data !== 'undefined' && data !== null && (_boundingRect || _textBoundsFn);
+}
 
 /**
  * @extends node-def
@@ -46,7 +51,6 @@ export default class Text extends DisplayObject {
     } = v;
 
     super.set(v);
-    super.collider(collider);
     this.attrs.x = x;
     this.attrs.y = y;
     this.attrs.dx = dx;
@@ -55,18 +59,24 @@ export default class Text extends DisplayObject {
     if (boundingRect) {
       this._boundingRect = boundingRect;
     } else if (typeof textBoundsFn === 'function') {
-      this._boundingRect = textBoundsFn(this.attrs);
+      this._textBoundsFn = textBoundsFn;
     }
+
+    super.collider(extend({ type: hasData(this) ? 'bounds' : null }, collider));
   }
 
   boundingRect(includeTransform = false) {
-    if (!this._boundingRect) {
+    if (!this._boundingRect && !this._textBoundsFn) {
       return {
         x: 0,
         y: 0,
         width: 0,
         height: 0
       };
+    }
+
+    if (!this._boundingRect && this._textBoundsFn) {
+      this._boundingRect = this._textBoundsFn(this.attrs);
     }
 
     const p = rectToPoints(this._boundingRect);

--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -56,6 +56,7 @@ export default class Text extends DisplayObject {
     this.attrs.dx = dx;
     this.attrs.dy = dy;
     this.attrs.text = text;
+    this._boundingRect = null; // Reset cache
     if (boundingRect) {
       this._boundingRect = boundingRect;
     } else if (typeof textBoundsFn === 'function') {

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -4,6 +4,7 @@ import { onLineBreak } from '../../text-manipulation';
 import createCanvasGradient from './canvas-gradient';
 import createRendererBox from '../renderer-box';
 import create from '../index';
+import injectTextBoundsFn from '../../text-manipulation/inject-textbounds';
 
 const reg = registry();
 
@@ -167,7 +168,10 @@ export function renderer(sceneFn = sceneFactory) {
       items: [sceneContainer],
       dpi: dpiRatio,
       on: {
-        create: [onLineBreak(canvasRenderer.measureText)]
+        create: [
+          onLineBreak(canvasRenderer.measureText),
+          injectTextBoundsFn(canvasRenderer)
+        ]
       }
     });
     const hasChangedScene = scene ? !newScene.equals(scene) : true;

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -9,6 +9,7 @@ import {
 } from './svg-gradient';
 import createRendererBox from '../renderer-box';
 import create from '../index';
+import injectTextBoundsFn from '../../text-manipulation/inject-textbounds';
 
 /**
  * Create a new svg renderer
@@ -81,7 +82,8 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
       on: {
         create: [
           onGradient,
-          onLineBreak(svg.measureText)
+          onLineBreak(svg.measureText),
+          injectTextBoundsFn(svg)
         ]
       }
     });

--- a/packages/picasso.js/src/web/text-manipulation/inject-textbounds.js
+++ b/packages/picasso.js/src/web/text-manipulation/inject-textbounds.js
@@ -1,0 +1,11 @@
+function hasData(data) {
+  return typeof data !== 'undefined' && data !== null;
+}
+
+export default function injectTextBoundsFn(renderer) {
+  return ({ node }) => {
+    if (node.type === 'text' && hasData(node.data) && !node.textBoundsFn) {
+      node.textBoundsFn = renderer.textBounds;
+    }
+  };
+}

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/text.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/text.spec.js
@@ -1,4 +1,5 @@
 import Text, { create as createText } from '../../../../../src/core/scene-graph/display-objects/text';
+import GeoRect from '../../../../../src/core/geometry/rect';
 
 describe('Text', () => {
   let node;
@@ -52,6 +53,40 @@ describe('Text', () => {
       expect(node.attrs.dy).to.equal(4);
       expect(node.collider()).to.be.null;
     });
+
+    it('should instantiate collider given data and explicit bounds', () => {
+      node = createText({
+        text: 'testing',
+        x: 1,
+        y: 2,
+        dx: 3,
+        dy: 4,
+        data: 0,
+        boundingRect: {
+          x: 0, y: 0, width: 0, height: 0
+        }
+      });
+      expect(node.collider()).to.be.a('object');
+      expect(node.collider().fn).to.be.an.instanceof(GeoRect);
+      expect(node.collider().type).to.equal('bounds');
+    });
+
+    it('should instantiate collider given data and bounds function', () => {
+      node = createText({
+        text: 'testing',
+        x: 1,
+        y: 2,
+        dx: 3,
+        dy: 4,
+        data: 0,
+        textBoundsFn: () => ({
+          x: 0, y: 0, width: 0, height: 0
+        })
+      });
+      expect(node.collider()).to.be.a('object');
+      expect(node.collider().fn).to.be.an.instanceof(GeoRect);
+      expect(node.collider().type).to.equal('bounds');
+    });
   });
 
   describe('BoundingRect', () => {
@@ -72,6 +107,19 @@ describe('Text', () => {
       expect(node.boundingRect()).to.deep.equal({
         x: 4, y: 6, width: 50, height: 100
       });
+    });
+
+    it('should cache result from textBounds function', () => {
+      def.x = 1;
+      def.y = 2;
+      def.dx = 3;
+      def.dy = 4;
+      def.textBoundsFn = sinon.stub().returns(mockedBounds);
+      node = createText(def);
+      node.boundingRect();
+      expect(def.textBoundsFn).to.have.been.calledOnce;
+      node.boundingRect(); // Should not call fn again
+      expect(def.textBoundsFn).to.have.been.calledOnce;
     });
 
     it('should use boundingRect attribute if supplied', () => {


### PR DESCRIPTION
This PR changes the default behavior of text nodes, they will now have a collider attached by default given that they are data bound. This enables text nodes to be targeted by interactions (brushing and shape look-up).

There is a performance impact here when the text is measured and the collider is created. It would be good to have colliders lazy evaluated (for all type of nodes) to reduce the overhead of enabling interactions. But I consider that out-of-scope for this PR.
