### PR TITLE
fix(q): handle qNoOfLeftDims = -1 for q-brush

### DIFF
--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -213,7 +213,7 @@ export default function qBrush(brush, opts = {}, layout) {
                 .map(s => +s)
                 .filter(v => !isNaN(v));
 
-              if (noOfLeftDims === 0 || dimInterColSortIdx >= noOfLeftDims) {
+              if ((noOfLeftDims === 0 || dimInterColSortIdx >= noOfLeftDims) && noOfLeftDims > -1) {
                 validValues.forEach((val) => {
                   methods.selectPivotCells.cells.push({
                     qType: 'T',

--- a/plugins/q/test/unit/q-brush.spec.js
+++ b/plugins/q/test/unit/q-brush.spec.js
@@ -310,6 +310,32 @@ describe('q-brush', () => {
       ]);
     });
 
+    it('should get left dimension, when qNoOfLeftDims = -1', () => {
+      layout.qHyperCube.qNoOfLeftDims = -1;
+
+      const selections = qBrush(brush, { byCells: true }, layout);
+      expect(selections[0].params).to.eql([
+        '/layers/0/qHyperCubeDef',
+        [
+          {
+            qCol: 2,
+            qRow: 3,
+            qType: 'L'
+          },
+          {
+            qCol: 2,
+            qRow: 2,
+            qType: 'L'
+          },
+          {
+            qCol: 2,
+            qRow: 7,
+            qType: 'L'
+          }
+        ]
+      ]);
+    });
+
     it('should do selectHyperCubeCells if qMode: S and byCells: true', () => {
       layout.qHyperCube.qMode = 'S';
 


### PR DESCRIPTION
**Checklist**

- [X] tests added
- [X] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

Handle qNoOfLeftDims = -1, specifically selecting in the left dimension. Documentation here: https://help.qlik.com/en-US/sense-developer/June2018/apis/EngineAPI/definitions-HyperCubeDef.html
