### PR TITLE
feat(brush-area-dir): add support for multiple fill targets

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "license": "MIT"
   },
   "entries": {
@@ -5030,9 +5030,17 @@
           "kind": "object",
           "entries": {
             "component": {
-              "description": "Render matching overlay on target component",
+              "description": "Render matching overlay on target component. @deprecated Use `components` instead",
               "optional": true,
               "type": "string"
+            },
+            "components": {
+              "description": "Render matching overlay on target components",
+              "optional": true,
+              "kind": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/docs/src/input/component-brush-area-dir.md
+++ b/docs/src/input/component-brush-area-dir.md
@@ -17,7 +17,7 @@ A `target` is configured in the `target` property:
 ```js
 settings: {
   target: {
-    component: 'my-target-component'
+    components: ['my-target-component']
   }
 }
 ```
@@ -103,7 +103,7 @@ components: [
       },
     },
     target: {
-      component: 'target-this-component'
+      components: ['target-this-component']
     }
   },
   ...


### PR DESCRIPTION
Adds support for multiple fill targets:

```js
{
  target: {
    components: ['a', 'b']
  }
}
```