### PR TITLE
feat: expose the visibility of a component

### DIFF
--- a/docs/src/input/components.md
+++ b/docs/src/input/components.md
@@ -106,6 +106,28 @@ picasso.chart({
 });
 ```
 
+## Visibility of a component
+It is possible to get the visibility of a component when it is mounted/unmounted. This can be done in the following example.
+
+Assume a custom component of type foo: 
+
+```js
+
+const foo = {
+  type: 'foo',
+  key: 'myComponent'
+};
+
+const chart = picasso.chart({
+  element,
+  settings: {
+    components: [foo]
+  }
+});
+
+chart.component('myComponent').isVisible(); // returns a boolean determining if the component is visible or not
+```
+
 ## Component lifecycle hooks
 
 __TODO__

--- a/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
@@ -58,8 +58,8 @@ describe('Component', () => {
     };
   });
 
-  function createAndRenderComponent(config) {
-    const instance = componentFactory(definition, {
+  function createInstance(config) {
+    return componentFactory(definition, {
       settings: config,
       chart,
       renderer,
@@ -68,6 +68,10 @@ describe('Component', () => {
         style: sinon.stub()
       }
     });
+  }
+
+  function createAndRenderComponent(config) {
+    const instance = createInstance(config);
     instance.beforeMount();
     instance.resize({});
     instance.beforeRender();
@@ -176,6 +180,25 @@ describe('Component', () => {
       instance.destroy();
 
       expect(instance.ctx.emit).to.be.a('function');
+    });
+  });
+
+  describe('Visibility', () => {
+    it('should return false for isVisible() when initialising', () => {
+      const instance = createInstance();
+      expect(instance.ctx.isVisible()).to.equal(false);
+    });
+
+    it('should return true for isVisible() when mounting', () => {
+      const instance = createInstance();
+      instance.mount();
+      expect(instance.ctx.isVisible()).to.equal(true);
+    });
+
+    it('should return false for isVisible() when unmounting', () => {
+      const instance = createInstance();
+      instance.unmount();
+      expect(instance.ctx.isVisible()).to.equal(false);
     });
   });
 

--- a/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
@@ -183,7 +183,7 @@ describe('Component', () => {
     });
   });
 
-  describe('Visibility', () => {
+  describe('visibility', () => {
     it('should return false for isVisible() when initialising', () => {
       const instance = createInstance();
       expect(instance.ctx.isVisible()).to.equal(false);

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -194,6 +194,7 @@ function componentFactory(definition, context = {}) {
   let resolver = settingsResolver({
     chart
   });
+  let isVisible;
 
   const brushArgs = {
     nodes: [],
@@ -545,8 +546,6 @@ function componentFactory(definition, context = {}) {
   };
 
   fn.mount = () => {
-    const isVisible = true;
-
     element = rend.element && rend.element() ? element : rend.appendTo(container);
     if (rend.setKey && typeof config.key === 'string') {
       rend.setKey(config.key);
@@ -560,14 +559,13 @@ function componentFactory(definition, context = {}) {
     setUpEmitter(instanceContext, emitter, config);
     setUpEmitter(definitionContext, emitter, definition);
 
+    isVisible = true;
     instanceContext.isVisible = () => isVisible;
   };
 
   fn.mounted = () => mounted(element);
 
   fn.unmount = () => {
-    const isVisible = false;
-
     [instanceContext, definitionContext].forEach((ctx) => {
       tearDownEmitter(ctx, emitter);
     });
@@ -579,6 +577,7 @@ function componentFactory(definition, context = {}) {
     brushStylers.length = 0;
     beforeUnmount();
 
+    isVisible = false;
     instanceContext.isVisible = () => isVisible;
   };
 

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -45,12 +45,15 @@ function prepareContext(ctx, definition, opts) {
     resolver,
     update,
     _DO_NOT_USE_getInfo,
-    symbol
+    symbol,
+    isVisible
   } = opts;
 
   ctx.emit = () => {};
 
-  setVisibility(ctx, false);
+  if (isVisible) {
+    isVisible();
+  }
 
   // TODO add setters and log warnings / errors to console
   Object.defineProperty(ctx, 'settings', {
@@ -480,7 +483,8 @@ function componentFactory(definition, context = {}) {
     dockConfig: () => dockConfig,
     mediator: () => mediator,
     style: () => style,
-    _DO_NOT_USE_getInfo: _DO_NOT_USE_getInfo.bind(definitionContext)
+    _DO_NOT_USE_getInfo: _DO_NOT_USE_getInfo.bind(definitionContext),
+    isVisible: () => setVisibility(instanceContext, false)
   });
 
   fn.getBrushedShapes = function getBrushedShapes(brushCtx, mode, props) {
@@ -559,7 +563,6 @@ function componentFactory(definition, context = {}) {
     setUpEmitter(definitionContext, emitter, definition);
 
     setVisibility(instanceContext, true);
-    setVisibility(definitionContext, true);
   };
 
   fn.mounted = () => mounted(element);
@@ -577,7 +580,6 @@ function componentFactory(definition, context = {}) {
     beforeUnmount();
 
     setVisibility(instanceContext, false);
-    setVisibility(definitionContext, false);
   };
 
   fn.onBrushTap = (e) => {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -18,8 +18,12 @@ const isReservedProperty = prop => [
   'beforeUpdate', 'updated', 'beforeRender', 'render', 'beforeUnmount', 'beforeDestroy',
   'destroyed', 'defaultSettings', 'data', 'settings', 'formatter',
   'scale', 'chart', 'dockConfig', 'mediator', 'style', 'resolver', 'registries',
-  '_DO_NOT_USE_getInfo', 'symbol'
+  '_DO_NOT_USE_getInfo', 'symbol', 'isVisible'
 ].some(name => name === prop);
+
+function setVisibility(ctx, isVisible) {
+  ctx.isVisible = () => isVisible;
+}
 
 function prepareContext(ctx, definition, opts) {
   const {
@@ -45,6 +49,8 @@ function prepareContext(ctx, definition, opts) {
   } = opts;
 
   ctx.emit = () => {};
+
+  setVisibility(ctx, false);
 
   // TODO add setters and log warnings / errors to console
   Object.defineProperty(ctx, 'settings', {
@@ -551,6 +557,9 @@ function componentFactory(definition, context = {}) {
 
     setUpEmitter(instanceContext, emitter, config);
     setUpEmitter(definitionContext, emitter, definition);
+
+    setVisibility(instanceContext, true);
+    setVisibility(definitionContext, true);
   };
 
   fn.mounted = () => mounted(element);
@@ -566,6 +575,9 @@ function componentFactory(definition, context = {}) {
     });
     brushStylers.length = 0;
     beforeUnmount();
+
+    setVisibility(instanceContext, false);
+    setVisibility(definitionContext, false);
   };
 
   fn.onBrushTap = (e) => {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -21,10 +21,6 @@ const isReservedProperty = prop => [
   '_DO_NOT_USE_getInfo', 'symbol', 'isVisible'
 ].some(name => name === prop);
 
-function setVisibility(ctx, isVisible) {
-  ctx.isVisible = () => isVisible;
-}
-
 function prepareContext(ctx, definition, opts) {
   const {
     require = []
@@ -484,7 +480,7 @@ function componentFactory(definition, context = {}) {
     mediator: () => mediator,
     style: () => style,
     _DO_NOT_USE_getInfo: _DO_NOT_USE_getInfo.bind(definitionContext),
-    isVisible: () => setVisibility(instanceContext, false)
+    isVisible: () => instanceContext.isVisible = () => false
   });
 
   fn.getBrushedShapes = function getBrushedShapes(brushCtx, mode, props) {
@@ -549,6 +545,8 @@ function componentFactory(definition, context = {}) {
   };
 
   fn.mount = () => {
+    const isVisible = true;
+
     element = rend.element && rend.element() ? element : rend.appendTo(container);
     if (rend.setKey && typeof config.key === 'string') {
       rend.setKey(config.key);
@@ -562,12 +560,14 @@ function componentFactory(definition, context = {}) {
     setUpEmitter(instanceContext, emitter, config);
     setUpEmitter(definitionContext, emitter, definition);
 
-    setVisibility(instanceContext, true);
+    instanceContext.isVisible = () => isVisible;
   };
 
   fn.mounted = () => mounted(element);
 
   fn.unmount = () => {
+    const isVisible = false;
+
     [instanceContext, definitionContext].forEach((ctx) => {
       tearDownEmitter(ctx, emitter);
     });
@@ -579,7 +579,7 @@ function componentFactory(definition, context = {}) {
     brushStylers.length = 0;
     beforeUnmount();
 
-    setVisibility(instanceContext, false);
+    instanceContext.isVisible = () => isVisible;
   };
 
   fn.onBrushTap = (e) => {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -48,7 +48,7 @@ function prepareContext(ctx, definition, opts) {
   ctx.emit = () => {};
 
   if (isVisible) {
-    isVisible();
+    ctx.isVisible = isVisible;
   }
 
   // TODO add setters and log warnings / errors to console
@@ -194,7 +194,7 @@ function componentFactory(definition, context = {}) {
   let resolver = settingsResolver({
     chart
   });
-  let isVisible;
+  let isVisible = false;
 
   const brushArgs = {
     nodes: [],
@@ -481,7 +481,7 @@ function componentFactory(definition, context = {}) {
     mediator: () => mediator,
     style: () => style,
     _DO_NOT_USE_getInfo: _DO_NOT_USE_getInfo.bind(definitionContext),
-    isVisible: () => instanceContext.isVisible = () => false
+    isVisible: () => isVisible
   });
 
   fn.getBrushedShapes = function getBrushedShapes(brushCtx, mode, props) {
@@ -560,7 +560,6 @@ function componentFactory(definition, context = {}) {
     setUpEmitter(definitionContext, emitter, definition);
 
     isVisible = true;
-    instanceContext.isVisible = () => isVisible;
   };
 
   fn.mounted = () => mounted(element);
@@ -578,7 +577,6 @@ function componentFactory(definition, context = {}) {
     beforeUnmount();
 
     isVisible = false;
-    instanceContext.isVisible = () => isVisible;
   };
 
   fn.onBrushTap = (e) => {


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

- allows a user to get the visibility of a component after it has been rendered.
