### PR TITLE
feat(scene-node): add boundsRelativeTo method

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4763,7 +4763,7 @@
           "type": "#/definitions/rect"
         },
         "boundsRelativeTo": {
-          "description": "Bounding rectangle of the node, relative a target.\n\nIf target is an HTMLElement, the bounds is relative to the HTMLElement.\nAny other target type will return the bounds reltive to the viewport of the browser.",
+          "description": "Bounding rectangle of the node, relative a target.\n\nIf target is an HTMLElement, the bounds are relative to the HTMLElement.\nAny other target type will return the bounds relative to the viewport of the browser.",
           "kind": "function",
           "params": [
             {
@@ -4781,7 +4781,7 @@
             },
             {
               "name": "includeTransform",
-              "description": "true will include any transform attribute on the node, false will not",
+              "description": "whether to include any applied transforms on the node",
               "defaultValue": true,
               "type": "boolean"
             }

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4763,7 +4763,7 @@
           "type": "#/definitions/rect"
         },
         "boundsRelativeTo": {
-          "description": "Bounding rectangle of the node, relative a target.\n\nIf target is an HTMLElement, the bounds is relative to the HTMLElement.\nIf target is a picasso component instance, the bounds is relative to that picasso component.\nAny other target type will return the bounds reltive to the viewport of the browser.",
+          "description": "Bounding rectangle of the node, relative a target.\n\nIf target is an HTMLElement, the bounds is relative to the HTMLElement.\nAny other target type will return the bounds reltive to the viewport of the browser.",
           "kind": "function",
           "params": [
             {
@@ -4772,9 +4772,6 @@
               "items": [
                 {
                   "type": "HTMLElement"
-                },
-                {
-                  "type": "Component"
                 },
                 {
                   "type": "any"
@@ -4793,7 +4790,7 @@
             "type": "#/definitions/rect"
           },
           "examples": [
-            "node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo(chartInstace.component('<some-key>'))\nnode.boundsRelativeTo('viewport');"
+            "node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo('viewport');"
           ]
         },
         "collider": {

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4781,7 +4781,7 @@
             },
             {
               "name": "includeTransform",
-              "description": "whether to include any applied transforms on the node",
+              "description": "Whether to include any applied transforms on the node",
               "defaultValue": true,
               "type": "boolean"
             }

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4762,6 +4762,40 @@
           "description": "Bounding rectangle of the node withing it's local coordinate system.\nOrigin is in the top-left corner of the scene element.",
           "type": "#/definitions/rect"
         },
+        "boundsRelativeTo": {
+          "description": "Bounding rectangle of the node, relative a target.\n\nIf target is an HTMLElement, the bounds is relative to the HTMLElement.\nIf target is a picasso component instance, the bounds is relative to that picasso component.\nAny other target type will return the bounds reltive to the viewport of the browser.",
+          "kind": "function",
+          "params": [
+            {
+              "name": "target",
+              "kind": "union",
+              "items": [
+                {
+                  "type": "HTMLElement"
+                },
+                {
+                  "type": "Component"
+                },
+                {
+                  "type": "any"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "name": "includeTransform",
+              "description": "true will include any transform attribute on the node, false will not",
+              "defaultValue": true,
+              "type": "boolean"
+            }
+          ],
+          "returns": {
+            "type": "#/definitions/rect"
+          },
+          "examples": [
+            "node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo(chartInstace.component('<some-key>'))\nnode.boundsRelativeTo('viewport');"
+          ]
+        },
         "collider": {
           "description": "Collider of the node. Transform on the node has been applied to the collider shape, if any, but excluding scaling transform related to devicePixelRatio.\nOrigin is in the top-left corner of the scene element.\n\nIf node has no collider, null is returned.",
           "kind": "union",

--- a/packages/picasso.js/src/core/scene-graph/__tests__/scene-node.spec.js
+++ b/packages/picasso.js/src/core/scene-graph/__tests__/scene-node.spec.js
@@ -221,69 +221,6 @@ describe('Scene Node', () => {
       });
     });
 
-    describe('Component', () => {
-      let compMock;
-
-      beforeEach(() => {
-        compMock = {
-          rect: {
-            x: 1,
-            y: 2,
-            margin: { left: 3, top: 4 },
-            scaleRatio: { x: 0.5, y: 2 }
-          }
-        };
-      });
-
-      it('should return node bounds relative to the component, including any transform', () => {
-        const bounds = {
-          x: 10, y: 20, width: 30, height: 40
-        };
-        const rect = createRect({ ...bounds, transform: 'translate(5, 15)' });
-        rect.resolveLocalTransform();
-        sceneNode = create(rect);
-        sceneNode.element = {
-          getBoundingClientRect: () => ({
-            left: 11,
-            top: 22
-          })
-        };
-        expect(sceneNode.boundsRelativeTo(compMock)).to.deep.equal({
-          x: 22.5, y: 49, width: 30, height: 40
-        });
-      });
-
-      it('should return node bounds relative to the component, excluding any transform', () => {
-        const bounds = {
-          x: 10, y: 20, width: 30, height: 40
-        };
-        const rect = createRect({ ...bounds, transform: 'translate(5, 15)' });
-        rect.resolveLocalTransform();
-        sceneNode = create(rect);
-        sceneNode.element = {
-          getBoundingClientRect: () => ({
-            left: 11,
-            top: 22
-          })
-        };
-        expect(sceneNode.boundsRelativeTo(compMock, false)).to.deep.equal({
-          x: 17.5, y: 34, width: 30, height: 40
-        });
-      });
-
-      it('should handle when element is not set', () => {
-        const bounds = {
-          x: 10, y: 20, width: 30, height: 40
-        };
-        nodeMock.boundingRect.returns(bounds);
-        sceneNode = create(nodeMock);
-        sceneNode.element = undefined;
-        expect(sceneNode.boundsRelativeTo(compMock)).to.deep.equal({
-          x: 6.5, y: 12, width: 30, height: 40
-        });
-      });
-    });
-
     describe('viewport', () => {
       it('should return node bounds relative to the viewport, including any transform', () => {
         const bounds = {

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -197,16 +197,14 @@ class SceneNode {
    * Bounding rectangle of the node, relative a target.
    *
    * If target is an HTMLElement, the bounds is relative to the HTMLElement.
-   * If target is a picasso component instance, the bounds is relative to that picasso component.
    * Any other target type will return the bounds reltive to the viewport of the browser.
    *
-   * @param {HTMLElement|Component|any} target
+   * @param {HTMLElement|any} target
    * @param {boolean} includeTransform - true will include any transform attribute on the node, false will not
    * @returns {rect}
    * @example
    *
    * node.boundsRelativeTo($('div'));
-   * node.boundsRelativeTo(chartInstace.component('<some-key>'))
    * node.boundsRelativeTo('viewport');
    */
   boundsRelativeTo(target, includeTransform = true) {
@@ -216,21 +214,10 @@ class SceneNode {
     let dx = selfRect.left;
     let dy = selfRect.top;
 
-    if (type === 'object' && target !== null) {
-      if (typeof target.getBoundingClientRect === 'function') {
-        const { left = 0, top = 0 } = target.getBoundingClientRect();
-        dx -= left;
-        dy -= top;
-      } else if (typeof target.rect === 'object') { // Picasso component
-        const {
-          x = 0,
-          y = 0,
-          margin = { left: 0, top: 0 },
-          scaleRatio = { x: 0, y: 0 }
-        } = target.rect;
-        dx -= margin.left + (x * scaleRatio.x);
-        dy -= margin.top + (y * scaleRatio.y);
-      }
+    if (type === 'object' && target !== null && typeof target.getBoundingClientRect === 'function') {
+      const { left = 0, top = 0 } = target.getBoundingClientRect();
+      dx -= left;
+      dy -= top;
     }
 
     bounds.x += dx;

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -200,7 +200,7 @@ class SceneNode {
    * Any other target type will return the bounds relative to the viewport of the browser.
    *
    * @param {HTMLElement|any} target
-   * @param {boolean} includeTransform - whether to include any applied transforms on the node
+   * @param {boolean} includeTransform - Whether to include any applied transforms on the node
    * @returns {rect}
    * @example
    *

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -196,11 +196,11 @@ class SceneNode {
   /**
    * Bounding rectangle of the node, relative a target.
    *
-   * If target is an HTMLElement, the bounds is relative to the HTMLElement.
-   * Any other target type will return the bounds reltive to the viewport of the browser.
+   * If target is an HTMLElement, the bounds are relative to the HTMLElement.
+   * Any other target type will return the bounds relative to the viewport of the browser.
    *
    * @param {HTMLElement|any} target
-   * @param {boolean} includeTransform - true will include any transform attribute on the node, false will not
+   * @param {boolean} includeTransform - whether to include any applied transforms on the node
    * @returns {rect}
    * @example
    *


### PR DESCRIPTION
Exposes a new method on the SceneNode that can be used to retrieve the bounding rectangle of the SceneNode relative to some target. Where the target may be a HTMLElement or the browser viewport.

**Usage**
```js
node.boundsRelativeTo($('div'));
node.boundsRelativeTo('viewport');
```