### PR TITLE
fix(axis): labels rendered outside the axis area

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -1,5 +1,5 @@
 function isMajorTick(tick) {
-  return !tick.isMinor;
+  return !tick.isMinor && tick.position >= 0 && tick.position <= 1;
 }
 
 function isVerticalLabelOverlapping({

--- a/packages/picasso.js/src/core/chart-components/axis/axis.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis.js
@@ -177,7 +177,7 @@ const axisComponent = {
     this.state.ticks = this.state.pxScale.ticks({
       distance,
       formatter
-    });
+    }).filter(t => t.position >= 0 && t.position <= 1);
   },
   render() {
     const {


### PR DESCRIPTION
Fix an issue where labels and ticks would be renderer outside the normal axis area.