### PR TITLE
perf: cache bounds calculations

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -31,22 +31,31 @@ export default class Circle extends DisplayObject {
     this.attrs.r = r;
 
     this.collider = opts;
+    this.__boundingRect = { true: null, false: null };
+    this.__bounds = { true: null, false: null };
   }
 
   boundingRect(includeTransform = false) {
+    if (this.__boundingRect[includeTransform] !== null) {
+      return this.__boundingRect[includeTransform];
+    }
     // TODO Handle Circle bounds correctly for a circle transformed to an non axis aligned ellipse/circle
     // Current solution only rotate the bounds, giving a larger boundingRect if rotated
     const p = this.bounds(includeTransform);
 
-    return {
+    this.__boundingRect[includeTransform] = {
       x: p[0].x,
       y: p[0].y,
       width: p[2].x - p[0].x,
       height: p[2].y - p[0].y
     };
+    return this.__boundingRect[includeTransform];
   }
 
   bounds(includeTransform = false) {
+    if (this.__bounds[includeTransform] !== null) {
+      return this.__bounds[includeTransform];
+    }
     // TODO Handle Circle bounds correctly for a circle transformed to an non axis aligned ellipse/circle
     const {
       cx, cy, r: rX, r: rY
@@ -68,15 +77,17 @@ export default class Circle extends DisplayObject {
       w = xMax - xMin;
       h = yMax - yMin;
 
-      return [
+      this.__bounds[includeTransform] = [
         { x: xMin, y: yMin },
         { x: xMin + w, y: yMin },
         { x: xMin + w, y: yMin + h },
         { x: xMin, y: yMin + h }
       ];
+    } else {
+      this.__bounds[includeTransform] = p;
     }
 
-    return p;
+    return this.__bounds[includeTransform];
   }
 }
 

--- a/packages/picasso.js/src/core/scene-graph/display-objects/line.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/line.js
@@ -38,9 +38,14 @@ export default class Line extends DisplayObject {
       y2
     };
     this.collider = extend(defaultCollider, collider);
+    this.__boundingRect = { true: null, false: null };
+    this.__bounds = { true: null, false: null };
   }
 
   boundingRect(includeTransform = false) {
+    if (this.__boundingRect[includeTransform] !== null) {
+      return this.__boundingRect[includeTransform];
+    }
     let p = lineToPoints(this.attrs);
 
     if (includeTransform && this.modelViewMatrix) {
@@ -50,22 +55,27 @@ export default class Line extends DisplayObject {
     const [xMin, yMin, xMax, yMax] = getMinMax(p);
     const hasSize = xMin !== xMax || yMin !== yMax;
 
-    return {
+    this.__boundingRect[includeTransform] = {
       x: xMin,
       y: yMin,
       width: hasSize ? Math.max(1, xMax - xMin) : 0,
       height: hasSize ? Math.max(1, yMax - yMin) : 0
     };
+    return this.__boundingRect[includeTransform];
   }
 
   bounds(includeTransform = false) {
+    if (this.__bounds[includeTransform] !== null) {
+      return this.__bounds[includeTransform];
+    }
     const rect = this.boundingRect(includeTransform);
-    return [
+    this.__bounds[includeTransform] = [
       { x: rect.x, y: rect.y },
       { x: rect.x + rect.width, y: rect.y },
       { x: rect.x + rect.width, y: rect.y + rect.height },
       { x: rect.x, y: rect.y + rect.height }
     ];
+    return this.__bounds[includeTransform];
   }
 }
 

--- a/packages/picasso.js/src/core/scene-graph/display-objects/path.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/path.js
@@ -58,9 +58,16 @@ export default class Path extends DisplayObject {
         }
       });
     }
+
+    this.__boundingRect = { true: null, false: null };
+    this.__bounds = { true: null, false: null };
   }
 
   boundingRect(includeTransform = false) {
+    if (this.__boundingRect[includeTransform] !== null) {
+      return this.__boundingRect[includeTransform];
+    }
+
     if (!this.points.length) {
       this.segments = this.segments.length ? this.segments : pathToSegments(this.attrs.d);
       this.points = flatten(this.segments);
@@ -69,23 +76,29 @@ export default class Path extends DisplayObject {
     const pt = includeTransform && this.modelViewMatrix ? this.modelViewMatrix.transformPoints(this.points) : this.points;
     const [xMin, yMin, xMax, yMax] = getMinMax(pt);
 
-    return {
+    this.__boundingRect[includeTransform] = {
       x: xMin || 0,
       y: yMin || 0,
       width: (xMax - xMin) || 0,
       height: (yMax - yMin) || 0
     };
+
+    return this.__boundingRect[includeTransform];
   }
 
   bounds(includeTransform = false) {
+    if (this.__bounds[includeTransform] !== null) {
+      return this.__bounds[includeTransform];
+    }
     const rect = this.boundingRect(includeTransform);
 
-    return [
+    this.__bounds[includeTransform] = [
       { x: rect.x, y: rect.y },
       { x: rect.x + rect.width, y: rect.y },
       { x: rect.x + rect.width, y: rect.y + rect.height },
       { x: rect.x, y: rect.y + rect.height }
     ];
+    return this.__bounds[includeTransform];
   }
 }
 

--- a/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
@@ -47,30 +47,42 @@ export default class Rect extends DisplayObject {
     }
 
     this.collider = opts;
+    this.__boundingRect = { true: null, false: null };
+    this.__bounds = { true: null, false: null };
   }
 
   boundingRect(includeTransform = false) {
+    if (this.__boundingRect[includeTransform] !== null) {
+      return this.__boundingRect[includeTransform];
+    }
     const p = rectToPoints(this.attrs);
     const pt = includeTransform && this.modelViewMatrix ? this.modelViewMatrix.transformPoints(p) : p;
     const [xMin, yMin, xMax, yMax] = getMinMax(pt);
 
-    return {
+    this.__boundingRect[includeTransform] = {
       x: xMin,
       y: yMin,
       width: xMax - xMin,
       height: yMax - yMin
     };
+
+    return this.__boundingRect[includeTransform];
   }
 
   bounds(includeTransform = false) {
+    if (this.__bounds[includeTransform] !== null) {
+      return this.__bounds[includeTransform];
+    }
     const rect = this.boundingRect(includeTransform);
 
-    return [
+    this.__bounds[includeTransform] = [
       { x: rect.x, y: rect.y },
       { x: rect.x + rect.width, y: rect.y },
       { x: rect.x + rect.width, y: rect.y + rect.height },
       { x: rect.x, y: rect.y + rect.height }
     ];
+
+    return this.__bounds[includeTransform];
   }
 }
 


### PR DESCRIPTION
This improves performance for calculating the bounding rectangle of a node. All calculations are now cached either with a transformation applied or without.

**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
