### PR TITLE
fix(render-order): Render components in specified order

### DIFF
--- a/packages/picasso.js/src/core/charts/chart.js
+++ b/packages/picasso.js/src/core/charts/chart.js
@@ -457,15 +457,18 @@ function chartFn(definition, context) {
 
     const toUpdate = [];
     const toRender = [];
+    let toRenderOrUpdate;
     if (partialData) {
       currentComponents.forEach((comp) => {
         if (comp.updateWith && comp.visible) {
           toUpdate.push(comp);
         }
       });
+      toRenderOrUpdate = toUpdate;
     } else {
       const { visible, hidden } = layout(currentComponents); // Relayout
       visibleComponents = visible;
+      toRenderOrUpdate = visible;
 
       visible.forEach((comp) => {
         if (comp.updateWith && comp.visible) {
@@ -485,11 +488,15 @@ function chartFn(definition, context) {
     toRender.forEach(comp => comp.instance.beforeMount());
     toRender.forEach(comp => comp.instance.mount());
 
-    toRender.forEach(comp => comp.instance.beforeRender());
-    toUpdate.forEach(comp => comp.instance.beforeRender());
+    toRenderOrUpdate.forEach(comp => comp.instance.beforeRender());
 
-    toRender.forEach(comp => comp.instance.render());
-    toUpdate.forEach(comp => comp.instance.update());
+    toRenderOrUpdate.forEach((comp) => {
+      if (comp.updateWith && comp.visible) {
+        comp.instance.update();
+      } else {
+        comp.instance.render();
+      }
+    });
 
     // Ensure that displayOrder is keept, only do so on re-layout update.
     // Which is only the case if partialData is false.

--- a/packages/picasso.js/test/component/chart/chart.comp.js
+++ b/packages/picasso.js/test/component/chart/chart.comp.js
@@ -230,4 +230,40 @@ describe('Chart', () => {
       expect(brushedShapes.map(s => s.attrs.fill)).to.deep.equal(['red', 'red']);
     });
   });
+
+  it('should render components in the correct order', () => {
+    let renderOrder = [];
+    p.component('custom-log-render', {
+      render() {
+        renderOrder.push(this.settings.key);
+        return [];
+      }
+    });
+    function createComp(order) {
+      return {
+        key: `comp${order}`,
+        displayOrder: order,
+        type: 'custom-log-render'
+      };
+    }
+
+    const comp0 = createComp(0);
+    const comp1 = createComp(1);
+    const comp2 = createComp(2);
+
+    settings.components.push(comp2);
+    settings.components.push(comp0);
+    const instance = chart({
+      element,
+      data: { data },
+      settings
+    });
+    expect(renderOrder).to.eql(['comp0', 'comp2']);
+    renderOrder = [];
+    settings.components.push(comp1);
+    instance.update({
+      settings
+    });
+    expect(renderOrder).to.eql(['comp0', 'comp1', 'comp2']);
+  });
 });


### PR DESCRIPTION
Before new components was rendered before old


**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
