### PR TITLE
fix(dock-layout): floor instead of ceil when rounding container values

### DIFF
--- a/packages/picasso.js/src/core/dock-layout/dock-settings-resolver.js
+++ b/packages/picasso.js/src/core/dock-layout/dock-settings-resolver.js
@@ -1,10 +1,10 @@
 import extend from 'extend';
 
 function roundRect(rect) {
-  rect.x = Math.ceil(rect.x);
-  rect.y = Math.ceil(rect.y);
-  rect.width = Math.ceil(rect.width);
-  rect.height = Math.ceil(rect.height);
+  rect.x = Math.floor(rect.x);
+  rect.y = Math.floor(rect.y);
+  rect.width = Math.floor(rect.width);
+  rect.height = Math.floor(rect.height);
 }
 
 function getRect(container, settings) {


### PR DESCRIPTION
Ceiling lead to components using more space than available in certain scenarios.