### PR TITLE
 feat(labels): link data on label

### DIFF
--- a/docs/spec.json
+++ b/docs/spec.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "license": "MIT"
   },
   "entries": {
@@ -1479,6 +1479,10 @@
                           }
                         ]
                       },
+                      "linkData": {
+                        "description": "Link data to the label",
+                        "type": "function"
+                      },
                       "placements": {
                         "kind": "array",
                         "items": {
@@ -1559,6 +1563,10 @@
                           }
                         ]
                       },
+                      "linkData": {
+                        "description": "Link data to the label",
+                        "type": "function"
+                      },
                       "align": {
                         "optional": true,
                         "defaultValue": 0.5,
@@ -1631,6 +1639,10 @@
                           }
                         ]
                       },
+                      "linkData": {
+                        "description": "Link data to the label",
+                        "type": "function"
+                      },
                       "placements": {
                         "kind": "array",
                         "items": {
@@ -1689,6 +1701,12 @@
                   "optional": true,
                   "defaultValue": "ltr",
                   "type": "string"
+                },
+                "scrollOffset": {
+                  "description": "Initial scroll offset",
+                  "optional": true,
+                  "defaultValue": 0,
+                  "type": "number"
                 }
               }
             },

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -333,6 +333,7 @@ export function precalculate({
  * @property {number} [fontSize=12]
  * @property {Array<object>} labels
  * @property {string|function} labels[].label - The text value
+ * @property {function} labels[].linkData - Link data to the label
  * @property {Array<object>} labels[].placements
  * @property {string} labels[].placements[].position - 'inside' | 'outside' | 'opposite'
  * @property {number} [labels[].placements[].justify=0] - Placement of the label along the direction of the bar

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -219,6 +219,7 @@ export function placeInBars(
       if (bounds && placement) {
         justify = placement.justify;
         fill = typeof placement.fill === 'function' ? placement.fill(arg, i) : placement.fill;
+        const linkData = typeof lblStngs.linkData === 'function' ? lblStngs.linkData(arg, i) : undefined;
 
         if (direction === 'up') {
           justify = 1 - justify;
@@ -238,6 +239,9 @@ export function placeInBars(
         });
 
         if (label) {
+          if (typeof linkData !== 'undefined') {
+            label.data = linkData;
+          }
           labels.push(label);
         }
       }

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
@@ -91,6 +91,7 @@ function getBounds(node) {
  * @property {number} [padding=4]
  * @property {Array<object>} labels
  * @property {string|function} labels[].label - The text value
+ * @property {function} labels[].linkData - Link data to the label
  * @property {number} [labels[].align=0.5]
  * @property {string|function} [labels[].fill='#333']
  */

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
@@ -187,6 +187,7 @@ export function rows({
 
       currentY += measurements[j].height + rowSettings.padding;
       let fill = typeof lblStngs.fill === 'function' ? lblStngs.fill(arg, i) : lblStngs.fill;
+      const linkData = typeof lblStngs.linkData === 'function' ? lblStngs.linkData(arg, i) : undefined;
       let label = placer(rect, texts[j], {
         fill,
         align: lblStngs.align,
@@ -195,6 +196,9 @@ export function rows({
         textMetrics: measurements[j]
       });
       if (label) {
+        if (typeof linkData !== 'undefined') {
+          label.data = linkData;
+        }
         labels.push(label);
       }
     }

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
@@ -378,6 +378,7 @@ function findBestPlacement({
  * @property {number} [fontSize=12]
  * @property {Array<object>} labels
  * @property {string|function} labels[].label - The text value
+ * @property {function} labels[].linkData - Link data to the label
  * @property {Array<object>} labels[].placements
  * @property {string} [labels[].placements[].position='into'] - 'inside' | 'into' | 'outside' (outside is not implmented yet)
  * @property {string} [labels[].placements[].fill='#333'] - Color of the label

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
@@ -427,6 +427,7 @@ export function slices(
         continue;
       }
       let direction = typeof lblStngs.direction === 'function' ? lblStngs.direction(arg, i) : lblStngs.direction || 'horizontal';
+      const linkData = typeof lblStngs.linkData === 'function' ? lblStngs.linkData(arg, i) : undefined;
 
       labelStruct.fontFamily = lblStngs.fontFamily;
       labelStruct.fontSize = `${lblStngs.fontSize}px`;
@@ -469,6 +470,9 @@ export function slices(
         });
 
         if (label) {
+          if (typeof linkData !== 'undefined') {
+            label.data = linkData;
+          }
           labels.push(label);
         }
       }

--- a/packages/picasso.js/test/unit/core/chart-components/labels/strategies/bars.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/labels/strategies/bars.spec.js
@@ -352,6 +352,42 @@ describe('labeling - bars', () => {
       });
     });
 
+    it('should link data', () => {
+      const settings = {
+        direction: () => 'right',
+        align: 0.4,
+        justify: 0.8,
+        labels: [{
+          placements: [{
+            position: 'inside', justify: 0.2, align: 0.5, fill: () => 'red'
+          }],
+          label: () => 'etikett',
+          linkData: ({ data }) => data
+        }]
+      };
+      const nodes = [{
+        localBounds: {
+          x: 10, y: 20, width: 40, height: 50
+        },
+        data: 1
+      }];
+      renderer.measureText.returns({ width: 20, height: 10 });
+      let labels = bars({
+        settings,
+        chart,
+        nodes,
+        rect: {
+          x: 0, y: 0, width: 100, height: 200
+        },
+        renderer,
+        style: {}
+      });
+
+      expect(labels[0]).to.containSubset({
+        data: 1
+      });
+    });
+
     it('should skip node if outside container', () => {
       const settings = {
         direction: () => 'right',

--- a/packages/picasso.js/test/unit/core/chart-components/labels/strategies/rows.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/labels/strategies/rows.spec.js
@@ -201,5 +201,38 @@ describe('labeling - rows', () => {
 
       expect(labels).to.eql(['label1']);
     });
+
+    it('should link data', () => {
+      const settings = {
+        align: 0,
+        justify: 0,
+        labels: [{
+          label: () => 'etikett',
+          linkData: ({ data }) => data
+        }]
+      };
+      const nodes = [{
+        type: 'rect',
+        bounds: {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100
+        },
+        data: 1
+      }];
+      renderer.measureText.returns({ width: 20, height: 10 });
+      let labels = rows({
+        settings,
+        chart,
+        nodes,
+        renderer,
+        style: {}
+      }, bounds => bounds);
+
+      expect(labels[0]).to.containSubset({
+        data: 1
+      });
+    });
   });
 });

--- a/packages/picasso.js/test/unit/core/chart-components/labels/strategies/slices.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/labels/strategies/slices.spec.js
@@ -231,6 +231,41 @@ describe('labeling - slices', () => {
       expect(labels).to.be.empty;
     });
 
+    it('should link data', () => {
+      const settings = {
+        direction: () => 'vertical',
+        labels: [{
+          placements: [{ position: 'into', fill: () => 'red' }],
+          label: () => 'etikett',
+          linkData: ({ data }) => data
+        }]
+      };
+      const nodes = [{
+        desc: {
+          slice: {
+            offset: { x: 25, y: 25 },
+            start: 0,
+            end: 2 * Math.PI,
+            innerRadius: 0,
+            outerRadius: 50
+          }
+        },
+        data: 1
+      }];
+      renderer.measureText.returns({ width: 20, height: 10 });
+      let labels = slices({
+        settings,
+        chart,
+        nodes,
+        renderer,
+        style: {}
+      });
+
+      expect(labels[0]).to.containSubset({
+        data: 1
+      });
+    });
+
     describe('label overlap', () => {
       function testLabelCount(count, list) {
         const settings = {


### PR DESCRIPTION
This PR adds a new property on the label component called `linkData`. Linking data on the label node allows the labels to be used in brushing.

The property is optional and off by default.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
