### PR TITLE
feat: dock settings as a function

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/axis.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis.js
@@ -114,7 +114,7 @@ const axisComponent = {
 
     this.state.concreteNodeBuilder = nodeBuilder(this.state.isDiscrete);
 
-    this.dockConfig.dock = this.state.settings.dock; // Override the dock setting (TODO should be removed)
+    this.dockConfig.dock(this.state.settings.dock); // Override the dock setting (TODO should be removed)
 
     this.state.isHorizontal = this.state.settings.align === 'top' || this.state.settings.align === 'bottom';
     this.state.labels.activeMode = updateActiveMode(this.state, this.state.settings, this.state.isDiscrete);

--- a/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
@@ -21,7 +21,8 @@ describe('Component', () => {
       container: () => ({}),
       table: () => ({}),
       dataset: () => ({}),
-      scale: sinon.stub()
+      scale: sinon.stub(),
+      logger: () => 'logger'
     };
     created = sinon.spy();
     beforeMount = sinon.spy();

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -269,7 +269,7 @@ function componentFactory(definition, context = {}) {
   const rend = rendString ? renderer || registries.renderer(rendString)() : renderer || registries.renderer()();
   brushArgs.renderer = rend;
 
-  const dockConfigCallbackContext = { resources: { logger: chart.logger() } };
+  const dockConfigCallbackContext = { resources: chart.logger ? { logger: chart.logger() } : {} };
   let dockConfig = createDockConfig(createDockDefinition(settings, preferredSize), dockConfigCallbackContext);
 
   const appendComponentMeta = (node) => {

--- a/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
@@ -23,11 +23,16 @@ describe('Dock Layout', () => {
 
     const dummy = function dummy() {};
 
-    dummy.dockConfig = dockConfig({
-      dock, displayOrder, show, prioOrder
+    dummy.dockConfig = () => dockConfig({
+      dock,
+      displayOrder,
+      show,
+      prioOrder,
+      preferredSize: ({ outer }) => ({ size: outer.width * size, edgeBleed }),
+      minimumLayoutMode
     });
-    dummy.dockConfig.requiredSize((inner, outer) => ({ size: outer.width * size, edgeBleed }));
-    dummy.dockConfig.minimumLayoutMode(minimumLayoutMode);
+    // dummy.dockConfig.computePreferredSize((inner, outer) => ());
+    // dummy.dockConfig.minimumLayoutMode(minimumLayoutMode);
 
     dummy.resize = function resize(...args) {
       if (!args.length) {
@@ -120,20 +125,6 @@ describe('Dock Layout', () => {
     });
     expect(mainComp.resize().innerRect, 'Main innerRect had incorrect calculated size').to.deep.include({
       x: 300, y: 0, width: 700, height: 1000
-    });
-  });
-
-  it('should apply a default configuration if a component have not set one', () => {
-    const rect = {
-      x: 0, y: 0, width: 1000, height: 1000
-    };
-    const mainComp = componentMock();
-    mainComp.dockConfig = undefined;
-    const dl = dockLayout();
-    dl.addComponent(mainComp);
-    dl.layout(rect);
-    expect(mainComp.resize().innerRect, 'Main innerRect had incorrect calculated size').to.deep.include({
-      x: 0, y: 0, width: 1000, height: 1000
     });
   });
 

--- a/packages/picasso.js/src/core/dock-layout/dock-config.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-config.js
@@ -13,12 +13,12 @@
  *  show: true
  * });
  */
-function dockConfig(settings = {}) {
+function dockConfig(settings = {}, instanceContext) {
   let {
     dock = '',
     displayOrder = 0,
     prioOrder = 0,
-    requiredSize = () => 0,
+    preferredSize = 0,
     minimumLayoutMode,
     show = true
   } = settings;
@@ -32,7 +32,7 @@ function dockConfig(settings = {}) {
    * Takes a function that returns the required size of a component.
    * The return value of the function can either be a number representing the required size in the dock direction
    * or an object with a `size` and `edgeBleed` property.
-   * @param {function} [calcFn] - Function to calculate the required size of a component
+   * @param {function} [size] - Function to calculate the required size of a component
    * @returns {function|this} If no parameter is passed, the current requiredSize function is return. Else the current context is returns to allow chaining.
    * @example
    * dockConfig.requireSize(() => 150); // Require a size of 150 in the dock direction
@@ -45,13 +45,7 @@ function dockConfig(settings = {}) {
    *  }
    * })); // Require a size of 150 in the dock direction and a bleed size of 50 to the left and right dock direction
    */
-  fn.requiredSize = function requiredSizeFn(calcFn) {
-    if (typeof calcFn === 'function') {
-      requiredSize = calcFn;
-      return this;
-    }
-    return requiredSize;
-  };
+  fn.computePreferredSize = (inner, outer) => (typeof preferredSize === 'function' ? preferredSize({ inner, outer, dock: fn.dock() }, instanceContext) : preferredSize);
 
   /**
    * Set the dock direction, supported values are left | right | top | bottom. Any other value will be interpreted as center dock.
@@ -60,9 +54,9 @@ function dockConfig(settings = {}) {
    * @example
    * dockConfig.dock('left');
    */
-  fn.dock = function dockFn(d) {
+  fn.dock = (d) => {
     if (typeof d === 'undefined') {
-      return dock;
+      return typeof dock === 'function' ? dock(instanceContext) : dock;
     }
     dock = d;
     return this;
@@ -84,9 +78,9 @@ function dockConfig(settings = {}) {
    * @example
    * dockConfig.displayOrder(99);
    */
-  fn.displayOrder = function displayOrderFn(order) {
+  fn.displayOrder = (order) => {
     if (typeof order === 'undefined') {
-      return displayOrder;
+      return typeof displayOrder === 'function' ? displayOrder(instanceContext) : displayOrder;
     }
     displayOrder = order;
     return this;
@@ -102,9 +96,9 @@ function dockConfig(settings = {}) {
    * @example
    * dockConfig.prioOrder(-1);
    */
-  fn.prioOrder = function prioOrderFn(order) {
+  fn.prioOrder = (order) => {
     if (typeof order === 'undefined') {
-      return prioOrder;
+      return typeof prioOrder === 'function' ? prioOrder(instanceContext) : prioOrder;
     }
     prioOrder = order;
     return this;
@@ -118,9 +112,9 @@ function dockConfig(settings = {}) {
    * dockConfig.minimumLayoutMode('L');
    * dockConfig.minimumLayoutMode({ width: 'S', height: 'L' });
    */
-  fn.minimumLayoutMode = function minimumLayoutModeFn(s) {
+  fn.minimumLayoutMode = (s) => {
     if (typeof s === 'undefined') {
-      return minimumLayoutMode;
+      return typeof minimumLayoutMode === 'function' ? minimumLayoutMode(instanceContext) : minimumLayoutMode;
     }
     minimumLayoutMode = s;
     return this;
@@ -133,9 +127,9 @@ function dockConfig(settings = {}) {
    */
   fn.show = function showFn(s) {
     if (typeof s === 'undefined') {
-      return show;
+      return typeof show === 'function' ? show(instanceContext) : show;
     }
-    show = !!s;
+    show = s;
     return this;
   };
 

--- a/packages/picasso.js/src/core/dock-layout/dock-config.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-config.js
@@ -8,12 +8,12 @@
  *  dock: 'left',
  *  displayOrder: 2,
  *  prioOrder: 1,
- *  requiredSize: () => 33,
+ *  preferredSize: 33,
  *  minimumLayoutMode: 'L',
  *  show: true
  * });
  */
-function dockConfig(settings = {}, instanceContext) {
+function dockConfig(settings = {}, callbackContext = {}) {
   let {
     dock = '',
     displayOrder = 0,
@@ -29,15 +29,16 @@ function dockConfig(settings = {}, instanceContext) {
   const fn = function fn() {};
 
   /**
-   * Takes a function that returns the required size of a component.
+   * Returns the preferred size of a component.
    * The return value of the function can either be a number representing the required size in the dock direction
    * or an object with a `size` and `edgeBleed` property.
-   * @param {function} [size] - Function to calculate the required size of a component
-   * @returns {function|this} If no parameter is passed, the current requiredSize function is return. Else the current context is returns to allow chaining.
+   * @param {object} [inner]
+   * @param {object} [outer]
+   * @returns {number|object} Returns the computed preferred size
    * @example
-   * dockConfig.requireSize(() => 150); // Require a size of 150 in the dock direction
+   * dockConfig.computePreferredSize(() => 150); // Require a size of 150 in the dock direction
    *
-   * dockConfig.requireSize(() => ({
+   * dockConfig.computePreferredSize(() => ({
    *  size: 150,
    *  edgeBleed: {
    *    left: 50,
@@ -45,21 +46,26 @@ function dockConfig(settings = {}, instanceContext) {
    *  }
    * })); // Require a size of 150 in the dock direction and a bleed size of 50 to the left and right dock direction
    */
-  fn.computePreferredSize = (inner, outer) => (typeof preferredSize === 'function' ? preferredSize({ inner, outer, dock: fn.dock() }, instanceContext) : preferredSize);
+  fn.computePreferredSize = (inner, outer) => {
+    if (typeof preferredSize === 'function') {
+      return preferredSize({ inner, outer, dock: fn.dock() }, callbackContext);
+    }
+    return preferredSize;
+  };
 
   /**
    * Set the dock direction, supported values are left | right | top | bottom. Any other value will be interpreted as center dock.
-   * @param {string} [d=''] - Dock direction
+   * @param {string} [val=''] - Dock direction
    * @returns {this} The current context
    * @example
    * dockConfig.dock('left');
    */
-  fn.dock = (d) => {
-    if (typeof d === 'undefined') {
-      return typeof dock === 'function' ? dock(instanceContext) : dock;
+  fn.dock = (val) => {
+    if (typeof val !== 'undefined') {
+      dock = val;
+      return fn;
     }
-    dock = d;
-    return this;
+    return typeof dock === 'function' ? dock(callbackContext) : dock;
   };
 
   /**
@@ -73,17 +79,17 @@ function dockConfig(settings = {}, instanceContext) {
    * A lower `displayOrder` also means that a component will be laid out first in a given direction,
    * i.e. laid out closer to the central area (non-directional area) then a component with a higher `displayOrder`.
    * It can in this case be seen as the x-index or y-index.
-   * @param {number} [order=0] - The display order
-   * @returns {this} The current context
+   * @param {number} [val=0] - The display order
+   * @returns {this|number} The current context or display order
    * @example
    * dockConfig.displayOrder(99);
    */
-  fn.displayOrder = (order) => {
-    if (typeof order === 'undefined') {
-      return typeof displayOrder === 'function' ? displayOrder(instanceContext) : displayOrder;
+  fn.displayOrder = (val) => {
+    if (typeof val !== 'undefined') {
+      displayOrder = val;
+      return this;
     }
-    displayOrder = order;
-    return this;
+    return typeof displayOrder === 'function' ? displayOrder(callbackContext) : displayOrder;
   };
 
   /**
@@ -91,46 +97,46 @@ function dockConfig(settings = {}, instanceContext) {
    * this is done before any components are laid out. When there is not enough space to add any more components
    * to a given area, all components not all ready added, are then discarded. The `prioOrder` is interpreted
    * in the ascending order. Such that a lower value is added to the layout engine first.
-   * @param {number} [order=0] - The prio order
-   * @returns {this} The current context
+   * @param {number} [val=0] - The prio order
+   * @returns {this|number} The current context or prio order
    * @example
    * dockConfig.prioOrder(-1);
    */
-  fn.prioOrder = (order) => {
-    if (typeof order === 'undefined') {
-      return typeof prioOrder === 'function' ? prioOrder(instanceContext) : prioOrder;
+  fn.prioOrder = (val) => {
+    if (typeof val !== 'undefined') {
+      prioOrder = val;
+      return this;
     }
-    prioOrder = order;
-    return this;
+    return typeof prioOrder === 'function' ? prioOrder(callbackContext) : prioOrder;
   };
 
   /**
    * Ger or set the minimumLayoutMode
-   * @param {string|object} [s] - The minimum layout mode
+   * @param {string|object} [val] - The minimum layout mode
    * @returns {string|object|this} If no parameter is passed the current context is returned, else the current layout mode.
    * @example
    * dockConfig.minimumLayoutMode('L');
    * dockConfig.minimumLayoutMode({ width: 'S', height: 'L' });
    */
-  fn.minimumLayoutMode = (s) => {
-    if (typeof s === 'undefined') {
-      return typeof minimumLayoutMode === 'function' ? minimumLayoutMode(instanceContext) : minimumLayoutMode;
+  fn.minimumLayoutMode = (val) => {
+    if (typeof val !== 'undefined') {
+      minimumLayoutMode = val;
+      return this;
     }
-    minimumLayoutMode = s;
-    return this;
+    return typeof minimumLayoutMode === 'function' ? minimumLayoutMode(callbackContext) : minimumLayoutMode;
   };
 
   /**
    * Set the component visibility. If false the component is not added to the layout engine.
-   * @param {boolean} [s=true] - Toggle visibility
-   * @returns {this} The current context
+   * @param {boolean} [val=true] - Toggle visibility
+   * @returns {this|boolean} The current context or show
    */
-  fn.show = function showFn(s) {
-    if (typeof s === 'undefined') {
-      return typeof show === 'function' ? show(instanceContext) : show;
+  fn.show = (val) => {
+    if (typeof val !== 'undefined') {
+      show = val;
+      return this;
     }
-    show = s;
-    return this;
+    return typeof show === 'function' ? show(callbackContext) : show;
   };
 
   return fn;

--- a/packages/picasso.js/src/core/dock-layout/dock-layout.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-layout.js
@@ -15,7 +15,8 @@ function validateComponent(component) {
 
 function cacheSize(c, reducedRect, containerRect) {
   if (typeof c.cachedSize === 'undefined') {
-    const size = c.config.requiredSize()(reducedRect, containerRect);
+    // TODO Breaking change, user defined prefSize will get a different callback context
+    const size = c.config.computePreferredSize(reducedRect, containerRect);
     if (typeof size === 'object') {
       c.cachedSize = Math.ceil(size.size);
       c.edgeBleed = size.edgeBleed;
@@ -309,14 +310,10 @@ export default function dockLayout(initialSettings) {
     validateComponent(component);
     docker.removeComponent(component);
 
-    // component.dockConfig can be undefined, a function or an object:
-    // if undefined: use default values from dockConfig()
-    // if function: use the function
-    // if object: wrap in dockConfig() function
     components.push({
       instance: component,
       key,
-      config: typeof component.dockConfig === 'function' ? component.dockConfig : dockConfig(component.dockConfig)
+      config: component.dockConfig()
     });
   };
 

--- a/packages/picasso.js/src/core/dock-layout/dock-layout.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-layout.js
@@ -1,5 +1,4 @@
 import extend from 'extend';
-import dockConfig from './dock-config';
 import resolveLayout, { resolveSettings } from './dock-settings-resolver';
 import { rectToPoints, pointsToRect } from '../geometry/util';
 
@@ -15,7 +14,6 @@ function validateComponent(component) {
 
 function cacheSize(c, reducedRect, containerRect) {
   if (typeof c.cachedSize === 'undefined') {
-    // TODO Breaking change, user defined prefSize will get a different callback context
     const size = c.config.computePreferredSize(reducedRect, containerRect);
     if (typeof size === 'object') {
       c.cachedSize = Math.ceil(size.size);

--- a/packages/picasso.js/test/helpers/component-factory-fixture.js
+++ b/packages/picasso.js/test/helpers/component-factory-fixture.js
@@ -119,7 +119,7 @@ export default function componentFactoryFixture() {
     return rendererOutput;
   };
 
-  fn.simulateLayout = opts => comp.dockConfig.requiredSize(opts.inner, opts.outer);
+  fn.simulateLayout = opts => comp.dockConfig().computePreferredSize(opts.inner, opts.outer);
 
   fn.getRenderOutput = () => rendererOutput;
 


### PR DESCRIPTION
* It's now possible to set dock related settings as a function, this includes `dock`, `displayOrder`, `prioOrder`, `show`, `minimumLayoutMode`.
* `preferredSize` can now be set as a function or a number. Both as a user defined setting and as component defined setting.
```js
// As a user defined settings
{ type: '<some-component-type>', preferredSize: 123 }

// As a component definition
{ created() {}, render() {}, preferredSize: 123 }
```
* In a component definition - `require['dockConfig']` will return the dockConfig instance, such that all properties are called as function and the return result is the evaluated outcome. Previously this returned the user defined setting.
```js
this.dockConfig.dock() // Is always called as a function and will return the evaluated dock direction. This is the preferred method to get dock settings. This will also return the default value if no setting was defined by the user or component definition.

this.settings.dock // Will return the user defined dock setting, which may or may not be a function.
```
* Fetching a component instance, ex. via `chartInstance.component('<some-key>')` will still return the user definition for dock related properties.
