### PR TITLE
fix(label): take orientation into account when checking label visibility

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars-overlapping-filter.js
@@ -1,5 +1,4 @@
 import { testRectRect } from '../../../math/narrow-phase-collision';
-import { rectContainsRect } from '../../../math/intersection';
 
 /**
  * Using the basic example found here: https://en.wikipedia.org/wiki/Binary_search_algorithm
@@ -53,8 +52,8 @@ findLeft = binaryLeftSearch) {
   return (doNotUse, labelIndex) => {
     const { textBounds: labelBounds, node: labelNode } = labels[labelIndex];
 
-    // ### Test if label is not fully inside container ###
-    if (!rectContainsRect(labelBounds, container)) {
+    // ### Test if label is not fully inside container based on the orientation ###
+    if (labelBounds[coord] < container[coord] || labelBounds[coord] + labelBounds[side] > container[coord] + container[side]) {
       return false;
     }
 


### PR DESCRIPTION
When a label is created through approxTextBounds function in bars.js, we add a padding 8 pixels to the width and the height which can make the label is not fully inside the container. This happens when a label is at the top of a bar and it is not shown up because it is not fully inside the container. What we need to check is if the label is fully inside the container only in the orientation of the chart.