### PR TITLE
feat: expose mode on brush consumer

### DIFF
--- a/docs/src/input/brushing.md
+++ b/docs/src/input/brushing.md
@@ -34,6 +34,7 @@ trigger: [{
 
 * `context`: name of the brush context to observe
 * `data`: the mapped data properties to observe. _Optional_
+* `mode`: data properties operator: `and`, `or`, `xor`. _Optional_
 * `filter`: a filtering function. _Optional_
 * `style`: the style to apply to the shapes of the component
   * `active`: the style of _active_ data points

--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -274,6 +274,13 @@ describe('Brushing', () => {
       };
     });
 
+    it('should call containsMappedData with provided arguments', () => {
+      const s = styler(dummyComponent, { ...consume, mode: 'moood', data: ['a'] });
+      s.update();
+
+      expect(brusherStub.containsMappedData.firstCall).to.have.been.calledWithExactly(data[0], ['a'], 'moood');
+    });
+
     it('start should store all original styling values', () => {
       styler(dummyComponent, consume);
       brusherStub.trigger('start');

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -21,7 +21,8 @@ export function styler(obj, {
   context,
   data,
   style,
-  filter
+  filter,
+  mode
 }) {
   const brusher = obj.chart.brush(context);
   const dataProps = data;
@@ -69,7 +70,7 @@ export function styler(obj, {
         });
       }
 
-      const isActive = brusher.containsMappedData(nodeData, dataProps);
+      const isActive = brusher.containsMappedData(nodeData, dataProps, mode);
       const activeIdx = activeNodes.indexOf(nodes[i]);
       let changed = false;
       if (isActive && activeIdx === -1) { // activated


### PR DESCRIPTION
This exposes `mode` on the brush consumer, allowing the user to set a condition on the data properties that need to be fulfilled in order to be considered brushed.

By default, a data item is considered brushed if data linked to any of the provided `data` properties is brushed.
By providing a `mode: 'and'`, we set a condition so that an item is considered brushed only of all its linked properties are brushed:

```js
consume: [{
  context: 'selection',
  data: ['x', 'y'],
  mode: 'and', // valid values: 'and', 'xor', 'or' (default)
  style: {
    active: {
      fill: 'red',
    },
  }
}]
```
