### PR TITLE
fix: keep track of element order

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
@@ -106,6 +106,9 @@ const component = {
     if (renderElement && renderElement.parentNode) {
       this.navigationRenderer.renderer.appendTo(renderElement.parentNode);
       this.titleRenderer.renderer.appendTo(renderElement.parentNode);
+
+      renderElement.parentNode.insertBefore(this.navigationRenderer.renderer.element(), renderElement);
+      renderElement.parentNode.insertBefore(this.titleRenderer.renderer.element(), renderElement);
     }
     this.navigationRenderer.render({
       rect: this.state.views.layout.navigation,
@@ -188,6 +191,12 @@ const component = {
   beforeDestroy() {
     this.navigationRenderer.renderer.destroy();
     this.titleRenderer.renderer.destroy();
+  },
+  additionalElements() {
+    return [
+      this.titleRenderer.renderer.element(),
+      this.navigationRenderer.renderer.element()
+    ];
   },
   _DO_NOT_USE_getInfo() {
     return {

--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -1,6 +1,6 @@
 import componentFactoryFixture from '../../../../test/helpers/component-factory-fixture';
 import elementMock from 'test-utils/mocks/element-mock';
-import chart from '..';
+import chart, { orderComponents } from '..';
 
 describe('Chart', () => {
   describe('lifecycle methods', () => {
@@ -166,6 +166,47 @@ describe('Chart', () => {
       chartInstance.update({ partialData: true, excludeFromUpdate: ['comp1'] });
       expect(comp1UpdatedCb).to.have.been.calledTwice;
       expect(comp2UpdatedCb).to.have.been.calledTwice;
+    });
+  });
+
+  describe('orderComponents', () => {
+    let visible;
+    let el;
+    beforeEach(() => {
+      const sub = ['b-1', 'b-2'].map(elementMock);
+      visible = ['a', 'b', 'c'].map(elementMock).map(e => ({
+        instance: {
+          renderer: () => ({
+            element: () => e
+          }),
+          def: {
+            additionalElements: e.name === 'b' ? () => sub : undefined
+          }
+        }
+      }));
+      el = elementMock('div');
+    });
+
+    it('should inject missing elements', () => {
+      orderComponents(el, visible);
+      let order = el.children.map(e => e.name);
+      expect(order).to.eql(['a', 'b-1', 'b-2', 'b', 'c']);
+    });
+
+    it('should re-order existing elements', () => {
+      orderComponents(el, visible); // initial will inject children into el
+
+      orderComponents(el, visible); // re-order when el is already populated
+      const order = el.children.map(e => e.name);
+      expect(order).to.eql(['a', 'b-1', 'b-2', 'b', 'c']);
+    });
+
+    it('should re-order existing elements with explicit order', () => {
+      orderComponents(el, visible); // initial will inject children into el
+
+      orderComponents(el, visible, [2, 0, 1]); // re-order when el is already populated
+      const order = el.children.map(e => e.name);
+      expect(order).to.eql(['b-1', 'b-2', 'b', 'c', 'a']);
     });
   });
 });

--- a/packages/picasso.js/src/core/dock-layout/dock-layout.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-layout.js
@@ -232,6 +232,7 @@ function positionComponents(components, logicalContainerRect, reducedRect, conta
 
   const referencedComponents = {};
   const referenceArray = components.slice();
+  const elementOrder = referenceArray.slice().sort((a, b) => a.config.displayOrder() - b.config.displayOrder());
   components.sort((a, b) => {
     if (b.referencedDocks.length > 0) {
       return -1;
@@ -317,6 +318,8 @@ function positionComponents(components, logicalContainerRect, reducedRect, conta
     c.instance.resize(rect, outerRect, logicalContainerRect);
     c.cachedSize = undefined;
   });
+
+  return components.map(c => elementOrder.indexOf(c));
 }
 
 function checkShowSettings(components, hiddenComponents, settings, logicalContainerRect) {
@@ -393,9 +396,10 @@ export default function dockLayout(initialSettings) {
     const [logicalContainerRect, containerRect] = resolveLayout(container, settings);
     checkShowSettings(components, hiddenComponents, settings, logicalContainerRect);
     const reduced = reduceLayoutRect(logicalContainerRect, components, hiddenComponents, settings);
-    positionComponents(components, logicalContainerRect, reduced, containerRect);
+    const order = positionComponents(components, logicalContainerRect, reduced, containerRect);
     return {
       visible: components.map(c => c.instance),
+      order,
       hidden: hiddenComponents
     };
   };

--- a/packages/test-utils/mocks/element-mock.js
+++ b/packages/test-utils/mocks/element-mock.js
@@ -46,6 +46,13 @@ function element(name, rect = { x: 0, y: 0, width: 100, height: 100 }) {
       el.parentNode = null;
       el.parentElement = this;
     },
+    insertBefore(el, ref) {
+      const idx = this.children.indexOf(el);
+      if (idx !== -1 && el !== ref) {
+        this.children.splice(idx, 1);
+      }
+      this.children.splice(this.children.indexOf(ref), el === ref ? 1 : 0, el);
+    },
     addEventListener(key, val) {
       const obj = {};
       obj[key] = val;


### PR DESCRIPTION
This makes sure components that have manually injected elements are tracked and ordered according to component order.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
