### PR TITLE
perf(canvas-renderer): set text context only when needed

### DIFF
--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/text.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/text.js
@@ -4,11 +4,17 @@ import { detectTextDirection, flipTextAnchor } from '../../../../core/utils/rtl-
 
 export default function render(t, { g }) {
   const text = ellipsText(t, measureText);
-
   g.font = `${t['font-size']} ${t['font-family']}`;
-  g.canvas.dir = detectTextDirection(t.text);
-  const textAlign = t['text-anchor'] === 'middle' ? 'center' : t['text-anchor'];
-  g.textAlign = flipTextAnchor(textAlign, g.canvas.dir);
+
+  const dir = detectTextDirection(t.text);
+  if (g.canvas.dir !== dir) {
+    g.canvas.dir = dir;
+  }
+  const textAnchor = t['text-anchor'] === 'middle' ? 'center' : t['text-anchor'];
+  const textAlign = flipTextAnchor(textAnchor, g.canvas.dir);
+  if (textAlign && g.textAlign !== textAlign) {
+    g.textAlign = textAlign;
+  }
 
   const bdy = baselineHeuristic(t);
 


### PR DESCRIPTION
Changing canvas state is expensive. This PR attempts to reduce the number of changes required by checking new value vs current value.

The `dir` is not stored on canvas context and as such not stored when `save()` method is called, the value should under normal circumstance not change after the initial set.

`textAlign` is however stored by calling `save()`. This should mean that it's only applicable if the value is equal to the default value "start".