### PR TITLE
fix(scales): fallback to default formatter

### DIFF
--- a/packages/picasso.js/src/core/scales/ticks/tick-generators.js
+++ b/packages/picasso.js/src/core/scales/ticks/tick-generators.js
@@ -194,7 +194,10 @@ function forceTicksAtBounds(ticks, scale, formatter) {
 }
 
 export function generateContinuousTicks({
-  settings, scale, distance, formatter
+  settings,
+  scale,
+  distance,
+  formatter = val => val
 }) {
   let ticks;
   const minorCount = settings.minorTicks && !notNumber(settings.minorTicks.count) ? Math.min(100, settings.minorTicks.count) : 0;


### PR DESCRIPTION
Fixes an issue where an exception could be thrown if a linear scale had no formatted and was configure with one of the following ticks settings: `forceAtBounds/count/values`

