### PR TITLE
fix(q): fix q brush when layout is missing

### DIFF
--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -58,8 +58,8 @@ export function extractFieldFromId(id, layout) {
     // depends on number of measures + number of attr expressions
     // in dimensions and measures before this one
     const offset = measureIdx;
-    measureIdx = 0;
     if (layout) {
+      measureIdx = 0;
       const hc = resolve(pathToCube, layout);
 
       // offset by number of measures
@@ -82,6 +82,11 @@ export function extractFieldFromId(id, layout) {
 
       // offset by the actual column value for the attribute expression itself
       measureIdx += +ATTR_EXPR_RX.exec(path)[1];
+    } else if (dimensionIdx > -1) {
+      dimensionIdx = -1;
+      measureIdx = +ATTR_EXPR_RX.exec(path)[1];
+    } else {
+      measureIdx += +ATTR_EXPR_RX.exec(path)[1] + 1;
     }
   }
 

--- a/plugins/q/test/unit/q-brush.spec.js
+++ b/plugins/q/test/unit/q-brush.spec.js
@@ -273,6 +273,15 @@ describe('q-brush', () => {
       });
     });
 
+    it('should map attribute expression layout value to params (on measure) - without layout', () => {
+      let v = extractFieldFromId('/qHyperCube/qMeasureInfo/1/qAttrExprInfo/1');
+      expect(v).to.eql({
+        path: '/qHyperCubeDef',
+        measureIdx: 3,
+        dimensionIdx: -1
+      });
+    });
+
     it('should map attribute expression layout value to params (on dimension)', () => {
       let v = extractFieldFromId('/qHyperCube/qDimensionInfo/1/qAttrExprInfo/1', {
         qHyperCube: {
@@ -283,6 +292,15 @@ describe('q-brush', () => {
       expect(v).to.eql({
         path: '/qHyperCubeDef',
         measureIdx: 6,
+        dimensionIdx: -1
+      });
+    });
+
+    it('should map attribute expression layout value to params (on dimension) - without layout', () => {
+      let v = extractFieldFromId('/qHyperCube/qDimensionInfo/1/qAttrExprInfo/1');
+      expect(v).to.eql({
+        path: '/qHyperCubeDef',
+        measureIdx: 1,
         dimensionIdx: -1
       });
     });


### PR DESCRIPTION
Fixes an issue when calculating the appropriate measure index to use for an attribute expression, and layout is missing.

**Checklist**

- [x] tests added
