### PR TITLE
fix(box): min/maxWidthPx doesnt work when scale is inverted

### DIFF
--- a/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
+++ b/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
@@ -356,10 +356,24 @@ describe('box shapes', () => {
       expect(w).to.equal(0.1);
     });
 
+    it('negative bandwidth - width is less than min width', () => {
+      bandwidth = -0.1;
+      item.box.minWidthPx = 0.1 * avaialbleWidth;
+      const w = getBoxWidth(bandwidth, item, avaialbleWidth);
+      expect(w).to.equal(-0.1);
+    });
+
     it('width is larger than max width', () => {
       item.box.maxWidthPx = 0.01 * avaialbleWidth;
       const w = getBoxWidth(bandwidth, item, avaialbleWidth);
       expect(w).to.equal(0.01);
+    });
+
+    it('negative bandwidth - width is larger than max width', () => {
+      bandwidth = -0.1;
+      item.box.maxWidthPx = 0.01 * avaialbleWidth;
+      const w = getBoxWidth(bandwidth, item, avaialbleWidth);
+      expect(w).to.equal(-0.01);
     });
   });
 });

--- a/packages/picasso.js/src/core/chart-components/box/box-shapes.js
+++ b/packages/picasso.js/src/core/chart-components/box/box-shapes.js
@@ -189,8 +189,10 @@ export function horizontalLine({
  * @ignore
  */
 export function getBoxWidth(bandwidth, item, maxMajorWidth) {
-  const boxWidth = Math.min(bandwidth * item.box.width, isNaN(item.box.maxWidthPx) ? maxMajorWidth : item.box.maxWidthPx / maxMajorWidth);
-  return isNaN(item.box.minWidthPx) ? boxWidth : Math.max(item.box.minWidthPx / maxMajorWidth, boxWidth);
+  const sign = bandwidth >= 0 ? 1 : -1;
+  let boxWidth = Math.min(sign * bandwidth * item.box.width, isNaN(item.box.maxWidthPx) ? maxMajorWidth : item.box.maxWidthPx / maxMajorWidth);
+  boxWidth = isNaN(item.box.minWidthPx) ? boxWidth : Math.max(item.box.minWidthPx / maxMajorWidth, boxWidth);
+  return boxWidth * sign;
 }
 
 export function buildShapes({


### PR DESCRIPTION
Fixes an issue where `minWidthPx` and `maxWidthPx` settings didn't work when the major scale was inverted.