### PR TITLE
feat(axis): add tiltThreshold

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.19.0",
+    "version": "0.21.0",
     "license": "MIT"
   },
   "entries": {
@@ -1214,6 +1214,13 @@
               "description": "Tilting angle in degrees. Capped between -90 and 90. Only applicable when labels are in `tilted` mode.",
               "optional": true,
               "defaultValue": 40,
+              "type": "number"
+            },
+            "tiltThreshold": {
+              "description": "Threshold for toggle of tilted labels. Capped between 0 and 1. For example, if it is set to 0.7, then tilted labels will be toggled if less than 70% of the labels are visible.",
+              "stability": "experimental",
+              "optional": true,
+              "defaultValue": 0.7,
               "type": "number"
             },
             "maxEdgeBleed": {

--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-size-calculator.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-size-calculator.spec.js
@@ -165,6 +165,21 @@ describe('Axis size calculator', () => {
         expect(state.labels.activeMode).to.equals('tilted');
       });
 
+      it('should switch to tilted orientation if tiltThreshold is set to 1', () => {
+        settings.dock = 'bottom';
+        settings.align = 'bottom';
+        settings.labels.show = true;
+        settings.labels.mode = 'auto';
+        rect.width = 5;
+        state.labels.activeMode = 'horizontal';
+        settings.labels.tiltThreshold = 1;
+        isDiscrete = true;
+
+        sizeFn(rect);
+
+        expect(state.labels.activeMode).to.equals('tilted');
+      });
+
       it('should if set use maxGlyphCount to determine if horizontal size limit is reached', () => {
         settings.dock = 'bottom';
         settings.align = 'bottom';

--- a/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
@@ -27,6 +27,10 @@ const DEFAULT_DISCRETE_SETTINGS = {
     /** Tilting angle in degrees. Capped between -90 and 90. Only applicable when labels are in `tilted` mode.
     * @type {number=} */
     tiltAngle: 40,
+    /** Threshold for toggle of tilted labels. Capped between 0 and 1. For example, if it is set to 0.7, then tilted labels will be toggled if less than 70% of the labels are visible.
+    * @type {number=}
+    * @experimental */
+    tiltThreshold: 0.7,
     /** Control the amount of space (in pixels) that labes can occupy outside their docking area. Only applicable when labels are in `tilted` mode.
     * @type {number=} */
     maxEdgeBleed: Infinity,

--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -59,7 +59,7 @@ function shouldAutoTilt({
 }) {
   const glyphCount = settings.labels.maxGlyphCount;
   const m = state.labels.activeMode === 'layered' ? 2 : 1;
-  const magicSizeRatioMultipler = 0.7; // So that if less the 70% of labels are visible, toggle on tilt
+  const magicSizeRatioMultipler = settings.labels.tiltThreshold ? settings.labels.tiltThreshold : 0.7; // So that if less the 70% of labels are visible, toggle on tilt or use variable tiltThreshold
   const ellipsCharSize = measure('…').width; // include ellipsed char in calc as it's generally large then the char it replaces
   const size = rect.width;
   let maxLabelWidth = 0;


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

- Gives the user the ability to set the tilt threshold of axis labels.

Usage 

```js

// Inside the axis component
{
  type: 'axis',
  scale: 'myDiscreteScale',
  dock: 'bottom'
  settings: {
    labels: {
          mode: 'auto',
	  tiltThreshold: 0.9 // Toggle on tilt, if less than 90% of the labels are visible
    }
  }
}
```
