### PR TITLE
feat(axis): add filter overlapping labels setting

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.15.0",
+    "version": "0.16.1",
     "license": "MIT"
   },
   "entries": {
@@ -1253,6 +1253,12 @@
               "optional": true,
               "defaultValue": 0,
               "type": "number"
+            },
+            "filterOverlapping": {
+              "description": "Toggle whether labels should be filtered if they are overlapping. Filtering may be applied in a non-sequential order.\nIf labels are overlapping and this setting is toggled off, the axis will automatically hide.",
+              "optional": true,
+              "defaultValue": false,
+              "type": "boolean"
             }
           }
         },
@@ -1352,6 +1358,12 @@
               "optional": true,
               "defaultValue": 0,
               "type": "number"
+            },
+            "filterOverlapping": {
+              "description": "Toggle whether labels should be filtered if they are overlapping. Filtering may be applied in a non-sequential order.\nIf labels are overlapping and this setting is toggled off, the axis will automatically hide.",
+              "optional": true,
+              "defaultValue": true,
+              "type": "boolean"
             }
           }
         },

--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-node-builder.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-node-builder.spec.js
@@ -1,6 +1,6 @@
 import { filterOverlappingLabels } from '../axis-node-builder';
 
-describe('Axis Node Buidlder', () => {
+describe('Axis Node Builder', () => {
   describe('filterOverlappingLabels', () => {
     let nodes;
 

--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-size-calculator.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-size-calculator.spec.js
@@ -102,6 +102,7 @@ describe('Axis size calculator', () => {
       settings.dock = 'bottom';
       settings.align = 'bottom';
       settings.labels.show = true;
+      settings.labels.filterOverlapping = false;
     });
 
     it('horizontal discrete axis should be considered to large when labels requires more size then available', () => {

--- a/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
@@ -50,7 +50,13 @@ const DEFAULT_DISCRETE_SETTINGS = {
     align: 0.5,
     /** Offset in pixels along the axis direction.
     * @type {number=} */
-    offset: 0
+    offset: 0,
+    /**
+     * Toggle whether labels should be filtered if they are overlapping. Filtering may be applied in a non-sequential order.
+     * If labels are overlapping and this setting is toggled off, the axis will automatically hide.
+     * @type {boolean=}
+     */
+    filterOverlapping: false
   },
   /**
    * @typedef {object}
@@ -112,7 +118,13 @@ const DEFAULT_CONTINUOUS_SETTINGS = {
     align: 0.5,
     /** Offset in pixels along the axis direction.
     * @type {number=} */
-    offset: 0
+    offset: 0,
+    /**
+     * Toggle whether labels should be filtered if they are overlapping. Filtering may be applied in a non-sequential order.
+     * If labels are overlapping and this setting is toggled off, the axis will automatically hide.
+     * @type {boolean=}
+     */
+    filterOverlapping: true
   },
   /**
    * @typedef {object}

--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -200,7 +200,7 @@ export default function getSize({
       }
     }
 
-    if (isDiscrete && state.labels.activeMode !== 'tilted' && isToLarge({
+    if (!settings.labels.filterOverlapping && state.labels.activeMode !== 'tilted' && isToLarge({
       rect, state, majorTicks, measure, horizontal
     })) {
       const toLargeSize = Math.max(rect.width, rect.height); // used to hide the axis
@@ -256,7 +256,7 @@ export default function getSize({
       const bleedDir = extendLeft ? 'left' : 'right';
       edgeBleed[bleedDir] = bleedSize;
 
-      if (isDiscrete && isTiltedLabelOverlapping({
+      if (!settings.labels.filterOverlapping && isTiltedLabelOverlapping({
         majorTicks, measureText, rect, bleedSize, angle: settings.labels.tiltAngle
       })) {
         return { size: Math.max(rect.width, rect.height), isToLarge: true };

--- a/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
@@ -72,17 +72,29 @@ function layeredLabelBuilder(ticks, buildOpts, settings, tickFn) {
   });
 }
 
-export function filterOverlappingLabels(labels, ticks) {
-  const isOverlapping = (l1, l2) => { // eslint-disable-line arrow-body-style
-    const rect1 = l1.boundingRect;
-    const rect2 = l2.boundingRect;
+export function filterOverlappingLabels(labels, ticks, buildOpts) {
+  let isOverlapping = (i, k) => { // eslint-disable-line arrow-body-style
+    const rect1 = labels[i].boundingRect;
+    const rect2 = labels[k].boundingRect;
 
     return testRectRect(rect1, rect2);
   };
 
+  if (buildOpts && buildOpts.tilted) {
+    const absAngle = Math.abs(buildOpts.angle);
+
+    isOverlapping = (i, k) => {
+      const stepSize = Math.abs(labels[i].x - labels[k].x);
+      const reciprocal = 1 / stepSize;
+      const distanceBetweenLabels = Math.sin(absAngle * (Math.PI / 180)) / reciprocal;
+
+      return labels[i].boundingRect.height > distanceBetweenLabels;
+    };
+  }
+
   for (let i = 0; i <= labels.length - 1; i++) {
     for (let k = i + 1; k <= Math.min(i + 5, i + (labels.length - 1)); k++) { // TODO Find a better way to handle exteme/layered labels then to iterare over ~5 next labels
-      if (labels[i] && labels[k] && isOverlapping(labels[i], labels[k])) {
+      if (labels[i] && labels[k] && isOverlapping(i, k)) {
         if (k === labels.length - 1) { // On collition with last label, remove current label instead
           labels.splice(i, 1);
           if (ticks) { ticks.splice(i, 1); }
@@ -161,11 +173,9 @@ function getStepSizeFn({
 
 export default function nodeBuilder(isDiscrete) {
   let calcMaxTextRectFn;
-  let filterLabels = false;
 
   function continuous() {
     calcMaxTextRectFn = continuousCalcMaxTextRect;
-    filterLabels = true;
     return continuous;
   }
 
@@ -231,8 +241,8 @@ export default function nodeBuilder(isDiscrete) {
       }
 
       // Remove labels (and paired tick) that are overlapping
-      if (filterLabels && !buildOpts.tilted) {
-        filterOverlappingLabels(labelNodes, majorTickNodes);
+      if (settings.labels.filterOverlapping) {
+        filterOverlappingLabels(labelNodes, majorTickNodes, buildOpts);
       }
 
       nodes.push(...labelNodes);

--- a/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
@@ -73,7 +73,7 @@ function layeredLabelBuilder(ticks, buildOpts, settings, tickFn) {
 }
 
 export function filterOverlappingLabels(labels, ticks, buildOpts) {
-  let isOverlapping = (i, k) => { // eslint-disable-line arrow-body-style
+  let isOverlapping = (i, k) => {
     const rect1 = labels[i].boundingRect;
     const rect2 = labels[k].boundingRect;
 


### PR DESCRIPTION
This PR adds the ability configure how the axis should behave when labels are overlapping. The default behavior is the same as before.

To toggle on filter:
```js
{
 // Toggle whether labels should be filtered if they are overlapping. Filtering may be applied in a non-sequential order. If labels are overlapping and this setting is toggled off, the axis will automatically hide
 settings: { labels: { filterOverlapping: true } }
}
```

There are some improvements that could be made on how it behaves in certain scenarios. Especially when the axis direction and labels are horizontal. But that would require a rather major change to the underlying axis code to fix. So it will have to wait for now.