### PR TITLE
fix(data): undefined data source in field

### DIFF
--- a/packages/picasso.js/src/core/data/__tests__/dataset.spec.js
+++ b/packages/picasso.js/src/core/data/__tests__/dataset.spec.js
@@ -28,18 +28,21 @@ describe('dataset', () => {
         { product: 'Shoes', sales: 23 }
       ];
       d = dataset({
+        key: 'test',
         data
       });
     });
 
     it('should find product field', () => {
       const f = d.field(0);
+      expect(f.id()).to.equal('test/product');
       expect(f.title()).to.equal('product');
       expect(f.items()).to.eql(['Cars', 'Bikes', 'Shoes']);
     });
 
     it('should find sales field', () => {
       const f = d.field('sales');
+      expect(f.id()).to.equal('test/sales');
       expect(f.title()).to.equal('sales');
       expect(f.items()).to.eql([56, 34, 23]);
     });
@@ -54,6 +57,7 @@ describe('dataset', () => {
         { product: 'Shoes', sales: 23 }
       ];
       d = dataset({
+        key: 'test',
         data,
         config: {
           parse: {
@@ -102,18 +106,21 @@ describe('dataset', () => {
 
     it('should find product field', () => {
       const f = d.field(0);
+      expect(f.id()).to.equal('test/product');
       expect(f.title()).to.equal('product');
       expect(f.items()).to.eql(['Cars', 'Shoes']);
     });
 
     it('should find sales field', () => {
       const f = d.field('sales');
+      expect(f.id()).to.equal('test/sales');
       expect(f.title()).to.equal('Sell sell sell');
       expect(f.items()).to.eql([112, 46]);
     });
 
     it('should find extra field', () => {
       const f = d.field('Added');
+      expect(f.id()).to.equal('test/extra');
       expect(f.key()).to.equal('extra');
       expect(f.items()).to.eql([5600, 2300]);
     });
@@ -127,11 +134,15 @@ describe('dataset', () => {
         ['Cars', 56],
         ['Cars', 59]
       ];
-      d = dataset({ data });
+      d = dataset({
+        key: 'test',
+        data
+      });
     });
 
     it('should find the second field', () => {
       const f = d.field(1);
+      expect(f.id()).to.equal('test/Sales');
       expect(f.title()).to.equal('Sales');
       expect(f.items()).to.eql([56, 59]);
     });
@@ -146,6 +157,7 @@ describe('dataset', () => {
         ['Bikes', 34]
       ];
       d = dataset({
+        key: 'test',
         data,
         config: {
           parse: {
@@ -187,6 +199,7 @@ describe('dataset', () => {
 
     it('should find the second field', () => {
       const f = d.field('Sell sell sell');
+      expect(f.id()).to.equal('test/sales');
       expect(f.title()).to.equal('Sell sell sell');
       expect(f.items()).to.eql([112, 68]);
       expect(f.value(33)).to.eql(37);
@@ -195,6 +208,7 @@ describe('dataset', () => {
 
     it('should add a third field', () => {
       const f = d.field('extra');
+      expect(f.id()).to.equal('test/extra');
       expect(f.title()).to.equal('Added');
       expect(f.items()).to.eql([21, 22]);
       expect(f.formatter()(0.22)).to.equal('0.220');
@@ -209,6 +223,7 @@ describe('dataset', () => {
         ['Cars', 59]
       ];
       d = dataset({
+        key: 'test',
         data,
         config: {
           parse: {
@@ -220,6 +235,7 @@ describe('dataset', () => {
 
     it('should find the second field', () => {
       const f = d.field(1);
+      expect(f.id()).to.equal('test/1');
       expect(f.title()).to.equal('1');
       expect(f.items()).to.eql([56, 59]);
     });
@@ -230,6 +246,7 @@ describe('dataset', () => {
     before(() => {
       const data = 'Product|Sales\nCars|56\nBikes|34';
       d = dataset({
+        key: 'test',
         data,
         config: {
           parse: { delimiter: '|' }
@@ -239,12 +256,14 @@ describe('dataset', () => {
 
     it('should find product field', () => {
       const f = d.field(0);
+      expect(f.id()).to.equal('test/Product');
       expect(f.title()).to.equal('Product');
       expect(f.items()).to.eql(['Cars', 'Bikes']);
     });
 
     it('should find sales field', () => {
       const f = d.field('Sales');
+      expect(f.id()).to.equal('test/Sales');
       expect(f.title()).to.equal('Sales');
       expect(f.items()).to.eql(['56', '34']);
     });
@@ -253,36 +272,44 @@ describe('dataset', () => {
   describe('dsv with guessed delimiter', () => {
     it('comma (,)', () => {
       const d = dataset({
+        key: 'test',
         data: 'Product,Sales\nCars,56\nBikes,34'
       });
       const f = d.field(0);
+      expect(f.id()).to.equal('test/Product');
       expect(f.title()).to.equal('Product');
       expect(f.items()).to.eql(['Cars', 'Bikes']);
     });
 
     it('semicolon (;)', () => {
       const d = dataset({
+        key: 'test',
         data: 'Pro,d\tuct;Sales\nCars;56\nBikes;34'
       });
       const f = d.field(0);
+      expect(f.id()).to.equal('test/Pro,d\tuct');
       expect(f.title()).to.equal('Pro,d\tuct');
       expect(f.items()).to.eql(['Cars', 'Bikes']);
     });
 
     it('tab (\\t)', () => {
       const d = dataset({
+        key: 'test',
         data: 'Pro,duct\tSales\nCars\t56\nBikes\t34'
       });
       const f = d.field(0);
+      expect(f.id()).to.equal('test/Pro,duct');
       expect(f.title()).to.equal('Pro,duct');
       expect(f.items()).to.eql(['Cars', 'Bikes']);
     });
 
     it('; with header only', () => {
       const d = dataset({
+        key: 'test',
         data: 'Product;Sales'
       });
       const f = d.field(0);
+      expect(f.id()).to.equal('test/Product');
       expect(f.title()).to.equal('Product');
     });
   });

--- a/packages/picasso.js/src/core/data/data.js
+++ b/packages/picasso.js/src/core/data/data.js
@@ -22,7 +22,7 @@ export default function datasets(dataSources, { types, logger }) {
     if (datasetFactory) {
       let key = d.key;
       if (typeof d.key === 'undefined') {
-        logger.warn(`Missing key for dataset at index: ${i}. Using index as key.`);
+        logger.warn(`Missing key for dataset. Using index '${i}' as key.`);
         key = i;
       }
       let dataset = datasetFactory({

--- a/packages/picasso.js/src/core/data/data.js
+++ b/packages/picasso.js/src/core/data/data.js
@@ -20,13 +20,17 @@ export default function datasets(dataSources, { types, logger }) {
   sets.forEach((d, i) => {
     let datasetFactory = types(d.type);
     if (datasetFactory) {
-      let key = d.key || i;
+      let key = d.key;
+      if (typeof d.key === 'undefined') {
+        logger.warn(`Missing key for dataset at index: ${i}. Using index as key.`);
+        key = i;
+      }
       let dataset = datasetFactory({
         key,
         data: d.data,
         config: d.config
       });
-      data[d.key || i] = dataset;
+      data[key] = dataset;
     }
   });
 

--- a/packages/picasso.js/src/core/data/dataset.js
+++ b/packages/picasso.js/src/core/data/dataset.js
@@ -114,7 +114,7 @@ const dsv = ({ data, config }) => {
 };
 
 const parseData = ({
-  source, data, cache, config
+  key, data, cache, config
 }) => {
   if (!data) {
     return;
@@ -132,7 +132,7 @@ const parseData = ({
   createFields({
     data: dd,
     cache,
-    source,
+    source: key,
     config
   });
 };


### PR DESCRIPTION
Fixes an issue where the dataset source was not pass down correctly to the field. Resulting in wrong field identifier.

A unfortunate side-effects of this issue was that brushing would not be applied properly in some cases.

```js
// Before
chartInstance.dataset('Producs').field('Sales').id() // would output `undefined/Sales`

// After
chartInstance.dataset('Producs').field('Sales').id() // will output `Products/Sales`
```