### PR TITLE
fix(layers): preserve original index if equal

### DIFF
--- a/packages/picasso.js/src/core/dock-layout/dock-layout.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-layout.js
@@ -172,7 +172,7 @@ function positionComponents(components, logicalContainerRect, reducedRect, conta
   };
 
   const referencedComponents = {};
-
+  const referenceArray = components.slice();
   components.sort((a, b) => {
     if (/^@/.test(b.config.dock())) {
       return -1;
@@ -180,7 +180,11 @@ function positionComponents(components, logicalContainerRect, reducedRect, conta
     if (/^@/.test(a.config.dock())) {
       return 1;
     }
-    return a.config.displayOrder() - b.config.displayOrder();
+    const diff = a.config.displayOrder() - b.config.displayOrder();
+    if (diff === 0) {
+      return referenceArray.indexOf(a) - referenceArray.indexOf(b);
+    }
+    return diff;
   }).forEach((c) => {
     let outerRect = {};
     let rect = {};

--- a/packages/picasso.js/test/component/chart/chart.comp.js
+++ b/packages/picasso.js/test/component/chart/chart.comp.js
@@ -239,9 +239,9 @@ describe('Chart', () => {
         return [];
       }
     });
-    function createComp(order) {
+    function createComp(key, order = key) {
       return {
-        key: `comp${order}`,
+        key: `comp${key}`,
         displayOrder: order,
         type: 'custom-log-render'
       };
@@ -250,9 +250,9 @@ describe('Chart', () => {
     const comp0 = createComp(0);
     const comp1 = createComp(1);
     const comp2 = createComp(2);
+    const comp3 = createComp(3, 1);
 
-    settings.components.push(comp2);
-    settings.components.push(comp0);
+    settings.components.push(comp2, comp0);
     const instance = chart({
       element,
       data: { data },
@@ -265,5 +265,11 @@ describe('Chart', () => {
       settings
     });
     expect(renderOrder).to.eql(['comp0', 'comp1', 'comp2']);
+    renderOrder = [];
+    settings.components.push(comp3);
+    instance.update({
+      settings
+    });
+    expect(renderOrder).to.eql(['comp0', 'comp1', 'comp3', 'comp2']);
   });
 });


### PR DESCRIPTION
The JavaScript sort algorithm implementation does not guarantee object order when sorting on object properties:

> If `compareFunction(a, b)` returns `0`, leave `a` and `b` unchanged with respect to each other, but sorted with respect to all different elements. Note: the ECMAscript standard does not guarantee this behaviour, and thus not all browsers (e.g. Mozilla versions dating back to at least 2003) respect this. Read more: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description

This was causing issues in a project I'm working on, specifically in Chrome.

This PR adds a check if the displayOrder is equal, and if so, uses the original array index to preserve the order.

The output below is based on 11 components, all defined _without_ setting `displayOrder`(defaulting to 0), the label targets are docked and prioritized above others.

Before (output is based on before and after sort):

<img width="264" alt="before" src="https://user-images.githubusercontent.com/83221/47267299-1152d880-d542-11e8-886c-1b6b92db4541.png">

After (output is based on before and after sort):

<img width="269" alt="after" src="https://user-images.githubusercontent.com/83221/47267292-08620700-d542-11e8-81bb-912c81d542e1.png">
