### PR TITLE
fix(q): add first or default check for empty qDataPages in extractor-t

### DIFF
--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -227,7 +227,7 @@ const getHierarchy = (cube, cache, config) => {
 };
 
 function getHierarchyForSMode(dataset) {
-  const matrix = dataset.raw().qDataPages[0].qMatrix;
+  const matrix = dataset.raw().qDataPages.length ? dataset.raw().qDataPages[0].qMatrix : [];
   const order = getColumnOrder(dataset);
   const fields = dataset.fields();
   const dimensions = dataset.fields().filter(f => f.type() === 'dimension')


### PR DESCRIPTION
When qDataPages was empty an exception was thrown. This handles that case a by adding a first or default check.