### PR TITLE
feat(q): add experimental virtual fields

### DIFF
--- a/docs/src/input/plugin-q.md
+++ b/docs/src/input/plugin-q.md
@@ -28,7 +28,8 @@ This dataset type understands the QIX hypercube format and its internals, making
 ```js
 const ds = picasso.data('q')({
   key: 'qHyperCube', // path to the hypercube from the layout
-  data: layout.qHyperCube
+  data: layout.qHyperCube,
+  config: { /* ... */ }
 });
 ```
 
@@ -37,6 +38,38 @@ Dimensions, measures, attribute expressions and attribute dimensions are all rec
 ```js
 const f = ds.field('Sales');
 const ff = ds.field('qDimensionInfo/1/qAttrDimInfo/2');
+```
+
+#### Config
+
+The `config` object allows for further configuration:
+
+- `config`: `<object>`
+  - `localeInfo`: <[LocaleInfo]> - App locale info used for formatting.
+  - `virtualFields`: `<Array<object>>` - Convenience config to alias fields. _Experimental_.
+    - `key`: `<string>` - Identifier for the field.
+    - `from`: `<string>` - Source field identifier.
+    - `override`: `<object>` - Override accessor inherited from source field.
+      - `value`: `<function>` - Value accessor.
+      - `label`: `<function>` - Label accessor.
+
+
+```js
+const ds = picasso.data('q')({
+  key: 'qHyperCube',
+  data: layout.qHyperCube,
+  config: {
+    virtualFields: [{
+      key: 'surpriseMe',
+      from: 'qMeasureInfo/0',
+      override: {
+        value: v => v.qValue * Math.random(),
+      }
+    }]
+  }
+});
+
+ds.field('surpriseMe').items(); // -> array of random numbers multiplied with the value from first measure
 ```
 
 ### Extracting data values
@@ -342,3 +375,9 @@ which results in `2 + 1 + 2 + 2 = 7`
 ## Formatting
 
 The `q` plugin comes bundled with a [formatter](formatters.md) attached the to data `field`. To use it, no configuration other then using the [q-dataset](plugin-q.md#q-dataset) is required.
+
+
+[LocaleInfo]: https://core.qlik.com/services/qix-engine/apis/qix/definitions/#localeinfo
+[object]: https://core.qlik.com/services/qix-engine/apis/qix/definitions/#localeinfo
+[string]: https://core.qlik.com/services/qix-engine/apis/qix/definitions/#localeinfo
+[function]: https://core.qlik.com/services/qix-engine/apis/qix/definitions/#localeinfo

--- a/plugins/q/src/data/__tests__/dataset.spec.js
+++ b/plugins/q/src/data/__tests__/dataset.spec.js
@@ -21,7 +21,7 @@ const NxTreeValue = {
 };
 const NxTreeNode = { qElemNo: 9, qText: 'nine', qValues: [{}, {}, NxTreeValue] };
 
-const ds = (qMode) => {
+const ds = (qMode, config = {}) => {
   const qDataPages = [{
     qArea: {
       qLeft: 0, qTop: 0, qWidth: 4, qHeight: 1
@@ -86,7 +86,8 @@ const ds = (qMode) => {
     config: {
       localeInfo: {
         qDecimalSep: '_'
-      }
+      },
+      ...config
     }
   });
 
@@ -150,6 +151,31 @@ describe('q-data', () => {
     it('bad cube should throw', () => {
       const d = () => q({ data: {} });
       expect(d).throw('The "data" input is not recognized as a hypercube');
+    });
+  });
+
+  describe('virtualFields', () => {
+    let d;
+    beforeEach(() => {
+      d = ds('S', {
+        virtualFields: [{
+          key: 'temporal',
+          from: 'qMeasureInfo/2',
+          override: {
+            value: '3'
+          }
+        }]
+      });
+    });
+
+    it('should be found', () => {
+      const f = d.field('temporal');
+      expect(f.value).to.equal('3');
+      expect(f.key()).to.equal('temporal');
+    });
+
+    it('should have link to its origin', () => {
+      expect(d.field('temporal').origin().key()).to.equal('qMeasureInfo/2');
     });
   });
 

--- a/plugins/q/src/data/__tests__/extractor-s.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-s.spec.js
@@ -750,5 +750,16 @@ describe('extractor-s', () => {
       }, { cache: localCache });
       expect(acc(row)).to.equal('exp');
     });
+
+    it('should return origin field accessor for virtual field', () => {
+      const f = {
+        origin: () => localCache.fields[2]
+      };
+      const row = ['a', 'b'];
+      const acc = getFieldAccessor(f, {
+        qArea: { qLeft: 1 }
+      }, { cache: localCache });
+      expect(acc(row)).to.equal('b');
+    });
   });
 });

--- a/plugins/q/src/data/__tests__/extractor-t.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-t.spec.js
@@ -1,4 +1,7 @@
-import { extract } from '../extractor-t';
+import {
+  extract,
+  getFieldDepth
+} from '../extractor-t';
 
 import {
   getPropsInfo,
@@ -374,6 +377,28 @@ describe('q-data-extractor-t', () => {
     };
 
     dataset.field.withArgs('qDimensionInfo/1/qAttrExprInfo/0').returns(attrExprField);
+
+    it('should return origin field depth for virtual field', () => {
+      const origin = {
+        key: () => 'qDimensionInfo/1'
+      };
+      const f = {
+        origin: () => origin
+      };
+      const depth = getFieldDepth(f, {
+        cube: {
+          qEffectiveInterColumnSortOrder: [2, 0, 1],
+          qDimensionInfo: [{}, {}, {}]
+        }
+      });
+      expect(depth).to.eql({
+        fieldDepth: 3,
+        pseudoMeasureIndex: -1,
+        measureIdx: -1,
+        attrDimIdx: -1,
+        attrIdx: -1
+      });
+    });
 
     it('should return empty array when root node is missing or empty', () => {
       const m = extract({

--- a/plugins/q/src/data/extractor-s.js
+++ b/plugins/q/src/data/extractor-s.js
@@ -7,6 +7,10 @@ export function getFieldAccessor(field, page, deps) {
     return -1;
   }
   const cache = deps.cache;
+  const origin = field.origin ? field.origin() : null;
+  if (origin) {
+    field = origin;
+  }
   let fieldIdx = cache.fields.indexOf(field);
   let attrIdx = -1;
   let attrDimIdx = -1;

--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -28,7 +28,8 @@ export function getFieldDepth(field, { cube }) {
   if (!field) {
     return -1;
   }
-  let key = field.key();
+
+  let key = field.origin && field.origin() ? field.origin().key() : field.key();
   let isFieldDimension = false;
   let fieldIdx = -1; // cache.fields.indexOf(field);
   let attrIdx = -1;

--- a/plugins/q/src/data/field.js
+++ b/plugins/q/src/data/field.js
@@ -7,7 +7,8 @@ export default function qField({
   localeInfo,
   fieldExtractor,
   value,
-  type
+  type,
+  sourceField
 } = {}) {
   let values;
 
@@ -23,6 +24,7 @@ export default function qField({
     raw: () => meta,
     title: () => meta.qFallbackTitle || meta.label,
     type: () => type,
+    origin: () => sourceField,
     items: () => {
       if (!values) {
         values = fieldExtractor(f);


### PR DESCRIPTION
Adds experimental support for virtual fields:

```js
const ds = picasso.data('q')({
  key: 'qHyperCube',
  data: layout.qHyperCube,
  config: {
    virtualFields: [{
      key: 'surpriseMe',
      from: 'qMeasureInfo/0',
      override: {
        value: v => v.qValue * Math.random(),
      }
    }]
  }
});

ds.field('surpriseMe').items(); // -> array of random numbers multiplied with the value from first measure
```