### PR TITLE
feat(brush-range): add label settings

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.18.2",
+    "version": "0.19.0",
     "license": "MIT"
   },
   "entries": {
@@ -5235,6 +5235,11 @@
               "optional": true,
               "defaultValue": "start",
               "type": "string"
+            },
+            "label": {
+              "description": "Callback function for the labels",
+              "optional": true,
+              "type": "function"
             }
           }
         },


### PR DESCRIPTION
Adds a new setting for the `brush-range` component that allows custom bubbles labels to defined via a callback function.

**Usage**
```js
{
  bubbles: {
    label: ({ datum, resources:{ formatter } }) => formatter('<key-of-custom-formatter>')(datum)
  },
}
```