### PR TITLE
feat(grid-lines): support callbacks in grid-line settings

### DIFF
--- a/packages/picasso.js/src/core/chart-components/grid/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/grid/__tests__/line.spec.js
@@ -210,4 +210,43 @@ describe('line component', () => {
 
     expect(rendererOutput).to.deep.equal([]);
   });
+
+  it('should render minorTicks with correct color', () => {
+    const config = {
+      shapeFn,
+      x: { scale: 'x' },
+      y: { scale: 'y' },
+      ticks: {
+        stroke: t => (t.data.dir === 'x' ? 'red' : 'blue')
+      }
+    };
+
+    componentFixture.simulateCreate(lineComponent, config);
+    rendererOutput = componentFixture.simulateRender(opts);
+
+    expect(rendererOutput).to.deep.equal([
+      {
+        stroke: 'red',
+        strokeWidth: 1,
+        strokeDasharray: undefined,
+        type: 'line',
+        flipXY: false,
+        x1: 49.5,
+        x2: 49.5,
+        y1: -0.5,
+        y2: 199.5
+      },
+      {
+        stroke: 'blue',
+        strokeWidth: 1,
+        strokeDasharray: undefined,
+        type: 'line',
+        flipXY: true,
+        x1: -0.5,
+        x2: 99.5,
+        y1: 99.5,
+        y2: 99.5
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
use settings-resolver

ex:
ticks: {
  show: (t, ix) => ix % 2 == 0, // show every other line
  stroke: t => t.data.dir === 'x' ? 'red' : 'blue' // color depending on direction
},


**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
