### PR TITLE
feat: add filter for brush consumer

### DIFF
--- a/docs/src/input/brushing.md
+++ b/docs/src/input/brushing.md
@@ -34,6 +34,7 @@ trigger: [{
 
 * `context`: name of the brush context to observe
 * `data`: the mapped data properties to observe. _Optional_
+* `filter`: a filtering function. _Optional_
 * `style`: the style to apply to the shapes of the component
   * `active`: the style of _active_ data points
   * `inactive`: the style of _inactive_ data points
@@ -42,6 +43,7 @@ trigger: [{
 consume: [{
   context: 'selection',
   data: ['x'],
+  filter: shape => shape.type === 'circle',
   style: {
     active: {
       fill: 'red',

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -15,7 +15,12 @@ export function reduceToLeafNodes(nodes = []) {
   }, []);
 }
 
-export function styler(obj, { context, data, style }) {
+export function styler(obj, {
+  context,
+  data,
+  style,
+  filter
+}) {
   const brusher = obj.chart.brush(context);
   const dataProps = data;
   const active = style.active || {};
@@ -34,9 +39,17 @@ export function styler(obj, { context, data, style }) {
   const activeNodes = [];
   let globalActivation = false; // track when we need to loop through all nodes, not just the active ones
 
+  const getNodes = () => {
+    let nodes = reduceToLeafNodes(obj.nodes);
+    if (typeof filter === 'function') {
+      nodes = nodes.filter(filter);
+    }
+    return nodes;
+  };
+
   const update = () => {
     // TODO - render nodes only once, i.e. don't render for each brush, update nodes for all brushes and then render
-    const nodes = reduceToLeafNodes(obj.nodes);
+    const nodes = getNodes();
     const len = nodes.length;
     let nodeData;
     let globalChanged = false;
@@ -88,7 +101,7 @@ export function styler(obj, { context, data, style }) {
   };
 
   const onStart = () => {
-    const nodes = reduceToLeafNodes(obj.nodes);
+    const nodes = getNodes();
     const len = nodes.length;
     for (let i = 0; i < len; i++) {
       nodes[i].__style = nodes[i].__style || {};
@@ -105,7 +118,7 @@ export function styler(obj, { context, data, style }) {
   };
 
   const onEnd = () => {
-    const nodes = reduceToLeafNodes(obj.nodes);
+    const nodes = getNodes();
     const len = nodes.length;
 
     for (let i = 0; i < len; i++) {

--- a/packages/picasso.js/test/unit/core/component/brushing.spec.js
+++ b/packages/picasso.js/test/unit/core/component/brushing.spec.js
@@ -382,5 +382,32 @@ describe('Brushing', () => {
       expect(output[0].fill).to.equal('inactiveFill');
       expect(output[1].fill).to.equal('inactiveFill'); // Inactive
     });
+
+    it('should only affect filtered nodes', () => {
+      dummyComponent.nodes = [
+        { type: 'a', fill: 'start', data: {} },
+        { type: 'b', fill: 'start', data: {} },
+        { type: 'c', fill: 'start', data: {} },
+        { type: 'd', fill: 'start', data: {} }
+      ];
+
+      styler(dummyComponent, {
+        context: 'test',
+        filter(n) { return n.type === 'a' || n.type === 'c'; },
+        style: {
+          active: {
+            fill: 'active'
+          },
+          inactive: {
+            fill: 'inactive'
+          }
+        }
+      });
+      brusherStub.trigger('start');
+      brusherStub.trigger('update');
+
+      const output = dummyComponent.renderer.render.args[0][0];
+      expect(output.map(n => n.fill)).to.eql(['inactive', 'start', 'active', 'start']);
+    });
   });
 });


### PR DESCRIPTION
This PR adds support for filtering shapes when consuming a brush:

```js
{
  brush: {
    consume: [{
      context: 'highlight',
      filter: s => s.fill === 'red', // apply only on red shapes
      style: {
        inactive: {
          opacity: 0.3
        }
      }
    }]
  }
}
```

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
