### PR TITLE
Change line 108

### DIFF
--- a/docs/src/input/component-labels.md
+++ b/docs/src/input/component-labels.md
@@ -105,7 +105,7 @@ components: [
               },
               placements: [
                 {
-                  position: 'info',
+                  position: 'into',
                   fill: ({ data }) => { return '#333'; } // select a color contrasting the containing slice
                 }
               ]


### PR DESCRIPTION
Change info to into for the labels on a pie


**Checklist**

- position: 'into' - its a typo error. Changed 'info' to 'into'
- Yes
- docs/src/input/component-labels.md
