### PR TITLE
fix(brush): brush only nodes with data

### DIFF
--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -379,7 +379,7 @@ describe('Brushing', () => {
 
       const output = dummyComponent.renderer.render.args[0][0];
       expect(output[0].stroke).to.equal('doNotUpdate'); // No data attr
-      expect(output[0].fill).to.equal('inactiveFill');
+      expect(output[0].fill).to.equal('doNotUpdate');
       expect(output[1].fill).to.equal('inactiveFill'); // Inactive
     });
 

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -100,6 +100,10 @@ export function styler(obj, {
     const nodes = getNodes();
     const len = nodes.length;
     for (let i = 0; i < len; i++) {
+      if (!nodes[i].data) {
+        continue;
+      }
+
       nodes[i].__style = nodes[i].__style || {};
       styleProps.forEach((s) => {
         nodes[i].__style[s] = nodes[i][s]; // store original value


### PR DESCRIPTION
When a brush was started all nodes would be set to inactive, even those without data. As there is no way to change the state of them to active, only nodes with data can be updated. This fix changes so that only nodes with data can be set to inactive or active.

Also as a TODO note, we should consider doing something better than a falsy check on the data attribute.

**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
