### PR TITLE
fix(box): add logic for minWidthPx

### DIFF
--- a/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
+++ b/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
@@ -1,4 +1,9 @@
-import { box, verticalLine, horizontalLine } from '../box-shapes';
+import {
+  box,
+  verticalLine,
+  horizontalLine,
+  getBoxWidth
+} from '../box-shapes';
 
 describe('box shapes', () => {
   describe('box', () => {
@@ -229,6 +234,41 @@ describe('box shapes', () => {
           type: null
         }
       });
+    });
+  });
+
+  describe('getBoxWidth', () => {
+    let item;
+    let avaialbleWidth;
+    let bandwidth;
+
+    beforeEach(() => {
+      avaialbleWidth = 100;
+      bandwidth = 0.1;
+      item = {
+        box: {
+          width: 0.5,
+          maxWidthPx: NaN,
+          minWidthPx: NaN
+        }
+      };
+    });
+
+    it('width is between min and max pixel width', () => {
+      const w = getBoxWidth(bandwidth, item, avaialbleWidth);
+      expect(w).to.equal(0.05);
+    });
+
+    it('width is less than min width', () => {
+      item.box.minWidthPx = 0.1 * avaialbleWidth;
+      const w = getBoxWidth(bandwidth, item, avaialbleWidth);
+      expect(w).to.equal(0.1);
+    });
+
+    it('width is larger than max width', () => {
+      item.box.maxWidthPx = 0.01 * avaialbleWidth;
+      const w = getBoxWidth(bandwidth, item, avaialbleWidth);
+      expect(w).to.equal(0.01);
     });
   });
 });

--- a/packages/picasso.js/src/core/chart-components/box/box-shapes.js
+++ b/packages/picasso.js/src/core/chart-components/box/box-shapes.js
@@ -108,6 +108,11 @@ export function horizontalLine({
   });
 }
 
+export function getBoxWidth(bandwidth, item, maxMajorWidth) {
+  const boxWidth = Math.min(bandwidth * item.box.width, isNaN(item.box.maxWidthPx) ? maxMajorWidth : item.box.maxWidthPx / maxMajorWidth);
+  return isNaN(item.box.minWidthPx) ? boxWidth : Math.max(item.box.minWidthPx / maxMajorWidth, boxWidth);
+}
+
 export function buildShapes({
   width,
   height,
@@ -158,7 +163,7 @@ export function buildShapes({
     keys.forEach(key => (item[key] = resolved[key].items[i]));
 
     const maxMajorWidth = flipXY ? height : width;
-    const boxWidth = Math.min(bandwidth * item.box.width, isNaN(item.box.maxWidthPx) ? maxMajorWidth : item.box.maxWidthPx / maxMajorWidth);
+    const boxWidth = getBoxWidth(bandwidth, item, maxMajorWidth);
     const boxPadding = (bandwidth - boxWidth) / 2;
     const boxCenter = boxPadding + item.major + (boxWidth / 2);
 


### PR DESCRIPTION
The `minWidthPx` setting for the box component was accidentally removed. This PR adds support for it again.
