### PR TITLE
feat: make it possible to exclude specific components from update

### DIFF
--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -120,5 +120,39 @@ describe('Chart', () => {
       expect(create).to.not.throw();
       expect(logger.warn).to.have.been.calledWithExactly('Unknown component: noop');
     });
+
+    it('should not update components specified in excludeFromUpdate array', () => {
+      const components = {
+        box: { has: () => true },
+        point: { has: () => true }
+      };
+      const comp = key => components[key];
+      comp.has = () => true;
+      const comp1UpdatedCb = sinon.spy();
+      const comp2UpdatedCb = sinon.spy();
+      const chartInstance = chart(Object.assign(definition, {
+        settings: {
+          components: [{
+            type: 'box',
+            key: 'comp1',
+            updated: comp1UpdatedCb
+          }, {
+            type: 'point',
+            key: 'comp2',
+            updated: comp2UpdatedCb
+          }]
+        }
+      }), {
+        registries: {
+          component: comp
+        }
+      });
+      chartInstance.update();
+      expect(comp1UpdatedCb).to.have.been.calledOnce;
+      expect(comp2UpdatedCb).to.have.been.calledOnce;
+      chartInstance.update({ excludeFromUpdate: ['comp2'] });
+      expect(comp1UpdatedCb).to.have.been.calledTwice;
+      expect(comp2UpdatedCb).to.have.been.calledOnce;
+    });
   });
 });

--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -1,3 +1,4 @@
+import componentFactoryFixture from '../../../../test/helpers/component-factory-fixture';
 import elementMock from 'test-utils/mocks/element-mock';
 import chart from '..';
 
@@ -123,11 +124,19 @@ describe('Chart', () => {
 
     it('should not update components specified in excludeFromUpdate array', () => {
       const components = {
-        box: { has: () => true },
-        point: { has: () => true }
+        box: {
+          has: () => true,
+          render: sinon.stub()
+        },
+        point: {
+          has: () => true,
+          render: sinon.stub()
+        }
       };
       const comp = key => components[key];
       comp.has = () => true;
+      const componentFixture = componentFactoryFixture();
+
       const comp1UpdatedCb = sinon.spy();
       const comp2UpdatedCb = sinon.spy();
       const chartInstance = chart(Object.assign(definition, {
@@ -144,7 +153,8 @@ describe('Chart', () => {
         }
       }), {
         registries: {
-          component: comp
+          component: comp,
+          renderer: () => () => componentFixture.mocks().renderer
         }
       });
       chartInstance.update();
@@ -152,7 +162,10 @@ describe('Chart', () => {
       expect(comp2UpdatedCb).to.have.been.calledOnce;
       chartInstance.update({ excludeFromUpdate: ['comp2'] });
       expect(comp1UpdatedCb).to.have.been.calledTwice;
-      expect(comp2UpdatedCb).to.have.been.calledOnce;
+      expect(comp2UpdatedCb).to.have.been.called;
+      chartInstance.update({ partialData: true, excludeFromUpdate: ['comp1'] });
+      expect(comp1UpdatedCb).to.have.been.calledTwice;
+      expect(comp2UpdatedCb).to.have.been.calledTwice;
     });
   });
 });

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -394,7 +394,7 @@ function chartFn(definition, context) {
    * @param {chart-definition} [chart] - Chart definition
    */
   instance.update = (newProps = {}) => {
-    const { partialData } = newProps;
+    const { partialData, excludeFromUpdate = [] } = newProps;
     if (newProps.data) {
       data = newProps.data;
     }
@@ -426,6 +426,12 @@ function chartFn(definition, context) {
     // Let the "components" array determine order of components
     currentComponents = components.map((comp) => {
       const idx = findComponentIndexByKey(comp.key);
+
+      // Component should not be updated
+      if (excludeFromUpdate.length && excludeFromUpdate.indexOf(comp.key) > -1) {
+        return currentComponents[idx];
+      }
+
       if (idx === -1) {
         // Component is added
         return createComponent(comp, element);

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -428,7 +428,7 @@ function chartFn(definition, context) {
       const idx = findComponentIndexByKey(comp.key);
 
       // Component should not be updated
-      if (excludeFromUpdate.length && excludeFromUpdate.indexOf(comp.key) > -1) {
+      if (excludeFromUpdate.indexOf(comp.key) > -1) {
         return currentComponents[idx];
       }
 


### PR DESCRIPTION
Makes it possible to send in an array called `excludeFromUpdate` in which you can specify the keys of the components you want to exclude from updating. This array is to be passed into `chartInstance.update`. This is one approach of optimizing performance (only re-render/update what's actually changed).

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
