### PR TITLE
fix(text): text line height leading space

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/title-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/title-renderer.js
@@ -63,7 +63,7 @@ export default function (legend) {
     render: (obj) => {
       render(obj, api.renderer, itemized);
     },
-    spread: () => (itemized ? itemized.bounds.height * 1.25 : 0),
+    spread: () => (itemized ? itemized.bounds.height : 0),
     extent: () => (itemized ? itemized.bounds.width : 0)
   };
 

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
@@ -66,9 +66,9 @@ describe('Line Break Resolver', () => {
       node.maxWidth = 3;
       node.lineHeight = 10;
       fn(state);
-      expect(state.node.children[0].dy).to.equal(5);
-      expect(state.node.children[1].dy).to.equal(15);
-      expect(state.node.children[2].dy).to.equal(25);
+      expect(state.node.children[0].dy).to.equal(4.5);
+      expect(state.node.children[1].dy).to.equal(14.5);
+      expect(state.node.children[2].dy).to.equal(24.5);
     });
 
     it('should include dy attribute when calculating position', () => {
@@ -80,9 +80,9 @@ describe('Line Break Resolver', () => {
       node.maxWidth = 3;
       node.lineHeight = 10;
       fn(state);
-      expect(state.node.children[0].dy).to.equal(8);
-      expect(state.node.children[1].dy).to.equal(18);
-      expect(state.node.children[2].dy).to.equal(28);
+      expect(state.node.children[0].dy).to.equal(7.5);
+      expect(state.node.children[1].dy).to.equal(17.5);
+      expect(state.node.children[2].dy).to.equal(27.5);
     });
 
     it('should remove maxWidth attribute and append ellipis char on last line', () => {

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
@@ -66,9 +66,9 @@ describe('Line Break Resolver', () => {
       node.maxWidth = 3;
       node.lineHeight = 10;
       fn(state);
-      expect(state.node.children[0].dy).to.equal(0);
-      expect(state.node.children[1].dy).to.equal(10);
-      expect(state.node.children[2].dy).to.equal(20);
+      expect(state.node.children[0].dy).to.equal(5);
+      expect(state.node.children[1].dy).to.equal(15);
+      expect(state.node.children[2].dy).to.equal(25);
     });
 
     it('should include dy attribute when calculating position', () => {
@@ -80,9 +80,9 @@ describe('Line Break Resolver', () => {
       node.maxWidth = 3;
       node.lineHeight = 10;
       fn(state);
-      expect(state.node.children[0].dy).to.equal(3);
-      expect(state.node.children[1].dy).to.equal(13);
-      expect(state.node.children[2].dy).to.equal(23);
+      expect(state.node.children[0].dy).to.equal(8);
+      expect(state.node.children[1].dy).to.equal(18);
+      expect(state.node.children[2].dy).to.equal(28);
     });
 
     it('should remove maxWidth attribute and append ellipis char on last line', () => {

--- a/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
+++ b/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
@@ -3,7 +3,7 @@ import { breakAll, breakWord } from './word-break';
 import { DEFAULT_LINE_HEIGHT, ELLIPSIS_CHAR } from './text-const';
 import { includesLineBreak } from './string-tokenizer';
 
-function generateLineNodes(result, item, lineHeight) {
+function generateLineNodes(result, item, halfLineHeight) {
   const container = { type: 'container', children: [] };
 
   if (typeof item.id !== 'undefined') { // TODO also inherit data attribute and more?
@@ -16,14 +16,16 @@ function generateLineNodes(result, item, lineHeight) {
     const node = extend({}, item);
     node.text = line;
     node._lineBreak = true; // Flag node as processed to avoid duplicate linebreak run
+    currentY += halfLineHeight; // leading height above
 
     if (result.reduced && i === result.lines.length - 1) {
       node.text += ELLIPSIS_CHAR;
     } else {
       delete node.maxWidth;
     }
+
     node.dy = isNaN(node.dy) ? currentY : node.dy + currentY;
-    currentY += lineHeight;
+    currentY += halfLineHeight; // Leading height below
     container.children.push(node);
   });
 
@@ -72,10 +74,10 @@ export function onLineBreak(measureText) {
         return;
       }
 
-      const lineHeight = tm.height * (item.lineHeight || DEFAULT_LINE_HEIGHT);
+      const halfLineHeight = (tm.height * (item.lineHeight || DEFAULT_LINE_HEIGHT)) / 2;
       const result = wordBreakFn(item, wrappedMeasureText(item, measureText));
 
-      state.node = generateLineNodes(result, item, lineHeight); // Convert node to container
+      state.node = generateLineNodes(result, item, halfLineHeight); // Convert node to container
     }
   };
 }

--- a/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
+++ b/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
@@ -3,7 +3,7 @@ import { breakAll, breakWord } from './word-break';
 import { DEFAULT_LINE_HEIGHT, ELLIPSIS_CHAR } from './text-const';
 import { includesLineBreak } from './string-tokenizer';
 
-function generateLineNodes(result, item, halfLineHeight) {
+function generateLineNodes(result, item, halfLead, height) {
   const container = { type: 'container', children: [] };
 
   if (typeof item.id !== 'undefined') { // TODO also inherit data attribute and more?
@@ -16,7 +16,7 @@ function generateLineNodes(result, item, halfLineHeight) {
     const node = extend({}, item);
     node.text = line;
     node._lineBreak = true; // Flag node as processed to avoid duplicate linebreak run
-    currentY += halfLineHeight; // leading height above
+    currentY += halfLead; // leading height above
 
     if (result.reduced && i === result.lines.length - 1) {
       node.text += ELLIPSIS_CHAR;
@@ -25,7 +25,8 @@ function generateLineNodes(result, item, halfLineHeight) {
     }
 
     node.dy = isNaN(node.dy) ? currentY : node.dy + currentY;
-    currentY += halfLineHeight; // Leading height below
+    currentY += height;
+    currentY += halfLead; // Leading height below
     container.children.push(node);
   });
 
@@ -74,10 +75,12 @@ export function onLineBreak(measureText) {
         return;
       }
 
-      const halfLineHeight = (tm.height * (item.lineHeight || DEFAULT_LINE_HEIGHT)) / 2;
+      const lineHeight = tm.height * Math.max((isNaN(item.lineHeight) ? DEFAULT_LINE_HEIGHT : item.lineHeight), 0);
+      const diff = lineHeight - tm.height;
+      const halfLead = diff / 2;
       const result = wordBreakFn(item, wrappedMeasureText(item, measureText));
 
-      state.node = generateLineNodes(result, item, halfLineHeight); // Convert node to container
+      state.node = generateLineNodes(result, item, halfLead, tm.height); // Convert node to container
     }
   };
 }

--- a/packages/picasso.js/src/web/text-manipulation/text-metrics.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-metrics.js
@@ -140,8 +140,10 @@ export function textBounds(node, measureFn = measureText) {
     }
     nodeCopy.text = widestLine;
     const bounds = calcTextBounds(nodeCopy, measureFn);
-    const lineHeight = node.lineHeight || DEFAULT_LINE_HEIGHT;
-    bounds.height = bounds.height * resolvedLineBreaks.lines.length * lineHeight;
+    const lineHeight = bounds.height * Math.max(isNaN(node.lineHeight) ? DEFAULT_LINE_HEIGHT : node.lineHeight, 0);
+    const diff = lineHeight - bounds.height;
+
+    bounds.height = (bounds.height + diff) * resolvedLineBreaks.lines.length;
 
     return bounds;
   }


### PR DESCRIPTION
Changes the behavior of how the line height attribute is applied for text nodes that contains line breaks. There is now a space above and below text that contains line breaks if line height attribute is > 1.

This aims to more closely implement the [w3 line-height](https://www.w3.org/TR/CSS2/visudet.html#inline-box-height) definition.

Known limitation:
* Full height of a glyph is estimated based only on the font and font-size.
* `textBounds()` returns slight different height for single line text with word break compared to single line text without word break. Fixing this would have a rather large impact on most component using text nodes so for now this will have to be as.