### PR TITLE
perf: lazy evaluation of scales and formatters

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.17.0",
+    "version": "0.18.2",
     "license": "MIT"
   },
   "entries": {
@@ -1047,27 +1047,35 @@
           }
         },
         "scales": {
-          "description": "Get the all registered scales",
+          "description": "Get all registered scales",
           "kind": "function",
           "params": [],
           "returns": {
-            "description": "Array of scales",
-            "kind": "array",
-            "items": {
-              "type": "scale"
-            }
+            "type": "Object",
+            "generics": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "scale"
+              }
+            ]
           }
         },
         "formatters": {
-          "description": "Get the all registered formatters",
+          "description": "Get all registered formatters",
           "kind": "function",
           "params": [],
           "returns": {
-            "description": "Array of formatters",
-            "kind": "array",
-            "items": {
-              "type": "formatter"
-            }
+            "type": "Object",
+            "generics": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "formatter"
+              }
+            ]
           }
         },
         "brush": {

--- a/packages/picasso.js/src/core/chart/formatter/__tests__/formatter.spec.js
+++ b/packages/picasso.js/src/core/chart/formatter/__tests__/formatter.spec.js
@@ -1,65 +1,117 @@
-import { create } from '..';
+import {
+  create,
+  collection
+} from '..';
 
 describe('chart formatters', () => {
-  let deps;
-  let formatterFn;
-  beforeEach(() => {
-    deps = {
-      formatter: {
-        has: sinon.stub(),
-        get: sinon.stub()
-      }
-    };
-    formatterFn = pattern => (value => `${pattern}${value}`);
-  });
-
-  it('should throw when type is not registered', () => {
-    const fn = () => create({
-      type: 'dummy'
-    }, null, deps);
-    expect(fn).to.throw('Formatter of type \'dummy\' was not found');
-  });
-
-  it('should create a formatter of a custom type', () => {
-    deps.formatter.has.withArgs('custom').returns(true);
-    deps.formatter.get.returns(formatterFn);
-    const s = create({
-      type: 'custom',
-      format: '$'
-    }, null, deps);
-    expect(s(45)).to.equal('$45');
-  });
-
-  it('should create a formatter of a specific subtype', () => {
-    deps.formatter.has.withArgs('custom-time').returns(true);
-    deps.formatter.get.returns(formatterFn);
-    const s = create({
-      formatter: 'custom',
-      type: 'time',
-      format: '$'
-    }, null, deps);
-    expect(s(45)).to.equal('$45');
-  });
-
-  it('should create a number subtype by default', () => {
-    deps.formatter.has.withArgs('custom-number').returns(true);
-    deps.formatter.get.returns(formatterFn);
-    const s = create({
-      formatter: 'custom',
-      format: '$'
-    }, null, deps);
-    expect(s(45)).to.equal('$45');
-  });
-
-  it('should return formatter from field', () => {
-    const extractor = () => ({
-      fields: [{
-        formatter: () => (value => `${value} %%% `)
-      }]
+  describe('collection', () => {
+    let fn;
+    beforeEach(() => {
+      fn = sinon.spy(def => (typeof def === 'object' && !Object.keys(def).length ? 'fallback' : def));
     });
-    const s = create({
-      data: {}
-    }, null, deps, extractor);
-    expect(s(45)).to.equal('45 %%% ');
+
+    it('should return fallback formatter when unknown config is used', () => {
+      const s = collection({}, null, null, fn).get({});
+      expect(s).to.equal('fallback');
+    });
+
+    it('should return formatter from config', () => {
+      const s = collection({ time: 'tick tock' }, null, null, fn).get('time');
+      expect(s).to.equal('tick tock');
+    });
+
+    it('should return named formatter from config', () => {
+      const s = collection({ time: 'tick tock' }, null, null, fn).get({ formatter: 'time' });
+      expect(s).to.equal('tick tock');
+    });
+
+    it('should return named type from config', () => {
+      const s = collection({ time: 'tick tock' }, null, null, fn).get({ type: 'time' });
+      expect(s).to.equal('tick tock');
+    });
+
+    it('should maintain cache of created formatters', () => {
+      const c = collection({ time: 'tick tock' }, null, null, fn);
+      c.get('time');
+      c.get('time');
+      expect(fn.callCount).to.equal(1);
+    });
+
+    it('should create formatter on the fly', () => {
+      const s = collection({}, null, null, fn).get({ data: 'd' });
+      expect(s).to.eql({ data: 'd' });
+    });
+
+    it('should return all formatters', () => {
+      const s = collection({ time: 'tick tock', p: '%' }, null, null, fn);
+      expect(s.all()).to.eql({
+        time: 'tick tock',
+        p: '%'
+      });
+    });
+  });
+
+  describe('create', () => {
+    let deps;
+    let formatterFn;
+    beforeEach(() => {
+      deps = {
+        formatter: {
+          has: sinon.stub(),
+          get: sinon.stub()
+        }
+      };
+      formatterFn = pattern => (value => `${pattern}${value}`);
+    });
+
+    it('should throw when type is not registered', () => {
+      const fn = () => create({
+        type: 'dummy'
+      }, null, deps);
+      expect(fn).to.throw('Formatter of type \'dummy\' was not found');
+    });
+
+    it('should create a formatter of a custom type', () => {
+      deps.formatter.has.withArgs('custom').returns(true);
+      deps.formatter.get.returns(formatterFn);
+      const s = create({
+        type: 'custom',
+        format: '$'
+      }, null, deps);
+      expect(s(45)).to.equal('$45');
+    });
+
+    it('should create a formatter of a specific subtype', () => {
+      deps.formatter.has.withArgs('custom-time').returns(true);
+      deps.formatter.get.returns(formatterFn);
+      const s = create({
+        formatter: 'custom',
+        type: 'time',
+        format: '$'
+      }, null, deps);
+      expect(s(45)).to.equal('$45');
+    });
+
+    it('should create a number subtype by default', () => {
+      deps.formatter.has.withArgs('custom-number').returns(true);
+      deps.formatter.get.returns(formatterFn);
+      const s = create({
+        formatter: 'custom',
+        format: '$'
+      }, null, deps);
+      expect(s(45)).to.equal('$45');
+    });
+
+    it('should return formatter from field', () => {
+      const extractor = () => ({
+        fields: [{
+          formatter: () => (value => `${value} %%% `)
+        }]
+      });
+      const s = create({
+        data: {}
+      }, null, deps, extractor);
+      expect(s(45)).to.equal('45 %%% ');
+    });
   });
 });

--- a/packages/picasso.js/src/core/chart/scales/__tests__/scales.spec.js
+++ b/packages/picasso.js/src/core/chart/scales/__tests__/scales.spec.js
@@ -1,148 +1,196 @@
-import { create } from '..';
+import {
+  create,
+  collection
+} from '..';
 
 describe('scales', () => {
-  let deps;
-  let scaleFn;
-  beforeEach(() => {
-    deps = {
-      scale: {
-        has: sinon.stub(),
-        get: sinon.stub()
-      }
-    };
-    scaleFn = () => ({
-      min: () => 0,
-      max: () => 1
+  describe('collection', () => {
+    let fn;
+    beforeEach(() => {
+      fn = sinon.spy(def => (typeof def === 'object' && !Object.keys(def).length ? 'fallback' : def));
+    });
+
+    it('should return fallback scale when unknown config is used', () => {
+      const s = collection({}, null, null, fn).get({});
+      expect(s).to.equal('fallback');
+    });
+
+    it('should return scale from config', () => {
+      const s = collection({ x: 'foo' }, null, null, fn).get('x');
+      expect(s).to.equal('foo');
+    });
+
+    it('should return named scale from config', () => {
+      const s = collection({ x: 'foo' }, null, null, fn).get({ scale: 'x' });
+      expect(s).to.equal('foo');
+    });
+
+    it('should maintain cache of create scales', () => {
+      const c = collection({ x: 'foo' }, null, null, fn);
+      c.get('x');
+      c.get('x');
+      expect(fn.callCount).to.equal(1);
+    });
+
+    it('should create scale on the fly', () => {
+      const s = collection({}, null, null, fn).get({ data: 'd' });
+      expect(s).to.eql({ data: 'd' });
+    });
+
+    it('should return all scales', () => {
+      const s = collection({ x: 'foo', y: 'measure' }, null, null, fn);
+      expect(s.all()).to.eql({
+        x: 'foo',
+        y: 'measure'
+      });
     });
   });
-  it('should not throw when source options is not provided', () => {
-    const fn = () => create({}, null, deps);
-    expect(fn).to.not.throw();
-  });
 
-  it('should create a scale of a specific type', () => {
-    deps.scale.has.withArgs('custom').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const s = create({
-      type: 'custom'
-    }, null, deps);
-    expect(s.type).to.equal('custom');
-  });
-
-  it('should create linear scale when no better type fits', () => {
-    deps.scale.has.withArgs('linear').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const s = create({}, null, deps);
-    expect(s.type).to.equal('linear');
-    expect(s.min()).to.equal(0);
-    expect(s.max()).to.equal(1);
-  });
-
-  it('should create linear scale when source fields are measures', () => {
-    deps.scale.has.withArgs('linear').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const dataset = {
-      field: sinon.stub()
-    };
-    const datasetFn = () => dataset;
-
-    dataset.field.withArgs('m1').returns({
-      type: () => 'measure',
-      min: () => 0,
-      max: () => 1
+  describe('create', () => {
+    let deps;
+    let scaleFn;
+    beforeEach(() => {
+      deps = {
+        scale: {
+          has: sinon.stub(),
+          get: sinon.stub()
+        }
+      };
+      scaleFn = () => ({
+        min: () => 0,
+        max: () => 1
+      });
     });
-    dataset.field.withArgs('m2').returns({
-      type: () => 'measure',
-      min: () => 0,
-      max: () => 1
+
+    it('should not throw when source options is not provided', () => {
+      const fn = () => create({}, null, deps);
+      expect(fn).to.not.throw();
     });
-    const s = create({
-      data: {
-        fields: ['m1', 'm2']
-      }
-    }, datasetFn, deps);
-    expect(s.type).to.equal('linear');
-  });
 
-  it('should create sequential color scale when source fields are measures and type is color', () => {
-    deps.scale.has.withArgs('sequential-color').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const dataset = {
-      field: sinon.stub()
-    };
-    const datasetFn = () => dataset;
-
-    dataset.field.withArgs('m1').returns({
-      type: () => 'measure',
-      min: () => 0,
-      max: () => 1
+    it('should create a scale of a specific type', () => {
+      deps.scale.has.withArgs('custom').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const s = create({
+        type: 'custom'
+      }, null, deps);
+      expect(s.type).to.equal('custom');
     });
-    const s = create({
-      type: 'color',
-      data: {
-        fields: ['m1']
-      }
-    }, datasetFn, deps);
-    expect(s.type).to.equal('sequential-color');
-  });
 
-  it('should create band scale when source fields are dimensions', () => {
-    deps.scale.has.withArgs('band').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const dataset = {
-      field: sinon.stub()
-    };
-    const datasetFn = () => dataset;
-
-    dataset.field.withArgs('d1').returns({
-      type: () => 'dimension',
-      values: () => [],
-      min: () => 2015,
-      max: () => 2017
+    it('should create linear scale when no better type fits', () => {
+      deps.scale.has.withArgs('linear').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const s = create({}, null, deps);
+      expect(s.type).to.equal('linear');
+      expect(s.min()).to.equal(0);
+      expect(s.max()).to.equal(1);
     });
-    const s = create({
-      data: {
-        fields: ['d1']
-      }
-    }, { dataset: datasetFn }, deps);
-    expect(s.type).to.equal('band');
-  });
 
-  it('should create categorical-color scale when source fields are dimensions and type is color', () => {
-    deps.scale.has.withArgs('categorical-color').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const dataset = {
-      field: sinon.stub()
-    };
-    const datasetFn = () => dataset;
+    it('should create linear scale when source fields are measures', () => {
+      deps.scale.has.withArgs('linear').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const dataset = {
+        field: sinon.stub()
+      };
+      const datasetFn = () => dataset;
 
-    dataset.field.withArgs('d1').returns({
-      type: () => 'dimension',
-      values: () => [],
-      min: () => 2015,
-      max: () => 2017
+      dataset.field.withArgs('m1').returns({
+        type: () => 'measure',
+        min: () => 0,
+        max: () => 1
+      });
+      dataset.field.withArgs('m2').returns({
+        type: () => 'measure',
+        min: () => 0,
+        max: () => 1
+      });
+      const s = create({
+        data: {
+          fields: ['m1', 'm2']
+        }
+      }, datasetFn, deps);
+      expect(s.type).to.equal('linear');
     });
-    const s = create({
-      type: 'color',
-      data: {
-        fields: ['d1']
-      }
-    }, { dataset: datasetFn }, deps);
-    expect(s.type).to.equal('categorical-color');
-  });
 
-  it('should create h-band scale when data is hierarchical', () => {
-    deps.scale.has.withArgs('h-band').returns(true);
-    deps.scale.get.returns(scaleFn);
-    const dataset = {
-      hierarchy: sinon.stub().returns({}),
-      fields: () => []
-    };
-    const datasetFn = () => dataset;
-    const s = create({
-      data: { hierarchy: {} }
-    }, { dataset: datasetFn }, deps);
+    it('should create sequential color scale when source fields are measures and type is color', () => {
+      deps.scale.has.withArgs('sequential-color').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const dataset = {
+        field: sinon.stub()
+      };
+      const datasetFn = () => dataset;
 
-    expect(s.type).to.equal('h-band');
+      dataset.field.withArgs('m1').returns({
+        type: () => 'measure',
+        min: () => 0,
+        max: () => 1
+      });
+      const s = create({
+        type: 'color',
+        data: {
+          fields: ['m1']
+        }
+      }, datasetFn, deps);
+      expect(s.type).to.equal('sequential-color');
+    });
+
+    it('should create band scale when source fields are dimensions', () => {
+      deps.scale.has.withArgs('band').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const dataset = {
+        field: sinon.stub()
+      };
+      const datasetFn = () => dataset;
+
+      dataset.field.withArgs('d1').returns({
+        type: () => 'dimension',
+        values: () => [],
+        min: () => 2015,
+        max: () => 2017
+      });
+      const s = create({
+        data: {
+          fields: ['d1']
+        }
+      }, { dataset: datasetFn }, deps);
+      expect(s.type).to.equal('band');
+    });
+
+    it('should create categorical-color scale when source fields are dimensions and type is color', () => {
+      deps.scale.has.withArgs('categorical-color').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const dataset = {
+        field: sinon.stub()
+      };
+      const datasetFn = () => dataset;
+
+      dataset.field.withArgs('d1').returns({
+        type: () => 'dimension',
+        values: () => [],
+        min: () => 2015,
+        max: () => 2017
+      });
+      const s = create({
+        type: 'color',
+        data: {
+          fields: ['d1']
+        }
+      }, { dataset: datasetFn }, deps);
+      expect(s.type).to.equal('categorical-color');
+    });
+
+    it('should create h-band scale when data is hierarchical', () => {
+      deps.scale.has.withArgs('h-band').returns(true);
+      deps.scale.get.returns(scaleFn);
+      const dataset = {
+        hierarchy: sinon.stub().returns({}),
+        fields: () => []
+      };
+      const datasetFn = () => dataset;
+      const s = create({
+        data: { hierarchy: {} }
+      }, { dataset: datasetFn }, deps);
+
+      expect(s.type).to.equal('h-band');
+    });
   });
 });

--- a/packages/picasso.js/src/core/chart/scales/index.js
+++ b/packages/picasso.js/src/core/chart/scales/index.js
@@ -68,23 +68,28 @@ export function create(options, d, deps) {
   return s;
 }
 
-export function getOrCreateScale(v, scales, d, deps) {
-  let s;
-  if (typeof v === 'string' && scales[v]) { // return by name
-    s = scales[v];
-  } else if (typeof v === 'object' && 'scale' in v && scales[v.scale]) { // return by { scale: "name" }
-    s = scales[v.scale];
-  }
-
-  return s || create(v, d, deps);
-}
-
-export function builder(obj, d, deps) {
+export function collection(scalesConfig, data, deps, fn = create) {
   const scales = {};
-  for (const s in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, s)) {
-      scales[s] = create(obj[s], d, deps);
+
+  return {
+    get(def) {
+      let key;
+      if (typeof def === 'string' && scalesConfig[def]) {
+        key = def;
+      } else if (typeof def === 'object' && 'scale' in def && scalesConfig[def.scale]) {
+        key = def.scale;
+      }
+
+      if (key) {
+        scales[key] = scales[key] || fn(scalesConfig[key], data, deps);
+        return scales[key];
+      }
+
+      return fn(def, data, deps);
+    },
+    all() {
+      Object.keys(scalesConfig).forEach(this.get);
+      return scales;
     }
-  }
-  return scales;
+  };
 }


### PR DESCRIPTION
Changes so that scales and formatters are evaluated when they are requested, instead of during chart creation. This improves performance as data extraction for unused scales/formatters will not be performed.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
