### PR TITLE
feat: set component key as attribute on renderer element

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -404,6 +404,10 @@ function componentFactory(definition, context = {}) {
       rend.render(nodes);
     }
     currentNodes = nodes;
+
+    if (rend.setKey && typeof config.key === 'string') {
+      rend.setKey(config.key);
+    }
   };
 
   fn.updated = updated;
@@ -527,6 +531,9 @@ function componentFactory(definition, context = {}) {
 
   fn.mount = () => {
     element = rend.element && rend.element() ? element : rend.appendTo(container);
+    if (rend.setKey && typeof config.key === 'string') {
+      rend.setKey(config.key);
+    }
 
     if (settings.brush) {
       addBrushStylers();

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
@@ -113,6 +113,16 @@ describe('canvas renderer', () => {
     expect(div.children.length).to.equal(0);
   });
 
+  describe('setKey', () => {
+    it('should set key attribute', () => {
+      const div = element('div');
+      const spy = sandbox.spy(div, 'setAttribute');
+      r.element = () => div;
+      r.setKey('myKey');
+      expect(spy).have.been.calledWith('data-key', 'myKey');
+    });
+  });
+
   describe('itemsAt', () => {
     let items;
 

--- a/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
@@ -130,4 +130,15 @@ describe('dom renderer', () => {
       });
     });
   });
+
+  describe('setKey', () => {
+    it('should set key attribute', () => {
+      const el = element('div');
+      const spy = sinon.spy(el, 'setAttribute');
+      rend.element = () => el;
+      rend.setKey(123);
+
+      expect(spy).to.have.been.calledWith('data-key', 123);
+    });
+  });
 });

--- a/packages/picasso.js/src/web/renderer/index.js
+++ b/packages/picasso.js/src/web/renderer/index.js
@@ -91,7 +91,11 @@ function create() {
      * @param {node--text-def} node
      * @return {rect} The bounding rectangle
      */
-    textBounds
+    textBounds,
+
+    setKey: (key) => {
+      renderer.element().setAttribute('data-key', key);
+    }
   };
 
   return renderer;

--- a/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
@@ -282,4 +282,15 @@ describe('svg renderer', () => {
       });
     });
   });
+
+  describe('setKey', () => {
+    it('should set key attribute', () => {
+      const el = element('div');
+      const spy = sinon.spy(el, 'setAttribute');
+      svg.element = () => el;
+      svg.setKey(123);
+
+      expect(spy).to.have.been.calledWith('data-key', 123);
+    });
+  });
 });


### PR DESCRIPTION
Sets a `data-key` attribute on all component container elements. I would primarily consider this a debug aid when inspecting elements.