### PR TITLE
fix(labels): Fix label overlap in slice strategy

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
@@ -366,6 +366,19 @@ function findBestPlacement({
   return { bounds: null, placement: null };
 }
 
+function collitionRect(bounds) {
+  if (bounds.anchor === 'start') {
+    return bounds;
+  }
+  // bounds.anchor === 'end'
+  return {
+    x: bounds.x - bounds.width,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height
+  };
+}
+
 /**
  * @typedef {object} component--labels~slices-label-strategy
  *
@@ -414,8 +427,8 @@ export function slices(
 
   const labelStruct = {};
   const labels = [];
-  let firstOutsideBounds = null;
-  let previousOutsideBounds = null;
+  let firstOutsideRect = null;
+  let previousOutsideRect = null;
 
   for (let i = 0, len = nodes.length; i < len; i++) {
     let node = nodes[i];
@@ -450,15 +463,16 @@ export function slices(
 
       if (bounds && placement) {
         if (placement.position === 'outside') {
-          if (!firstOutsideBounds) {
-            firstOutsideBounds = bounds;
-          } else if (firstOutsideBounds.anchor === bounds.anchor && collisions.testRectRect(firstOutsideBounds, bounds)) {
+          const r = collitionRect(bounds);
+          if (!firstOutsideRect) {
+            firstOutsideRect = r;
+          } else if (firstOutsideRect && collisions.testRectRect(firstOutsideRect, r)) {
             continue;
           }
-          if (previousOutsideBounds && previousOutsideBounds.anchor === bounds.anchor && collisions.testRectRect(previousOutsideBounds, bounds)) {
+          if (previousOutsideRect && collisions.testRectRect(previousOutsideRect, r)) {
             continue;
           }
-          previousOutsideBounds = bounds;
+          previousOutsideRect = r;
         }
 
         let fill = typeof placement.fill === 'function' ? placement.fill(arg, i) : placement.fill;

--- a/packages/picasso.js/test/unit/core/chart-components/labels/strategies/slices.spec.js
+++ b/packages/picasso.js/test/unit/core/chart-components/labels/strategies/slices.spec.js
@@ -327,6 +327,74 @@ describe('labeling - slices', () => {
           { start: 0, end: 0.1 }
         ]);
       });
+
+      it('test for bug with a longer label overlap with a shorter one', () => {
+        const settings = {
+          direction: () => 'vertical',
+          labels: [{
+            placements: [{ position: 'outside', fill: () => 'red' }],
+            label: ({ node }) => node.label
+          }]
+        };
+        const nodes = [{
+          label: 'Eggs',
+          desc: {
+            slice: {
+              offset: { x: 400.5, y: 176 },
+              start: 6.028915516022773,
+              end: 6.048023620437467,
+              innerRadius: 0,
+              outerRadius: 140.8
+            }
+          }
+        }, {
+          label: 'Anchovies',
+          desc: {
+            slice: {
+              offset: { x: 400.5, y: 176 },
+              start: 6.218028611691536,
+              end: 6.227965057950124,
+              innerRadius: 0,
+              outerRadius: 140.8
+            }
+          }
+        }];
+
+        renderer.measureText.withArgs({
+          text: 'Eggs',
+          fontFamily: sinon.match.any,
+          fontSize: sinon.match.any
+        }).returns({
+          width: 27.3515625, height: 11.995312499999999
+        });
+        renderer.measureText.withArgs({
+          text: 'Anchovies',
+          fontFamily: sinon.match.any,
+          fontSize: sinon.match.any
+        }).returns({
+          width: 55.365234375, height: 11.995312499999999
+        });
+
+        let labels = slices({
+          settings,
+          chart,
+          nodes,
+          renderer,
+          rect: {
+            x: 0, y: 0, width: 801, height: 352
+          },
+          style: {
+            label: {
+              fontSize: '16px',
+              fontFamily: 'simpsons',
+              fill: 'green'
+            }
+          }
+        });
+
+        expect(renderer.measureText).to.be.calledTwice;
+        expect(labels.length).to.eql(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Fix a bug in the overlap detection code that can happen if there are a short and a long label in the top left quadrant

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
