### PR TITLE
fix: only move elements that have new position

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -81,9 +81,10 @@ const moveToPosition = (element, comp, index) => {
   const nodes = element.children;
   const i = Math.max(0, index);
   const node = nodes[i];
+  if (el === node) { return; }
   const additionalEl = comp.instance.def.additionalElements && comp.instance.def.additionalElements().filter(Boolean);
   if (element.insertBefore && typeof node !== 'undefined') {
-    element.insertBefore(el, nodes[i]);
+    element.insertBefore(el, node);
     if (additionalEl) {
       additionalEl.forEach((ae) => {
         element.insertBefore(ae, el);


### PR DESCRIPTION
IE11 throws "Unspecified error" when trying to insert an element before itself when it has the property `_reactRootContainer` (which contains DOM references).