### PR TITLE
perf(q): memoize time formatter

### DIFF
--- a/plugins/q/src/formatter/timeFormat.js
+++ b/plugins/q/src/formatter/timeFormat.js
@@ -58,7 +58,9 @@ export default function formatter(pattern, qtype = 'TS', localeInfo = null) {
    */
   format.locale = function locale(li) {
     qformat = dateFormatFactory(li, pattern, qtype);
-    memoized = memoize(qformat.format.bind(qformat));
+    memoized = memoize(qformat.format.bind(qformat), {
+      toKey: date => (typeof date === 'object' ? date.getTime() : date)
+    });
     return this;
   };
 


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
