### PR TITLE
fix: use parentNode property instead of parentElement where applicable

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
@@ -103,7 +103,7 @@ const component = {
     }
   },
   mounted(renderElement) {
-    if (renderElement && renderElement.parentNode) {
+    if (renderElement && renderElement.parentNode && renderElement.parentNode.nodeType === 1) {
       this.navigationRenderer.renderer.appendTo(renderElement.parentNode);
       this.titleRenderer.renderer.appendTo(renderElement.parentNode);
     }
@@ -170,7 +170,7 @@ const component = {
     this.navigationRenderer = navigationRendererFactory(this);
     this.titleRenderer = titleRendererFactory(this);
     this.navigationRenderer.renderer = this.registries.renderer('dom')();
-    this.titleRenderer.renderer = this.registries.renderer()();
+    this.titleRenderer.renderer = this.registries.renderer(this.settings.renderer)();
     update(this);
   },
   preferredSize(obj) {

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
@@ -103,9 +103,9 @@ const component = {
     }
   },
   mounted(renderElement) {
-    if (renderElement && renderElement.parentElement) {
-      this.navigationRenderer.renderer.appendTo(renderElement.parentElement);
-      this.titleRenderer.renderer.appendTo(renderElement.parentElement);
+    if (renderElement && renderElement.parentNode) {
+      this.navigationRenderer.renderer.appendTo(renderElement.parentNode);
+      this.titleRenderer.renderer.appendTo(renderElement.parentNode);
     }
     this.navigationRenderer.render({
       rect: this.state.views.layout.navigation,
@@ -170,7 +170,7 @@ const component = {
     this.navigationRenderer = navigationRendererFactory(this);
     this.titleRenderer = titleRendererFactory(this);
     this.navigationRenderer.renderer = this.registries.renderer('dom')();
-    this.titleRenderer.renderer = this.registries.renderer(this.settings.renderer)();
+    this.titleRenderer.renderer = this.registries.renderer()();
     update(this);
   },
   preferredSize(obj) {

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
@@ -103,7 +103,7 @@ const component = {
     }
   },
   mounted(renderElement) {
-    if (renderElement && renderElement.parentNode && renderElement.parentNode.nodeType === 1) {
+    if (renderElement && renderElement.parentNode) {
       this.navigationRenderer.renderer.appendTo(renderElement.parentNode);
       this.titleRenderer.renderer.appendTo(renderElement.parentNode);
     }

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -117,7 +117,7 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
 
   svg.destroy = () => {
     // parentElement is not supported in IE11 for SVGElement.
-    if (el && el.parentNode && el.parentNode.nodeType === 1) {
+    if (el && el.parentNode) {
       el.parentNode.removeChild(el);
     }
     el = null;

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -116,8 +116,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
   };
 
   svg.destroy = () => {
-    if (el && el.parentElement) {
-      el.parentElement.removeChild(el);
+    // parentElement is not supported in IE11 for SVGElement.
+    if (el && el.parentNode && el.parentNode.nodeType === 1) {
+      el.parentNode.removeChild(el);
     }
     el = null;
     group = null;

--- a/packages/test-utils/mocks/element-mock.js
+++ b/packages/test-utils/mocks/element-mock.js
@@ -9,6 +9,7 @@ function element(name, rect = { x: 0, y: 0, width: 100, height: 100 }) {
     listeners: [],
     parentNode: null,
     parentElement: null,
+    nodeType: 1,
     ownerDocument: {
       createElementNS(ns, tag) {
         return element(`${ns}:${tag}`);

--- a/packages/test-utils/mocks/element-mock.js
+++ b/packages/test-utils/mocks/element-mock.js
@@ -9,7 +9,6 @@ function element(name, rect = { x: 0, y: 0, width: 100, height: 100 }) {
     listeners: [],
     parentNode: null,
     parentElement: null,
-    nodeType: 1,
     ownerDocument: {
       createElementNS(ns, tag) {
         return element(`${ns}:${tag}`);


### PR DESCRIPTION
[parentElement](https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement) is not support for SVGElement in IE11.

Fixes an issue where the title and navigation buttons in the categorical legend would not be displayed at all in IE11. Given that the svg renderer was used.