### PR TITLE
fix(scene-graph): class selector partial match

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/node-selector.js
+++ b/packages/picasso.js/src/core/scene-graph/node-selector.js
@@ -43,11 +43,14 @@ const FILTERS = {
 
   universal: objects => objects,
 
-  tag: (c, objects) => { // eslint-disable-line arrow-body-style
+  tag: (selector, objects) => { // eslint-disable-line arrow-body-style
     return objects.filter((o) => {
       const tag = o.tag;
       if (tag) {
-        return tag.indexOf(c.replace('.', '')) !== -1;
+        return tag
+          .trim()
+          .split(/\s+/)
+          .indexOf(selector.replace('.', '')) !== -1;
       }
       return false;
     });

--- a/packages/picasso.js/test/unit/core/scene-graph/node-selector.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/node-selector.spec.js
@@ -231,7 +231,7 @@ describe('Node Selector', () => {
     describe('tag', () => {
       it('should select all objects that contains tag', () => {
         c1.tag = 'title myTag label';
-        c2.tag = 'testing';
+        c2.tag = 'myTag-plus myTagPlus';
         t1.tag = 'myTag';
         const result = filter(
           { type: 'tag', value: '.myTag' },
@@ -263,6 +263,17 @@ describe('Node Selector', () => {
           [c1, c2, c3, t1, r1]
         );
         expect(result).to.deep.equal([]);
+      });
+
+      it('should not match empty tag', () => {
+        c1.tag = '';
+        c2.tag = ' test-tag ';
+        const result = filter(
+          { type: 'tag', value: '.' },
+          [c1, c2, c3, t1, r1]
+        );
+
+        expect(result).to.be.empty;
       });
     });
   });


### PR DESCRIPTION
This fixes an issue where a class selector could match only parts of a tag.

__Before__
`.test` selector matches `testing someOtherTag` tag
`.test` selector matches `test someOtherTag` tag

__After__
`.test` selector does not match `testing someOtherTag` tag
`.test` selector matches `test someOtherTag` tag

