### PR TITLE
feat(scene-graph): get parent and child nodes

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4633,6 +4633,17 @@
         "params": []
       },
       "entries": {
+        "children": {
+          "description": "Get child nodes",
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/SceneNode"
+          }
+        },
+        "parent": {
+          "description": "Get parent node",
+          "type": "#/definitions/SceneNode"
+        },
         "type": {
           "description": "Node type",
           "type": "string"

--- a/packages/picasso.js/src/core/scene-graph/__tests__/scene-node.spec.js
+++ b/packages/picasso.js/src/core/scene-graph/__tests__/scene-node.spec.js
@@ -19,7 +19,12 @@ describe('Scene Node', () => {
       desc: {
         myProp: 1337
       },
-      tag: 'Hello world'
+      tag: 'Hello world',
+      children: [
+        { type: 'child 1' },
+        { type: 'child 2' }
+      ],
+      parent: { type: 'parent node' }
     };
 
     nodeMock.boundingRect = sinon.stub();
@@ -28,6 +33,25 @@ describe('Scene Node', () => {
     });
 
     sceneNode = create(nodeMock);
+  });
+
+  it('should return child nodes', () => {
+    const c = sceneNode.children;
+    expect(c).to.be.of.length(2);
+    expect(c).to.containSubset([
+      { type: 'child 1' },
+      { type: 'child 2' }
+    ]);
+  });
+
+  it('should return parent node', () => {
+    expect(sceneNode.parent).to.containSubset({ type: 'parent node' });
+  });
+
+  it('should null when there is no parent node', () => {
+    nodeMock.parent = null;
+    sceneNode = create(nodeMock);
+    expect(sceneNode.parent).to.equal(null);
   });
 
   it('should expose node type', () => {

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -73,6 +73,24 @@ class SceneNode {
     this._collider = () => colliderToShape(node, this._dpi);
     this._desc = node.desc;
     this._tag = node.tag;
+    this._children = () => node.children.map(n => new SceneNode(n));
+    this._parent = () => (node.parent ? new SceneNode(node.parent) : null);
+  }
+
+  /**
+   * Get child nodes
+   * @type {SceneNode[]}
+   */
+  get children() {
+    return this._children();
+  }
+
+  /**
+   * Get parent node
+   * @type {SceneNode}
+   */
+  get parent() {
+    return this._parent();
   }
 
   /**


### PR DESCRIPTION
This adds the ability to get parent and child nodes from a scene node. Which enables basic traversing of the scene graph.

All API:s that returns a scene node are affected.

```js
chartInstance.findShapes('container')[0].children.forEach(child => {
  // Do something with the child node
});
```
