### PR TITLE
fix(tooltip): scaling when using appendTo

### DIFF
--- a/packages/picasso.js/src/web/components/tooltip/__tests__/tooltip.spec.js
+++ b/packages/picasso.js/src/web/components/tooltip/__tests__/tooltip.spec.js
@@ -216,7 +216,7 @@ describe('Tooltip', () => {
         x: 0,
         y: 0,
         width: 100,
-        height: 100,
+        height: 50,
         scaleRatio: { x: 0, y: 0 }
       };
 
@@ -229,6 +229,7 @@ describe('Tooltip', () => {
       componentFixture.simulateRender({ inner: container, outer: container });
 
       expect(stub).to.have.been.called;
+      expect(componentFixture.mocks().renderer.size).to.have.been.calledWith({ width: 100, height: 50 });
     });
 
     it('should apply appendTo on updated', () => {
@@ -237,6 +238,7 @@ describe('Tooltip', () => {
       componentFixture.simulateUpdate(config);
 
       expect(stub).to.have.been.called;
+      expect(componentFixture.mocks().renderer.size).to.have.been.calledWith({ width: 100, height: 50 });
     });
   });
 });

--- a/packages/picasso.js/src/web/components/tooltip/tooltip.js
+++ b/packages/picasso.js/src/web/components/tooltip/tooltip.js
@@ -364,14 +364,9 @@ const component = {
           scale: this.chart.scale
         }
       }) : this.props.appendTo;
-      const bounds = this.state.targetElement.getBoundingClientRect();
-      const size = {
-        width: bounds.width,
-        height: bounds.height,
-        scaleRatio: this.renderer.size().scaleRatio
-      };
+      const { width, height } = this.state.targetElement.getBoundingClientRect();
       this.renderer.destroy();
-      this.rect = this.renderer.size(size);
+      this.rect = this.renderer.size({ width, height });
       this.renderer.appendTo(this.state.targetElement);
     } else {
       this.state.targetElement = this.renderer.element();


### PR DESCRIPTION
Fixes an issue where the tooltip would become really small if the chart was scaled down. This changes so that the tooltip root element will be the same size as the appendTo element.