### PR TITLE
fix: invert justify when bar direction is left

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -292,6 +292,40 @@ describe('labeling - bars', () => {
         overflow: false
       }]]);
     });
+
+    it('should call placer with certain arguments', () => {
+      findPlacement.returns({
+        bounds: 'bounds',
+        placement: {
+          fill: 'blue',
+          justify: 0.3,
+          direction: 'left',
+          align: 0.4
+        }
+      });
+      placeInBars({
+        chart,
+        targetNodes: [{
+          node: {},
+          texts: ['a'],
+          measurements: [2],
+          labelSettings: [{ fontSize: '11px', fontFamily: 'bb' }],
+          placementSettings: [{}],
+          direction: 'left'
+        }],
+        collectiveOrientation: 'h'
+      }, findPlacement, placer, postFilter);
+      expect(placer.firstCall).to.have.been.calledWithExactly('bounds', 'a', {
+        fill: 'blue',
+        justify: 0.4,
+        align: 0.7,
+        fontSize: '11px',
+        fontFamily: 'bb',
+        textMetrics: 2,
+        rotate: false,
+        overflow: false
+      });
+    });
   });
 
   describe('bar strategy', () => {

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -215,7 +215,8 @@ export function placeInBars(
     rect,
     fitsHorizontally,
     collectiveOrientation
-  }, findPlacement = findBestPlacement,
+  },
+  findPlacement = findBestPlacement,
   placer = placeTextInRect,
   postFilter = filterOverlapping
 ) {
@@ -283,6 +284,9 @@ export function placeInBars(
           justify = 1 - justify;
         }
         if (placement.position === 'opposite') {
+          justify = 1 - justify;
+        }
+        if (direction === 'left') {
           justify = 1 - justify;
         }
 


### PR DESCRIPTION
Fixes `justify` in bar labeling strategy when bar `direction` is `'left'`

Before:
![label justify bug](https://user-images.githubusercontent.com/16324367/52422651-c5c73900-2af6-11e9-84ad-b1e2f2fa3a59.png)

After:
![label justify fix](https://user-images.githubusercontent.com/16324367/52422661-cb248380-2af6-11e9-8131-9000623e67bf.png)
