### PR TITLE
feat(line): add layer sort option

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -2528,6 +2528,43 @@
           "defaultValue": "line",
           "type": "string"
         }
+      },
+      "definitions": {
+        "layerSort": {
+          "kind": "function",
+          "params": [
+            {
+              "name": "a",
+              "kind": "object",
+              "entries": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "kind": "array",
+                  "items": {
+                    "type": "#/definitions/datum-extract"
+                  }
+                }
+              }
+            },
+            {
+              "name": "b",
+              "kind": "object",
+              "entries": {
+                "id": {
+                  "type": "string"
+                },
+                "data": {
+                  "kind": "array",
+                  "items": {
+                    "type": "#/definitions/datum-extract"
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     },
     "component--line-settings": {
@@ -2568,6 +2605,10 @@
               "optional": true,
               "defaultValue": true,
               "type": "boolean"
+            },
+            "sort": {
+              "optional": true,
+              "type": "#/definitions/component--line/definitions/layerSort"
             },
             "line": {
               "kind": "object",

--- a/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
@@ -318,4 +318,43 @@ describe('line component', () => {
       });
     });
   });
+
+  describe('layer order', () => {
+    let config;
+    beforeEach(() => {
+      config = {
+        data: [2.1, 2.2, 2.3, 1.1, 1.2, 1.3, 3.1, 3.2, 3.3],
+        settings: {
+          coordinates: {
+            major(d, i) { return i; },
+            minor(d) { return d.datum.value; },
+            layerId(d) { return 10 - Math.round(d.datum.value); }
+          },
+          layers: {
+            line: {
+              stroke: d => ['red', 'green', 'blue'][Math.round(d.datum.value) - 1]
+            }
+          }
+        }
+      };
+
+      componentFixture.mocks().theme.style.returns({});
+    });
+
+    it('should be sorted by median by default', () => {
+      componentFixture.simulateCreate(component, config);
+      rendered = componentFixture.simulateRender(opts);
+      const order = rendered.map(layer => layer.stroke);
+      expect(order).to.eql(['red', 'green', 'blue']);
+    });
+
+    it('should be sorted by custom sorting function', () => {
+      config.settings.layers.sort = (a, b) => b.data[0].value - a.data[0].value;
+
+      componentFixture.simulateCreate(component, config);
+      rendered = componentFixture.simulateRender(opts);
+      const order = rendered.map(layer => layer.stroke);
+      expect(order).to.eql(['blue', 'green', 'red']);
+    });
+  });
 });


### PR DESCRIPTION
Adds support for sorting layers:

```js
settings: {
  coordinates: {
    minor: { scale: 'y' },
    major: { scale: 'x' },
    layerId: { ref: 'year' } 
  },
  orientation: 'horizontal',
  layers: {
    sort(a, b) { return b.data[0].minor.value - a.data[0].minor.value; } // sort by first point in descending order
    line: {
      strokeWidth: 2,
      stroke: 'red'
    },
  }
}
```

closes #220
