### PR TITLE
fix(svg-renderer): use quotation marks on gradient url

### DIFF
--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-gradient.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-gradient.js
@@ -45,7 +45,7 @@ function checkGradient(item = {}, attr = 'fill', url = '') {
     gradientId = gradient.id;
   }
 
-  return `url(${url}#${gradientId})`;
+  return `url('${url}#${gradientId}')`;
 }
 
 /**

--- a/packages/picasso.js/test/unit/web/renderer/svg-renderer/svg-gradient.spec.js
+++ b/packages/picasso.js/test/unit/web/renderer/svg-renderer/svg-gradient.spec.js
@@ -53,7 +53,7 @@ describe('svg-gradient', () => {
 
       expect(state.node.type).to.be.equal('rect');
       expect(state.node.children).to.be.undefined;
-      expect(state.node.fill).to.include('url(#');
+      expect(state.node.fill).to.include('url(\'#');
     });
 
     it('should resolve gradients defintion for stroke', () => {
@@ -64,7 +64,7 @@ describe('svg-gradient', () => {
 
       expect(state.node.type).to.be.equal('rect');
       expect(state.node.children).to.be.undefined;
-      expect(state.node.stroke).to.include('url(#');
+      expect(state.node.stroke).to.include('url(\'#');
     });
   });
 


### PR DESCRIPTION
Fixes an issue where the gradient url would be invalid, if the url contained parentheses.
