### PR TITLE
feat(debug): add support for components that use the outer area

### DIFF
--- a/packages/picasso.js/src/core/chart-components/debug/debug-collider.js
+++ b/packages/picasso.js/src/core/chart-components/debug/debug-collider.js
@@ -6,7 +6,8 @@ const debugColliderDef = {
       selector: '*',
       fill: 'rgba(0, 255, 0, 0.1)',
       stroke: 'lime',
-      opacity: 1
+      opacity: 1,
+      useOuterRect: false
     }
   },
   on: {
@@ -29,6 +30,12 @@ const debugColliderDef = {
   },
   created() {
     this.props = this.settings.settings;
+  },
+  resize({ outer, inner }) {
+    if (this.props.useOuterRect) {
+      return outer;
+    }
+    return inner;
   },
   render() { },
   mounted() {

--- a/packages/picasso.js/src/core/chart-components/debug/debug-path-to-points.js
+++ b/packages/picasso.js/src/core/chart-components/debug/debug-path-to-points.js
@@ -8,7 +8,8 @@ const debugPathToPointsDef = {
       fill: 'transparent',
       stroke: 'lime',
       opacity: 1,
-      radius: 2
+      radius: 2,
+      useOuterRect: false
     }
   },
   on: {
@@ -41,6 +42,12 @@ const debugPathToPointsDef = {
   },
   created() {
     this.props = this.settings.settings;
+  },
+  resize({ outer, inner }) {
+    if (this.props.useOuterRect) {
+      return outer;
+    }
+    return inner;
   },
   render() { },
   mounted() {


### PR DESCRIPTION
Some components, like the axis for example, use the outer dock area as its container, causing issues when trying to dock on top of the component. This enable one to force the use of the outer dock area via a setting.