### PR TITLE
fix(svg-renderer): do not add undefined title attribute

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -57,7 +57,9 @@ export default class Text extends DisplayObject {
     this.attrs.dx = dx;
     this.attrs.dy = dy;
     this.attrs.text = text;
-    this.attrs.title = title;
+    if (typeof title !== 'undefined') {
+      this.attrs.title = String(title);
+    }
     if (typeof boundingRect === 'object') {
       this._textBoundsFn = () => boundingRect;
     } else if (typeof textBoundsFn === 'function') {


### PR DESCRIPTION
Fixes `title='undefined'` in DOM output

Before:
```html
<text title="undefined" data-value="0" data-label="Americas">Americas</text>
```
After:
```html
<text data-value="0" data-label="Americas">Americas</text>
```