### PR TITLE
fix(scene-graph): bounds collision with transform

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/collision-resolver.js
+++ b/packages/picasso.js/src/core/scene-graph/collision-resolver.js
@@ -31,9 +31,11 @@ function resolveFrontChildCollision(node, type, input) {
 
   for (let i = num - 1; i >= 0; i--) {
     const desc = node.descendants[i];
-    const collider = desc._collider;
+    if (desc.collider === null) {
+      continue;
+    }
 
-    if (collider && collider.fn[type](input)) {
+    if (desc.collider[type](input)) {
       const collision = createCollision(desc);
 
       appendParentNode(desc, collision);
@@ -45,8 +47,7 @@ function resolveFrontChildCollision(node, type, input) {
 }
 
 function resolveGeometryCollision(node, type, input) {
-  const collider = node._collider.fn;
-  if (collider[type](input)) {
+  if (node.collider[type](input)) {
     const c = createCollision(node);
 
     appendParentNode(node, c);
@@ -83,12 +84,13 @@ function inverseTransform(node, input) {
 }
 
 function resolveCollision(node, intersectionType, input) {
-  const collider = node._collider;
-  if (collider === null) { return null; }
+  if (node.colliderType === null) {
+    return null;
+  }
 
   const transformedInput = inverseTransform(node, input);
 
-  if (collider.type === 'frontChild') {
+  if (node.colliderType === 'frontChild') {
     return resolveFrontChildCollision(node, intersectionType, transformedInput);
   }
 
@@ -105,7 +107,7 @@ function findAllCollisions(nodes, intersectionType, ary, input) {
     if (collision) { ary.push(collision); }
 
     // Only traverse children if no match is found on parent and it doesnt have any custom collider
-    if (node.children && !collision && !node._collider) {
+    if (node.children && !collision && !node.collider) {
       findAllCollisions(node.children, intersectionType, ary, input);
     }
   }
@@ -120,7 +122,7 @@ function hasCollision(nodes, intersectionType, input) {
 
     if (collision !== null) { return true; }
 
-    if (node.children && !node._collider) {
+    if (node.children && !node.collider) {
       return hasCollision(node.children, intersectionType, input);
     }
   }

--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -30,7 +30,7 @@ export default class Circle extends DisplayObject {
     this.attrs.cy = cy;
     this.attrs.r = r;
 
-    super.collider(opts);
+    super.collider = opts;
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -30,7 +30,7 @@ export default class Circle extends DisplayObject {
     this.attrs.cy = cy;
     this.attrs.r = r;
 
-    super.collider = opts;
+    this.collider = opts;
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/container.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/container.js
@@ -42,7 +42,7 @@ export default class Container extends DisplayObject {
       type: null
     }, collider);
 
-    super.collider(opts);
+    super.collider = opts;
   }
 
   boundingRect(includeTransform = false) {
@@ -76,7 +76,7 @@ export default class Container extends DisplayObject {
       const opts = extend({
         type: 'bounds', x: 0, y: 0, width: 0, height: 0
       }, this._boundingRect);
-      super.collider(opts);
+      super.collider = opts;
     }
 
     return r;
@@ -93,7 +93,7 @@ export default class Container extends DisplayObject {
       const opts = extend({
         type: 'bounds', x: 0, y: 0, width: 0, height: 0
       }, this._boundingRect);
-      super.collider(opts);
+      super.collider = opts;
     }
 
     return r;
@@ -113,7 +113,7 @@ export default class Container extends DisplayObject {
 
     if (this._collider && this._collider.type === 'bounds') {
       const opts = extend(this.boundingRect(true), { type: 'bounds' });
-      super.collider(opts);
+      super.collider = opts;
     }
 
     return this;
@@ -124,7 +124,7 @@ export default class Container extends DisplayObject {
 
     if (this._collider && this._collider.type === 'bounds') {
       const opts = extend(this.boundingRect(true), { type: 'bounds' });
-      super.collider(opts);
+      super.collider = opts;
     }
 
     return this;

--- a/packages/picasso.js/src/core/scene-graph/display-objects/container.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/container.js
@@ -42,7 +42,7 @@ export default class Container extends DisplayObject {
       type: null
     }, collider);
 
-    super.collider = opts;
+    this.collider = opts;
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/container.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/container.js
@@ -76,7 +76,7 @@ export default class Container extends DisplayObject {
       const opts = extend({
         type: 'bounds', x: 0, y: 0, width: 0, height: 0
       }, this._boundingRect);
-      super.collider = opts;
+      this.collider = opts;
     }
 
     return r;
@@ -93,7 +93,7 @@ export default class Container extends DisplayObject {
       const opts = extend({
         type: 'bounds', x: 0, y: 0, width: 0, height: 0
       }, this._boundingRect);
-      super.collider = opts;
+      this.collider = opts;
     }
 
     return r;
@@ -113,7 +113,7 @@ export default class Container extends DisplayObject {
 
     if (this._collider && this._collider.type === 'bounds') {
       const opts = extend(this.boundingRect(true), { type: 'bounds' });
-      super.collider = opts;
+      this.collider = opts;
     }
 
     return this;
@@ -124,7 +124,7 @@ export default class Container extends DisplayObject {
 
     if (this._collider && this._collider.type === 'bounds') {
       const opts = extend(this.boundingRect(true), { type: 'bounds' });
-      super.collider = opts;
+      this.collider = opts;
     }
 
     return this;

--- a/packages/picasso.js/src/core/scene-graph/display-objects/line.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/line.js
@@ -37,7 +37,7 @@ export default class Line extends DisplayObject {
       x2,
       y2
     };
-    super.collider = extend(defaultCollider, collider);
+    this.collider = extend(defaultCollider, collider);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/line.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/line.js
@@ -37,7 +37,7 @@ export default class Line extends DisplayObject {
       x2,
       y2
     };
-    super.collider(extend(defaultCollider, collider));
+    super.collider = extend(defaultCollider, collider);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/path.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/path.js
@@ -55,7 +55,7 @@ export default class Path extends DisplayObject {
         }
       });
 
-      super.collider = collection;
+      this.collider = collection;
     }
   }
 

--- a/packages/picasso.js/src/core/scene-graph/display-objects/path.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/path.js
@@ -35,7 +35,7 @@ export default class Path extends DisplayObject {
     this.attrs.d = v.d;
 
     if (Array.isArray(v.collider) || (typeof v.collider === 'object' && v.collider.type)) {
-      super.collider = v.collider;
+      this.collider = v.collider;
     } else if (v.d) {
       const collection = [];
       this.segments = pathToSegments(v.d);

--- a/packages/picasso.js/src/core/scene-graph/display-objects/path.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/path.js
@@ -1,3 +1,4 @@
+import extend from 'extend';
 import DisplayObject from './display-object';
 import { getMinMax } from '../../geometry/util';
 import pathToSegments from '../parse-path-d';
@@ -33,28 +34,28 @@ export default class Path extends DisplayObject {
     this.points = [];
     this.attrs.d = v.d;
 
-    if (v.collider) {
-      super.collider(v.collider);
+    if (Array.isArray(v.collider) || (typeof v.collider === 'object' && v.collider.type)) {
+      super.collider = v.collider;
     } else if (v.d) {
-      const col = [];
+      const collection = [];
       this.segments = pathToSegments(v.d);
       this.segments.forEach((segment) => {
         if (segment.length <= 1) {
           // Omit empty and single point segments
         } else if (isClosed(segment)) {
-          col.push({
+          collection.push(extend({
             type: 'polygon',
             vertices: segment
-          });
+          }, v.collider));
         } else {
-          col.push({
+          collection.push(extend({
             type: 'polyline',
             points: segment
-          });
+          }, v.collider));
         }
       });
 
-      super.collider(col);
+      super.collider = collection;
     }
   }
 

--- a/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
@@ -46,7 +46,7 @@ export default class Rect extends DisplayObject {
       this.attrs.height = -height;
     }
 
-    super.collider(opts);
+    super.collider = opts;
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
@@ -46,7 +46,7 @@ export default class Rect extends DisplayObject {
       this.attrs.height = -height;
     }
 
-    super.collider = opts;
+    this.collider = opts;
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -65,7 +65,7 @@ export default class Text extends DisplayObject {
       this._textBoundsFn = textBoundsFn;
     }
 
-    super.collider = extend({ type: hasData(this) ? 'bounds' : null }, collider);
+    this.collider = extend({ type: hasData(this) ? 'bounds' : null }, collider);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -65,7 +65,7 @@ export default class Text extends DisplayObject {
       this._textBoundsFn = textBoundsFn;
     }
 
-    super.collider(extend({ type: hasData(this) ? 'bounds' : null }, collider));
+    super.collider = extend({ type: hasData(this) ? 'bounds' : null }, collider);
   }
 
   boundingRect(includeTransform = false) {

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -39,14 +39,12 @@ function geometryToDef(geometry, dpi, mvm) {
  * @returns {object} Returns a node definition of the collider
  */
 function colliderToShape(node, dpi) {
-  const collider = node.collider();
-
-  if (collider && collider.fn) {
+  if (node.collider) {
     const mvm = node.modelViewMatrix;
-    const isCollection = collider.type === 'collection';
+    const isCollection = node.colliderType === 'collection';
 
     if (isCollection) {
-      const children = collider.fn.geometries.map(geometry => geometryToDef(geometry, dpi, mvm));
+      const children = node.collider.geometries.map(geometry => geometryToDef(geometry, dpi, mvm));
 
       return {
         type: 'container',
@@ -54,7 +52,7 @@ function colliderToShape(node, dpi) {
       };
     }
 
-    return geometryToDef(collider.fn, dpi, mvm);
+    return geometryToDef(node.collider, dpi, mvm);
   }
 
   return null;

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/circle.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/circle.spec.js
@@ -21,9 +21,8 @@ describe('Circle', () => {
       expect(circle.attrs.cx).to.be.equal(0);
       expect(circle.attrs.cy).to.be.equal(0);
       expect(circle.attrs.r).to.be.equal(0);
-      expect(circle.collider()).to.be.a('object');
-      expect(circle.collider().fn).to.be.an.instanceof(GeoCircle);
-      expect(circle.collider().type).to.equal('circle');
+      expect(circle.colliderType).to.equal('circle');
+      expect(circle.collider).to.be.an.instanceof(GeoCircle);
     });
 
     it('should accept arguments', () => {
@@ -35,9 +34,8 @@ describe('Circle', () => {
       expect(circle.attrs.cx).to.be.equal(10);
       expect(circle.attrs.cy).to.be.equal(20);
       expect(circle.attrs.r).to.be.equal(5);
-      expect(circle.collider()).to.be.a('object');
-      expect(circle.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(circle.collider().type).to.equal('rect');
+      expect(circle.colliderType).to.equal('rect');
+      expect(circle.collider).to.be.an.instanceof(GeoRect);
     });
   });
 
@@ -50,9 +48,8 @@ describe('Circle', () => {
       expect(circle.attrs.cx).to.be.equal(99);
       expect(circle.attrs.cy).to.be.equal(999);
       expect(circle.attrs.r).to.be.equal(9);
-      expect(circle.collider()).to.be.a('object');
-      expect(circle.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(circle.collider().type).to.equal('rect');
+      expect(circle.colliderType).to.equal('rect');
+      expect(circle.collider).to.be.an.instanceof(GeoRect);
     });
 
     it('should default to zero cx', () => {
@@ -82,13 +79,13 @@ describe('Circle', () => {
       expect(circle.attrs.cx).to.be.equal(0);
       expect(circle.attrs.cy).to.be.equal(0);
       expect(circle.attrs.r).to.be.equal(0);
-      expect(circle.collider().fn).to.be.an.instanceof(GeoCircle);
+      expect(circle.collider).to.be.an.instanceof(GeoCircle);
     });
 
     it('should be able to disable the default collider', () => {
       circle = createCircle(shape);
       circle.set({ collider: { type: null } });
-      expect(circle.collider()).to.equal(null);
+      expect(circle.colliderType).to.equal(null);
     });
   });
 

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/display-object.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/display-object.spec.js
@@ -15,7 +15,7 @@ describe('Display Object', () => {
     });
 
     it('should not have a collider by default', () => {
-      expect(_displayObject.collider()).to.equal(null);
+      expect(_displayObject.collider).to.equal(null);
     });
   });
 
@@ -96,9 +96,9 @@ describe('Display Object', () => {
   describe('getItemsFrom', () => {
     beforeEach(() => {
       _displayObject.set({ fill: 'me' });
-      _displayObject.collider({
+      _displayObject.collider = {
         type: 'rect', x: 0, y: 0, width: 100, height: 100
-      });
+      };
     });
 
     it('should return a collision with it self, if it contains point', () => {
@@ -148,9 +148,9 @@ describe('Display Object', () => {
 
   describe('containsPoint', () => {
     beforeEach(() => {
-      _displayObject.collider({
+      _displayObject.collider = {
         type: 'rect', x: 0, y: 0, width: 100, height: 100
-      });
+      };
     });
 
     it('should return a true if it contains point', () => {
@@ -166,9 +166,9 @@ describe('Display Object', () => {
 
   describe('intersectsLine', () => {
     beforeEach(() => {
-      _displayObject.collider({
+      _displayObject.collider = {
         type: 'rect', x: 0, y: 0, width: 100, height: 100
-      });
+      };
     });
 
     it('should return a true if it intersect line', () => {
@@ -188,9 +188,9 @@ describe('Display Object', () => {
 
   describe('intersectsRect', () => {
     beforeEach(() => {
-      _displayObject.collider({
+      _displayObject.collider = {
         type: 'rect', x: 0, y: 0, width: 100, height: 100
-      });
+      };
     });
 
     it('should return a true if it intersect rect', () => {
@@ -210,9 +210,9 @@ describe('Display Object', () => {
 
   describe('intersectsCircle', () => {
     beforeEach(() => {
-      _displayObject.collider({
+      _displayObject.collider = {
         type: 'rect', x: 0, y: 0, width: 100, height: 100
-      });
+      };
     });
 
     it('should return a true if it intersect circle', () => {

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/gradient-item.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/gradient-item.spec.js
@@ -13,7 +13,7 @@ describe('GradientItem', () => {
 
     it('should not have a collider by default', () => {
       item = createGradientItem();
-      expect(item.collider()).to.equal(null);
+      expect(item.collider).to.equal(null);
     });
 
     it('should accept arguments', () => {

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/line.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/line.spec.js
@@ -23,9 +23,8 @@ describe('Line', () => {
       expect(line.attrs.y1).to.be.equal(0);
       expect(line.attrs.x2).to.be.equal(0);
       expect(line.attrs.y2).to.be.equal(0);
-      expect(line.collider()).to.be.a('object');
-      expect(line.collider().fn).to.be.an.instanceof(GeoLine);
-      expect(line.collider().type).to.equal('line');
+      expect(line.collider).to.be.an.instanceof(GeoLine);
+      expect(line.colliderType).to.equal('line');
     });
 
     it('should accept arguments', () => {
@@ -39,9 +38,8 @@ describe('Line', () => {
       expect(line.attrs.y1).to.be.equal(20);
       expect(line.attrs.x2).to.be.equal(100);
       expect(line.attrs.y2).to.be.equal(200);
-      expect(line.collider()).to.be.a('object');
-      expect(line.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(line.collider().type).to.equal('rect');
+      expect(line.collider).to.be.an.instanceof(GeoRect);
+      expect(line.colliderType).to.equal('rect');
     });
   });
 
@@ -55,9 +53,8 @@ describe('Line', () => {
       expect(line.attrs.y1).to.be.equal(20);
       expect(line.attrs.x2).to.be.equal(100);
       expect(line.attrs.y2).to.be.equal(200);
-      expect(line.collider()).to.be.a('object');
-      expect(line.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(line.collider().type).to.equal('rect');
+      expect(line.collider).to.be.an.instanceof(GeoRect);
+      expect(line.colliderType).to.equal('rect');
     });
 
     it('should handle no arguments', () => {
@@ -67,15 +64,14 @@ describe('Line', () => {
       expect(line.attrs.y1).to.be.equal(0);
       expect(line.attrs.x2).to.be.equal(0);
       expect(line.attrs.y2).to.be.equal(0);
-      expect(line.collider()).to.be.a('object');
-      expect(line.collider().fn).to.be.an.instanceof(GeoLine);
-      expect(line.collider().type).to.equal('line');
+      expect(line.collider).to.be.an.instanceof(GeoLine);
+      expect(line.colliderType).to.equal('line');
     });
 
     it('should be able to disable the default collider', () => {
       line = createLine(shape);
       line.set({ collider: { type: null } });
-      expect(line.collider()).to.equal(null);
+      expect(line.collider).to.equal(null);
     });
   });
 

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/path.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/path.spec.js
@@ -10,16 +10,15 @@ describe('Path', () => {
       path = create();
       expect(path).to.be.an.instanceof(Path);
       expect(path.attrs.d).to.be.equal(undefined);
-      expect(path.collider()).to.be.equal(null);
+      expect(path.collider).to.be.equal(null);
     });
 
     it('should accept arguments', () => {
       path = create({ d: 'M10 15' });
       expect(path).to.be.an.instanceof(Path);
       expect(path.attrs.d).to.be.equal('M10 15');
-      expect(path.collider()).to.be.a('object');
-      expect(path.collider().fn).to.be.an.instanceof(GeometryCollection);
-      expect(path.collider().type).to.equal('collection');
+      expect(path.collider).to.be.an.instanceof(GeometryCollection);
+      expect(path.colliderType).to.equal('collection');
     });
   });
 

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/rect.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/rect.spec.js
@@ -23,9 +23,8 @@ describe('Rect', () => {
       expect(rect.attrs.y).to.be.equal(0);
       expect(rect.attrs.width).to.be.equal(0);
       expect(rect.attrs.height).to.be.equal(0);
-      expect(rect.collider()).to.be.a('object');
-      expect(rect.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(rect.collider().type).to.equal('rect');
+      expect(rect.collider).to.be.an.instanceof(GeoRect);
+      expect(rect.colliderType).to.equal('rect');
     });
 
     it('should accept arguments', () => {
@@ -39,9 +38,8 @@ describe('Rect', () => {
       expect(rect.attrs.y).to.be.equal(20);
       expect(rect.attrs.width).to.be.equal(15);
       expect(rect.attrs.height).to.be.equal(25);
-      expect(rect.collider()).to.be.a('object');
-      expect(rect.collider().fn).to.be.an.instanceof(GeoCircle);
-      expect(rect.collider().type).to.equal('circle');
+      expect(rect.collider).to.be.an.instanceof(GeoCircle);
+      expect(rect.colliderType).to.equal('circle');
     });
   });
 
@@ -55,9 +53,8 @@ describe('Rect', () => {
       expect(rect.attrs.y).to.be.equal(999);
       expect(rect.attrs.width).to.be.equal(1337);
       expect(rect.attrs.height).to.be.equal(101);
-      expect(rect.collider()).to.be.a('object');
-      expect(rect.collider().fn).to.be.an.instanceof(GeoCircle);
-      expect(rect.collider().type).to.equal('circle');
+      expect(rect.collider).to.be.an.instanceof(GeoCircle);
+      expect(rect.colliderType).to.equal('circle');
     });
 
     it('should handle no arguments', () => {
@@ -67,13 +64,13 @@ describe('Rect', () => {
       expect(rect.attrs.y).to.be.equal(0);
       expect(rect.attrs.width).to.be.equal(0);
       expect(rect.attrs.height).to.be.equal(0);
-      expect(rect.collider().fn).to.be.an.instanceof(GeoRect);
+      expect(rect.collider).to.be.an.instanceof(GeoRect);
     });
 
     it('should be able to disable the default collider', () => {
       rect = createRect(shape);
       rect.set({ collider: { type: null } });
-      expect(rect.collider()).to.equal(null);
+      expect(rect.collider).to.equal(null);
     });
   });
 

--- a/packages/picasso.js/test/unit/core/scene-graph/display-objects/text.spec.js
+++ b/packages/picasso.js/test/unit/core/scene-graph/display-objects/text.spec.js
@@ -34,7 +34,7 @@ describe('Text', () => {
       expect(node.attrs.y).to.be.equal(0);
       expect(node.attrs.dx).to.be.equal(0);
       expect(node.attrs.dy).to.be.equal(0);
-      expect(node.collider()).to.be.null;
+      expect(node.collider).to.be.null;
     });
 
     it('should accept arguments', () => {
@@ -53,7 +53,7 @@ describe('Text', () => {
       expect(node.attrs.y).to.equal(2);
       expect(node.attrs.dx).to.equal(3);
       expect(node.attrs.dy).to.equal(4);
-      expect(node.collider()).to.be.null;
+      expect(node.collider).to.be.null;
     });
 
     it('should instantiate collider given data and explicit bounds', () => {
@@ -68,9 +68,9 @@ describe('Text', () => {
           x: 0, y: 0, width: 0, height: 0
         }
       });
-      expect(node.collider()).to.be.a('object');
-      expect(node.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(node.collider().type).to.equal('bounds');
+      expect(node.collider).to.be.a('object');
+      expect(node.collider).to.be.an.instanceof(GeoRect);
+      expect(node.colliderType).to.equal('bounds');
     });
 
     it('should instantiate collider given data and bounds function', () => {
@@ -85,9 +85,8 @@ describe('Text', () => {
           x: 0, y: 0, width: 0, height: 0
         })
       });
-      expect(node.collider()).to.be.a('object');
-      expect(node.collider().fn).to.be.an.instanceof(GeoRect);
-      expect(node.collider().type).to.equal('bounds');
+      expect(node.collider).to.be.an.instanceof(GeoRect);
+      expect(node.colliderType).to.equal('bounds');
     });
   });
 


### PR DESCRIPTION
This fixes an issue where a container with a bounds collider would not resolve transform on it's children properly when doing collision test. It was mostly notable on the `box` component, where brushing/shapesAt would not work properly on HiDPI devices (MacBook/mobile devices).

The issue was introduced as a part of #115 and exposed from picasso.js ^0.10.0.

The actual solution resolves the node collider function upon first use, instead of while the node is created. This allow the transform on all node to be resolved before it's used.