### PR TITLE
chore: fix source-map generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lerna": "^3.4.3",
     "mocha-junit-reporter": "^1.18.0",
     "protractor": "^5.4.1",
-    "rollup": "^0.67.0",
+    "rollup": "0.66.2",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7349,9 +7349,9 @@ rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.3:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@^0.67.0:
-  version "0.67.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.67.0.tgz#16d4f259c55224dded6408e7666b7731500797a3"
+rollup@0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.2.tgz#77acdb9f4093f5f035ce75480577c40a81ea7999"
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"


### PR DESCRIPTION
Revert rollup version to `0.66.2` due to invalid source-map generation in versions since `0.66.3`. 

https://github.com/rollup/rollup/issues/2525