### PR TITLE
fix: update component config

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -185,8 +185,8 @@ function componentFactory(definition, context = {}) {
     theme,
     renderer // Used by tests
   } = context;
-  const config = context.settings || {};
   const emitter = EventEmitter.mixin({});
+  let config = context.settings || {};
   let settings = extend(true, {}, defaultSettings, config);
   let data = [];
   let scale;
@@ -302,6 +302,7 @@ function componentFactory(definition, context = {}) {
   // Set new settings - will trigger mapping of data and creation of scale / formatter.
   fn.set = (opts = {}) => {
     if (opts.settings) {
+      config = opts.settings;
       settings = extend(true, {}, defaultSettings, opts.settings);
       dockConfig = createDockConfig(createDockDefinition(settings, preferredSize), dockConfigCallbackContext);
     }


### PR DESCRIPTION
This solves an issue when `preferredSize` has been updated in a component definition but the component keeps using the `preferredSize` specified in the initial definition.

This solution updated the config object in the `component-factory` when a component is updated. It might not be the optimal solution, or it may have unexpected effects... What do you guys think, @miralemd, @cbt1 ?