### PR TITLE
fix(box): out of bounds symbol arrow direction

### DIFF
--- a/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
+++ b/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
@@ -53,6 +53,49 @@ describe('box shapes', () => {
     });
   });
 
+  it('should create a correct out of bounds shape at the bottom of the graph with flipXY', () => {
+    const item = {
+      major: 0.3,
+      oob: {
+        size: 10
+      }
+    };
+
+    // We mock the symbol() function here
+    let result = oob({
+      value: 1, item, boxCenter: item.major, rendWidth: 200, rendHeight: 150, flipXY: true, symbol: v => v
+    });
+
+    expect(result).to.eql({
+      size: 10,
+      startAngle: 0,
+      x: 195,
+      y: 45
+    });
+
+    item.major = 0.5;
+  });
+
+  it('should create a correct out of bounds shape at the top of the graph with flipXY', () => {
+    const item = {
+      major: 0.75,
+      oob: {
+        size: 10
+      }
+    };
+
+    // We mock the symbol() function here
+    let result = oob({
+      value: 0, item, boxCenter: item.major, rendWidth: 200, rendHeight: 150, flipXY: true, symbol: v => v
+    });
+
+    expect(result).to.eql({
+      size: 10,
+      startAngle: 180,
+      x: 5,
+      y: 112.5
+    });
+  });
 
   describe('box', () => {
     it('should create a correct box shape', () => {

--- a/packages/picasso.js/src/core/chart-components/box/box-shapes.js
+++ b/packages/picasso.js/src/core/chart-components/box/box-shapes.js
@@ -23,18 +23,20 @@ export function oob({
   let y = 'y';
   let calcwidth = rendWidth;
   let calcheight = rendHeight;
+  let startAngle = value < 0.5 ? 90 : -90;
 
   if (flipXY) {
     x = 'y';
     y = 'x';
     calcwidth = rendHeight;
     calcheight = rendWidth;
+    startAngle = value < 0.5 ? 180 : 0;
   }
 
   return symbol(extend({}, item.oob, {
     [x]: boxCenter * calcwidth,
     [y]: Math.max((item.oob.size / 2), Math.min(value * calcheight, calcheight - (item.oob.size / 2))),
-    startAngle: value < 0.5 ? 90 : -90
+    startAngle
   }));
 }
 


### PR DESCRIPTION
The out of bounds arrow symbol was in the right place, but when specifying flipXY it did not take arrow direction into account. This is now fixed and added proper tests for it aswel..

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
