### PR TITLE
feat(range-brush): add keys to dom elements

### DIFF
--- a/packages/picasso.js/src/web/components/brush-range/__tests__/brush-area-dir.spec.js
+++ b/packages/picasso.js/src/web/components/brush-range/__tests__/brush-area-dir.spec.js
@@ -90,6 +90,7 @@ describe('Brush Area Directional', () => {
           sel: 'div',
           data: {
             'data-value': 0,
+            'data-key': 'brush-area-dir-edge-0',
             style: {
               cursor: 'ew-resize',
               position: 'absolute',
@@ -132,6 +133,7 @@ describe('Brush Area Directional', () => {
           sel: 'div',
           data: {
             'data-value': 100,
+            'data-key': 'brush-area-dir-edge-0',
             style: {
               cursor: 'ew-resize',
               position: 'absolute',
@@ -178,6 +180,7 @@ describe('Brush Area Directional', () => {
             data: {
               'data-other-value': 100,
               'data-idx': 0,
+              'data-key': 'brush-area-dir-bubble-0',
               style: {
                 position: 'relative',
                 borderRadius: '4px',
@@ -222,6 +225,7 @@ describe('Brush Area Directional', () => {
             data: {
               'data-other-value': 0,
               'data-idx': 0,
+              'data-key': 'brush-area-dir-bubble-0',
               style: {
                 position: 'relative',
                 borderRadius: '4px',
@@ -274,6 +278,7 @@ describe('Brush Area Directional', () => {
           sel: 'div',
           data: {
             'data-value': 0,
+            'data-key': 'brush-area-dir-edge-0',
             style: {
               cursor: 'ns-resize',
               position: 'absolute',
@@ -316,6 +321,7 @@ describe('Brush Area Directional', () => {
           sel: 'div',
           data: {
             'data-value': 150,
+            'data-key': 'brush-area-dir-edge-0',
             style: {
               cursor: 'ns-resize',
               position: 'absolute',
@@ -362,6 +368,7 @@ describe('Brush Area Directional', () => {
             data: {
               'data-other-value': 150,
               'data-idx': 0,
+              'data-key': 'brush-area-dir-bubble-0',
               style: {
                 position: 'relative',
                 borderRadius: '4px',
@@ -406,6 +413,7 @@ describe('Brush Area Directional', () => {
             data: {
               'data-other-value': 0,
               'data-idx': 0,
+              'data-key': 'brush-area-dir-bubble-0',
               style: {
                 position: 'relative',
                 borderRadius: '4px',

--- a/packages/picasso.js/src/web/components/brush-range/__tests__/brush-range.spec.js
+++ b/packages/picasso.js/src/web/components/brush-range/__tests__/brush-range.spec.js
@@ -151,6 +151,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 0,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -182,6 +183,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 1,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -207,6 +209,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 1,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['-']
@@ -229,6 +232,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 0,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['-']
@@ -275,6 +279,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 0,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -306,6 +311,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 1,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -331,6 +337,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 1,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['0']
@@ -353,6 +360,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 0,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['1']
@@ -392,6 +400,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 0,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -426,6 +435,7 @@ describe('Brush Range', () => {
           sel: 'div',
           data: {
             'data-value': 1,
+            'data-key': 'brush-range-edge--1',
             style: rootEdgeStyle
           },
           children: [{
@@ -454,6 +464,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 1,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['0']
@@ -478,6 +489,7 @@ describe('Brush Range', () => {
             data: {
               'data-other-value': 0,
               'data-idx': -1,
+              'data-key': 'brush-range-bubble--1',
               style: bubbleStyle
             },
             children: ['1']

--- a/packages/picasso.js/src/web/components/brush-range/brush-area-dir.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-area-dir.js
@@ -174,7 +174,9 @@ const brushAreaDirectionalComponent = {
     this.rect = {
       x: 0, y: 0, width: 0, height: 0
     };
-    this.state = {};
+    this.state = {
+      key: this.settings.key || 'brush-area-dir'
+    };
   },
   beforeRender(opts) {
     this.rect = opts.size;

--- a/packages/picasso.js/src/web/components/brush-range/brush-range-node-builder.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-range-node-builder.js
@@ -6,7 +6,7 @@ import {
 } from './brush-range-const';
 
 function buildLine({
-  h, isVertical, value, pos, align, borderHit, state
+  h, isVertical, value, pos, align, borderHit, state, idx
 }) {
   const isAlignStart = align !== 'end';
   const alignStart = { left: '0', top: '0' };
@@ -40,6 +40,7 @@ function buildLine({
       e.srcElement.children[0].style[isVertical ? 'height' : 'width'] = '1px';
     },
     'data-value': value,
+    'data-key': [state.key, 'edge', idx].join('-'),
     style: {
       cursor: isVertical ? 'ns-resize' : 'ew-resize',
       position: 'absolute',
@@ -96,6 +97,7 @@ function buildBubble({
   }, [
     // bubble
     h('div', {
+      'data-key': [state.key, 'bubble', idx].join('-'),
       'data-other-value': otherValue,
       'data-idx': idx,
       style: extend({
@@ -206,7 +208,8 @@ export default function buildRange({
     value: start < end ? vStart : vEnd,
     pos: top,
     align: 'start',
-    state
+    state,
+    idx
   }));
 
   els.push(buildLine({
@@ -216,7 +219,8 @@ export default function buildRange({
     value: start < end ? vEnd : vStart,
     pos: bottom,
     align: 'end',
-    state
+    state,
+    idx
   }));
 
   const bubbles = state.settings.bubbles;

--- a/packages/picasso.js/src/web/components/brush-range/brush-range.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-range.js
@@ -216,7 +216,9 @@ const brushRangeComponent = {
     rangeClear(e) { this.clear(e); }
   },
   created() {
-    this.state = {};
+    this.state = {
+      key: this.settings.key || 'brush-range'
+    };
   },
   beforeRender(opts) {
     this.state.rect = opts.size;


### PR DESCRIPTION
Add keys to dom elements in the form of data attributes in order to identify the elements during event handling.