### PR TITLE
feat(labels): allow text to overflow bars

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.17.0",
+    "version": "0.18.2",
     "license": "MIT"
   },
   "entries": {
@@ -2071,6 +2071,12 @@
                               "optional": true,
                               "defaultValue": "'#333'",
                               "type": "string"
+                            },
+                            "overflow": {
+                              "description": "True if the label is allowed to overflow the bar",
+                              "optional": true,
+                              "defaultValue": false,
+                              "type": "boolean"
                             }
                           },
                           "kind": "object"

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars-overlapping-filter.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars-overlapping-filter.spec.js
@@ -1,6 +1,7 @@
 import create, { binaryLeftSearch } from '../bars-overlapping-filter';
 
 describe('binaryLeftSearch', () => {
+  const extractBounds = item => item.rect;
   let ary;
 
   beforeEach(() => {
@@ -13,7 +14,7 @@ describe('binaryLeftSearch', () => {
   });
 
   it('should find the first node that may intersect the label', () => {
-    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', 'rect');
+    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', extractBounds);
     expect(left).to.equal(2); // x: 40, width: 10 may intersect x: 50
   });
 
@@ -29,15 +30,15 @@ describe('binaryLeftSearch', () => {
       { rect: { x: 70, width: 10 } },
       { rect: { x: 80, width: 10 } }
     ];
-    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', 'rect');
+    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', extractBounds);
     expect(left).to.equal(3); // x: 40, width: 10 may intersect x: 50
   });
 
   it('should handle no possible intersections', () => {
-    let left = binaryLeftSearch({ x: -999 }, ary, 'x', 'width', 'rect');
+    let left = binaryLeftSearch({ x: -999 }, ary, 'x', 'width', extractBounds);
     expect(left).to.equal(0); // Return first index
 
-    left = binaryLeftSearch({ x: 999 }, ary, 'x', 'width', 'rect');
+    left = binaryLeftSearch({ x: 999 }, ary, 'x', 'width', extractBounds);
     expect(left).to.equal(3); // Return last index
   });
 });
@@ -68,7 +69,7 @@ describe('filter overlapping labels', () => {
   it('should not filter if collision with self', () => {
     const node = { localBounds: createBounds(10, 10, 20, 20) };
     const labelMeta = { node, textBounds: node.localBounds };
-    context.nodes = [node];
+    context.targetNodes = [{ node }];
     context.labels = [labelMeta];
     const filter = create(context);
     const labels = [0];
@@ -80,7 +81,7 @@ describe('filter overlapping labels', () => {
     const node1 = { localBounds: createBounds(10, 0, 20, 2) };
     const labelMeta0 = { node: node0, textBounds: createBounds(-1, 1, 20, 20) }; // Removed beccause its partially outside the containr
     const labelMeta1 = { node: node1, textBounds: createBounds(10, 2, 20, 20) };
-    context.nodes = [node0, node1];
+    context.targetNodes = [{ node: node0 }, { node: node1 }];
     context.labels = [labelMeta0, labelMeta1];
     const filter = create(context);
     const labels = [0, 1];
@@ -90,7 +91,7 @@ describe('filter overlapping labels', () => {
   it('should filter if not fully inside the container', () => {
     const node0 = { localBounds: createBounds(-1, 0, 20, 1) };
     const labelMeta0 = { node: node0, textBounds: createBounds(-1, 1, 20, 20) }; // Removed beccause its partially outside the containr
-    context.nodes = [node0];
+    context.targetNodes = [{ node: node0 }];
     context.labels = [labelMeta0];
     const filter = create(context);
     const labels = [0];
@@ -102,7 +103,7 @@ describe('filter overlapping labels', () => {
     const node1 = { localBounds: createBounds(10, 0, 10, 2) };
     const labelMeta0 = { node: node0, textBounds: createBounds(0, 10, 20, 20) };
     const labelMeta1 = { node: node1, textBounds: createBounds(10, 10, 20, 20) };
-    context.nodes = [node0, node1];
+    context.targetNodes = [{ node: node0 }, { node: node1 }];
     context.labels = [labelMeta0, labelMeta1];
     const filter = create(context);
     const labels = [0, 1];
@@ -114,7 +115,7 @@ describe('filter overlapping labels', () => {
     const node1 = { localBounds: createBounds(10, 0, 10, 2) };
     const labelMeta0 = { node: node0, textBounds: createBounds(0, 1, 20, 1) };
     const labelMeta1 = { node: node1, textBounds: createBounds(10, 2, 20, 20) };
-    context.nodes = [node0, node1];
+    context.targetNodes = [{ node: node0 }, { node: node1 }];
     context.labels = [labelMeta0, labelMeta1];
     const filter = create(context);
     const labels = [0, 1];

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars-overlapping-filter.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars-overlapping-filter.spec.js
@@ -1,0 +1,123 @@
+import create, { binaryLeftSearch } from '../bars-overlapping-filter';
+
+describe('binaryLeftSearch', () => {
+  let ary;
+
+  beforeEach(() => {
+    ary = [
+      { rect: { x: 0, width: 10 } },
+      { rect: { x: 20, width: 10 } },
+      { rect: { x: 40, width: 10 } }, // 2
+      { rect: { x: 70, width: 10 } }
+    ];
+  });
+
+  it('should find the first node that may intersect the label', () => {
+    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', 'rect');
+    expect(left).to.equal(2); // x: 40, width: 10 may intersect x: 50
+  });
+
+  it('should find the first node that may intersect the label when there are duplicate nodes', () => {
+    ary = [
+      { rect: { x: 0, width: 10 } },
+      { rect: { x: 20, width: 10 } },
+      { rect: { x: 39, width: 10 } },
+      { rect: { x: 40, width: 10 } }, // 3
+      { rect: { x: 40, width: 10 } },
+      { rect: { x: 40, width: 10 } },
+      { rect: { x: 40, width: 10 } },
+      { rect: { x: 70, width: 10 } },
+      { rect: { x: 80, width: 10 } }
+    ];
+    const left = binaryLeftSearch({ x: 50 }, ary, 'x', 'width', 'rect');
+    expect(left).to.equal(3); // x: 40, width: 10 may intersect x: 50
+  });
+
+  it('should handle no possible intersections', () => {
+    let left = binaryLeftSearch({ x: -999 }, ary, 'x', 'width', 'rect');
+    expect(left).to.equal(0); // Return first index
+
+    left = binaryLeftSearch({ x: 999 }, ary, 'x', 'width', 'rect');
+    expect(left).to.equal(3); // Return last index
+  });
+});
+
+describe('filter overlapping labels', () => {
+  let context;
+  function createBounds(x, y, width, height) {
+    return {
+      x,
+      y,
+      width,
+      height
+    };
+  }
+
+  beforeEach(() => {
+    context = {
+      orientation: 'v',
+      container: {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100
+      }
+    };
+  });
+
+  it('should not filter if collision with self', () => {
+    const node = { localBounds: createBounds(10, 10, 20, 20) };
+    const labelMeta = { node, textBounds: node.localBounds };
+    context.nodes = [node];
+    context.labels = [labelMeta];
+    const filter = create(context);
+    const labels = [0];
+    expect(labels.filter(filter)).to.eql(labels);
+  });
+
+  it('should not filter by text to text collision if label already have been removed', () => {
+    const node0 = { localBounds: createBounds(-1, 0, 20, 1) };
+    const node1 = { localBounds: createBounds(10, 0, 20, 2) };
+    const labelMeta0 = { node: node0, textBounds: createBounds(-1, 1, 20, 20) }; // Removed beccause its partially outside the containr
+    const labelMeta1 = { node: node1, textBounds: createBounds(10, 2, 20, 20) };
+    context.nodes = [node0, node1];
+    context.labels = [labelMeta0, labelMeta1];
+    const filter = create(context);
+    const labels = [0, 1];
+    expect(labels.filter(filter)).to.eql([1]);
+  });
+
+  it('should filter if not fully inside the container', () => {
+    const node0 = { localBounds: createBounds(-1, 0, 20, 1) };
+    const labelMeta0 = { node: node0, textBounds: createBounds(-1, 1, 20, 20) }; // Removed beccause its partially outside the containr
+    context.nodes = [node0];
+    context.labels = [labelMeta0];
+    const filter = create(context);
+    const labels = [0];
+    expect(labels.filter(filter)).to.eql([]);
+  });
+
+  it('should filter by text to text collision', () => {
+    const node0 = { localBounds: createBounds(0, 0, 5, 1) };
+    const node1 = { localBounds: createBounds(10, 0, 10, 2) };
+    const labelMeta0 = { node: node0, textBounds: createBounds(0, 10, 20, 20) };
+    const labelMeta1 = { node: node1, textBounds: createBounds(10, 10, 20, 20) };
+    context.nodes = [node0, node1];
+    context.labels = [labelMeta0, labelMeta1];
+    const filter = create(context);
+    const labels = [0, 1];
+    expect(labels.filter(filter)).to.eql([0]);
+  });
+
+  it('should filter by text to node collision', () => {
+    const node0 = { localBounds: createBounds(0, 0, 5, 20) };
+    const node1 = { localBounds: createBounds(10, 0, 10, 2) };
+    const labelMeta0 = { node: node0, textBounds: createBounds(0, 1, 20, 1) };
+    const labelMeta1 = { node: node1, textBounds: createBounds(10, 2, 20, 20) };
+    context.nodes = [node0, node1];
+    context.labels = [labelMeta0, labelMeta1];
+    const filter = create(context);
+    const labels = [0, 1];
+    expect(labels.filter(filter)).to.eql([1]);
+  });
+});

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -19,6 +19,8 @@ function place(position, direction) {
   });
 }
 
+const postFilter = () => () => true;
+
 describe('labeling - bars', () => {
   describe('bar rects', () => {
     it('inside', () => {
@@ -278,7 +280,7 @@ describe('labeling - bars', () => {
           direction: 'right'
         }],
         collectiveOrientation: 'h'
-      }, findPlacement, placer);
+      }, findPlacement, placer, postFilter);
       expect(labels).to.eql([['bounds', 'a', {
         fill: 'blue',
         justify: 0.4,
@@ -286,7 +288,8 @@ describe('labeling - bars', () => {
         fontSize: '11px',
         fontFamily: 'bb',
         textMetrics: 2,
-        rotate: false
+        rotate: false,
+        overflow: false
       }]]);
     });
   });

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
@@ -44,7 +44,7 @@ export default function filterOverlappingLabels({
   container
 },
 findLeft = binaryLeftSearch) {
-  const removedLabels = {};
+  const renderLabels = [];
   const coord = orientation === 'v' ? 'x' : 'y';
   const side = orientation === 'v' ? 'width' : 'height';
   const getTextBounds = item => item.textBounds;
@@ -55,18 +55,13 @@ findLeft = binaryLeftSearch) {
 
     // ### Test if label is not fully inside container ###
     if (!rectContainsRect(labelBounds, container)) {
-      removedLabels[labelIndex] = true;
       return false;
     }
 
     // ### Test label to label collision ###
-    // Only check up until the current label index, which sets a prio order from left to right,
-    // such that labels too the left are priorities and rendered first.
-    const leftStartLabel = findLeft(labelBounds, labels, coord, side, getTextBounds);
-    for (let i = leftStartLabel; i < labelIndex; i++) {
-      // Skip collision check if label have already been removed
-      if (!removedLabels[i] && testRectRect(labelBounds, labels[i].textBounds)) {
-        removedLabels[labelIndex] = true;
+    const leftStartLabel = findLeft(labelBounds, renderLabels, coord, side, getTextBounds);
+    for (let i = leftStartLabel; i < renderLabels.length; i++) {
+      if (testRectRect(labelBounds, renderLabels[i].textBounds)) {
         return false;
       }
     }
@@ -82,12 +77,12 @@ findLeft = binaryLeftSearch) {
       }
 
       if (testRectRect(labelBounds, node.localBounds) && labelNode !== node) {
-        removedLabels[labelIndex] = true;
         return false;
       }
     }
 
     // No collision occured, allow the label to be rendered
+    renderLabels.push(labels[labelIndex]);
     return true;
   };
 }

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
@@ -1,0 +1,88 @@
+import { testRectRect } from '../../../math/narrow-phase-collision';
+import { rectContainsRect } from '../../../math/intersection';
+
+/**
+ * Using the basic example found here: https://en.wikipedia.org/wiki/Binary_search_algorithm
+ *
+ * Finds the first node that may intersect the label.
+ * @private
+ */
+function binaryLeftSearch(labelBounds, ary, coord, side, prop) {
+  let left = 0;
+  let right = ary.length - 1;
+  let node;
+
+  while (left < right) {
+    let m = Math.floor((left + right) / 2);
+    node = ary[m];
+    if (node[prop][coord] + node[prop][side] < labelBounds[coord]) { // is on right side
+      left = m + 1;
+    } else { // is on the left side
+      right = m - 1;
+    }
+  }
+  return left;
+}
+
+/**
+ * The purpose of this module is to act a filtering function to remove any labels
+ * that meets one of the following criterias:
+ * -- The label is not fully inside the container, such that it would be fully or partially clipped if rendered
+ * -- The label overlaps another label
+ * -- The label overlaps another bar which is not the bar the label is originating from
+ *
+ * Assumes that the nodes are sorted from left/top to right/down, as that allows
+ * some optimizations to be performed.
+ * @private
+ * @returns {function} Filter function, returns false if label be removed and true otherwise
+ */
+export default function filterOverlappingLabels({
+  orientation,
+  nodes,
+  labels,
+  container
+}) {
+  const removedLabels = {};
+  const coord = orientation === 'v' ? 'x' : 'y';
+  const side = orientation === 'v' ? 'width' : 'height';
+
+  return (doNotUse, labelIndex) => {
+    const { textBounds: labelBounds, node: labelNode } = labels[labelIndex];
+
+    // ### Test if label is not fully inside container ###
+    if (!rectContainsRect(labelBounds, container)) {
+      removedLabels[labelIndex] = true;
+      return false;
+    }
+
+    // ### Test label to label collision ###
+    // Only check up until the current label index, which sets a prio order from left to right,
+    // such that labels too the left are priorities and rendered first.
+    const leftStartLabel = binaryLeftSearch(labelBounds, labels, coord, side, 'textBounds');
+    for (let i = leftStartLabel; i < labelIndex; i++) {
+      // Skip collision check if label have already been removed
+      if (!removedLabels[i] && testRectRect(labelBounds, labels[i].textBounds)) {
+        removedLabels[labelIndex] = true;
+        return false;
+      }
+    }
+
+    // ### Test label to node collision ###
+    const leftStartNode = binaryLeftSearch(labelBounds, nodes, coord, side, 'localBounds');
+    for (let i = leftStartNode; i < nodes.length; i++) {
+      const node = nodes[i];
+      // Do not test beyond this node, as they are assumed to not collide with the label
+      if ((labelBounds[coord] + labelBounds[side]) < node.localBounds[coord]) {
+        break;
+      }
+
+      if (testRectRect(labelBounds, node.localBounds) && labelNode !== node) {
+        removedLabels[labelIndex] = true;
+        return false;
+      }
+    }
+
+    // No collision occured, allow the label to be rendered
+    return true;
+  };
+}


### PR DESCRIPTION
This PR adds a new property on the labels components `bar` strategy. Enabling texts to be rendered even when they don't fully fit the bar.

There is a performance overhead introduced each label needs to be checked for possible intersections with other nodes and when all selected bars are sorted by direction.

The logic for determining the best possible placement doesn't consider overflow property for now.

Also should rename it to something other than overflow..

![overflow-labels](https://user-images.githubusercontent.com/16608020/50835680-a43c2b80-1357-11e9-8dc2-9819296f4ecb.jpg)

**Usage:**
```js
{
        type: 'labels',
        settings: {
          sources: [
            {
              component: 'bars',
              selector: 'rect',
              strategy: {
                type: 'bar',
                settings: {
                  labels: [{
                    placements: [
                      { position: 'outside', fill: '#666', overflow: true }
                    ]
                  }]
                }
              },
            },
          ],
        },
      }
```

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
