### PR TITLE
feat(brush-range): observe brush changes

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -5102,7 +5102,16 @@
       "entries": {
         "brush": {
           "description": "Brush context to apply changes to",
-          "type": "string"
+          "kind": "union",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "type": "any"
         },
         "scale": {
           "description": "Scale to extract data from",

--- a/docs/src/input/component-brush-range.md
+++ b/docs/src/input/component-brush-range.md
@@ -109,7 +109,7 @@ It is possible to observe brush changes and render a range/s upon change.
       context: '<some-context>',
       observe: true // The brush range is than rendererd every time the brush context changes
     },
-    scale: '<some-linear-scale>
+    scale: '<some-linear-scale>'
   }
 }
 

--- a/docs/src/input/component-brush-range.md
+++ b/docs/src/input/component-brush-range.md
@@ -97,6 +97,26 @@ components: [
 ]
 ```
 
+### Observe brush change
+
+It is possible to observe brush changes and render a range/s upon change.
+
+```js
+{
+  type: 'brush-range',
+  settings: {
+    brush: {
+      context: '<some-context>',
+      observe: true // The brush range is than rendererd every time the brush context changes
+    },
+    scale: '<some-linear-scale>
+  }
+}
+
+// The following code will trigger the brush-range to render
+chartInstance.brush('<some-context>').toggleRange('<key>', { min: 1, max: 2 });
+```
+
 ## API Reference
 
 ### Settings


### PR DESCRIPTION
This PR adds a new setting the brush-range component that allows the user to configure the component to render ranges when a brush context is updated. It is turn off by default.

It now also keep the range when a chart update (only if partial data) is performed. This is a new default behavior and is not something that can be turned off.

Example:
```js
{
  type: 'brush-range',
  settings: {
    brush: {
      context: '<some-context>',
      observe: true // The brush range is than rendered every time the brush context changes
    },
    scale: '<some-linear-scale>'
  }
}

// The following code will trigger the brush-range to render
chartInstance.brush('<some-context>').toggleRange('<key>', { min: 1, max: 2 });
```