### PR TITLE
fix(dock-layout): remove components that are docked at hidden components

### DIFF
--- a/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
@@ -168,6 +168,36 @@ describe('Dock Layout', () => {
     });
   });
 
+  it('should remove component that are docked to another component which does not fit', () => {
+    const leftComp = componentMock({ dock: 'left', size: 0.30 });
+    const leftComp2 = componentMock({ dock: 'left', size: 0.30, key: 'notFit' });
+    const leftComp3 = componentMock({ dock: 'left', size: 0.30, instance: { ctx: { dock: '@notFit' } } });
+    const mainComp = componentMock();
+    const rect = {
+      x: 0, y: 0, width: 1000, height: 1000
+    };
+    const dl = dockLayout();
+    dl.addComponent(leftComp);
+    dl.addComponent(leftComp2);
+    dl.addComponent(leftComp3);
+    dl.addComponent(mainComp);
+
+    dl.layout(rect);
+
+    expect(leftComp.resize().innerRect, 'leftComp innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 300, height: 1000
+    });
+    expect(leftComp2.resize().innerRect, 'leftComp2 innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 0, height: 0
+    });
+    expect(leftComp3.resize().innerRect, 'leftComp3 innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 0, height: 0
+    });
+    expect(mainComp.resize().innerRect, 'Main innerRect had incorrect calculated size').to.deep.include({
+      x: 300, y: 0, width: 700, height: 1000
+    });
+  });
+
   describe('Settings', () => {
     let settings;
     let container;

--- a/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/dock-layout/__tests__/dock-layout.spec.js
@@ -9,7 +9,8 @@ describe('Dock Layout', () => {
     prioOrder = 0,
     edgeBleed = {},
     minimumLayoutMode,
-    show = true
+    show = true,
+    ctx = {}
   } = {}) {
     let outerRect = {
       x: 0, y: 0, width: 0, height: 0
@@ -41,6 +42,8 @@ describe('Dock Layout', () => {
       [innerRect, outerRect, containerRect] = args;
       return this;
     };
+
+    dummy.ctx = ctx;
 
     return dummy;
   };
@@ -170,8 +173,8 @@ describe('Dock Layout', () => {
 
   it('should remove component that are docked to another component which does not fit', () => {
     const leftComp = componentMock({ dock: 'left', size: 0.30 });
-    const leftComp2 = componentMock({ dock: 'left', size: 0.30, key: 'notFit' });
-    const leftComp3 = componentMock({ dock: 'left', size: 0.30, instance: { ctx: { dock: '@notFit' } } });
+    const leftComp2 = componentMock({ dock: 'left', size: 0.30, ctx: { key: 'notFit' } });
+    const leftComp3 = componentMock({ dock: '@notFit', size: 0.30 });
     const mainComp = componentMock();
     const rect = {
       x: 0, y: 0, width: 1000, height: 1000
@@ -192,6 +195,37 @@ describe('Dock Layout', () => {
     });
     expect(leftComp3.resize().innerRect, 'leftComp3 innerRect had incorrect calculated size').to.deep.include({
       x: 0, y: 0, width: 0, height: 0
+    });
+    expect(mainComp.resize().innerRect, 'Main innerRect had incorrect calculated size').to.deep.include({
+      x: 300, y: 0, width: 700, height: 1000
+    });
+  });
+
+  it('should keep component because one of the referenced components are shown', () => {
+    const leftComp = componentMock({ dock: 'left', size: 0.30, ctx: { key: 'fit' } });
+    const leftComp2 = componentMock({ dock: 'left', size: 0.30, ctx: { key: 'notFit' } });
+    const leftComp3 = componentMock({ dock: '@fit, @notFit', size: 0.30 });
+    const mainComp = componentMock();
+    const rect = {
+      x: 0, y: 0, width: 1000, height: 1000
+    };
+    const dl = dockLayout();
+    dl.addComponent(leftComp, 'fit');
+    dl.addComponent(leftComp2);
+    dl.addComponent(leftComp3);
+    dl.addComponent(mainComp);
+
+    dl.layout(rect);
+
+    // leftComp3 should be docked on top of leftComp
+    expect(leftComp.resize().innerRect, 'leftComp innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 300, height: 1000
+    });
+    expect(leftComp2.resize().innerRect, 'leftComp2 innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 0, height: 0
+    });
+    expect(leftComp3.resize().innerRect, 'leftComp3 innerRect had incorrect calculated size').to.deep.include({
+      x: 0, y: 0, width: 300, height: 1000
     });
     expect(mainComp.resize().innerRect, 'Main innerRect had incorrect calculated size').to.deep.include({
       x: 300, y: 0, width: 700, height: 1000

--- a/packages/picasso.js/src/core/dock-layout/dock-layout.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-layout.js
@@ -224,13 +224,11 @@ function positionComponents(components, logicalContainerRect, reducedRect, conta
   const referencedComponents = {};
   const referenceArray = components.slice();
   components.sort((a, b) => {
-    if (a.referencedDocks.length > 0 || b.referencedDocks.length > 0) {
-      if (/^@/.test(b.config.dock())) {
-        return -1;
-      }
-      if (/^@/.test(a.config.dock())) {
-        return 1;
-      }
+    if (b.referencedDocks.length > 0) {
+      return -1;
+    }
+    if (a.referencedDocks.length > 0) {
+      return 1;
     }
     const diff = a.config.displayOrder() - b.config.displayOrder();
     if (diff === 0) {
@@ -361,19 +359,13 @@ export default function dockLayout(initialSettings) {
     validateComponent(component);
     docker.removeComponent(component);
 
-    function getReferencedDocks(dock) {
-      if (!/^@/.test(dock)) {
-        return [];
-      }
-
-      return dock.split(',').map(s => s.replace(/^\s*@/, ''));
-    }
+    const dock = component.dockConfig().dock();
 
     components.push({
       instance: component,
       key,
       config: component.dockConfig(),
-      referencedDocks: getReferencedDocks(component.dockConfig().dock())
+      referencedDocks: /^@/.test(dock) ? dock.split(',').map(s => s.replace(/^\s*@/, '')) : []
     });
   };
 


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

Updates the visible and hidden components based on components that are docked to other components.
 For example, assume a component called myRect:
 {
  key: 'myRect',
   type: 'rect',
   dock: 'bottom'
 }
  and a component called myLine:
 {
  key: 'myLine',
  type: 'line',
 dock: '@myRect'
 }
 if the layout engine decides to hide myRect, then myLine should be hidden as well.