### PR TITLE
fix(axis): ellipsis threshold for continuous horizontal axis

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-label-node.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-label-node.spec.js
@@ -261,7 +261,6 @@ describe('Axis Label Node', () => {
         tick = createTick(0, 0);
         expected.x = 0;
         expected.anchor = 'start';
-        expected.maxWidth *= 0.75;
         expect(buildLabel(tick, buildOpts)).to.deep.include(expected);
       });
 
@@ -276,7 +275,6 @@ describe('Axis Label Node', () => {
         tick = createTick(1, 1);
         expected.x = 50;
         expected.anchor = 'end';
-        expected.maxWidth *= 0.75;
         expect(buildLabel(tick, buildOpts)).to.deep.include(expected);
       });
 
@@ -304,7 +302,6 @@ describe('Axis Label Node', () => {
         tick = createTick(0, 0);
         expected.x = 0;
         expected.anchor = 'start';
-        expected.maxWidth *= 0.75;
         expect(buildLabel(tick, buildOpts)).to.deep.include(expected);
       });
 
@@ -319,7 +316,6 @@ describe('Axis Label Node', () => {
         tick = createTick(1, 1);
         expected.x = 50;
         expected.anchor = 'end';
-        expected.maxWidth *= 0.75;
         expect(buildLabel(tick, buildOpts)).to.deep.include(expected);
       });
 

--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/get-continuous-label-rect.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/get-continuous-label-rect.spec.js
@@ -1,0 +1,118 @@
+import getHorizontalWidth from '../get-continuous-label-rect';
+
+describe('axis - get horizontal continuous label width', () => {
+  let opts;
+  let width;
+
+  beforeEach(() => {
+    opts = {
+      major: [],
+      innerRect: { x: 0, width: 100 },
+      outerRect: { x: 0, width: 100 },
+      tick: { position: 0 },
+      layered: false,
+      index: 0
+    };
+  });
+
+  describe('Case 1 - Less than 2 ticks', () => {
+    it('should return inner rect width', () => {
+      opts.major = [1];
+      opts.outerRect.width = 200;
+      width = getHorizontalWidth(opts);
+
+      expect(width).to.eql(opts.innerRect.width);
+    });
+  });
+
+  describe('Case 2 - Is first or last tick', () => {
+    describe('first tick', () => {
+      it('double distance to neighbouring tick is less than available edge bleed', () => {
+        const tick = { position: 0.0 };
+        opts.innerRect.x = 100; // 100 px edge bleed
+        opts.major = [tick, { position: 0.2 }]; // 20 px between ticks
+        opts.index = 0;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.eql(16);
+      });
+
+      it('distance to neighbouring tick is greater than double available edge bleed', () => {
+        const tick = { position: 0.0 };
+        opts.innerRect.x = 1; // 1 px edge bleed
+        opts.major = [tick, { position: 0.2 }]; // 20 px between ticks
+        opts.index = 0;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.eql(8);
+      });
+
+      it('double distance of edge bleed is greater than distance to neighbouring tick', () => {
+        const tick = { position: 0.1 };
+        opts.innerRect.x = 5; // 15 px edge bleed
+        opts.major = [tick, { position: 0.5 }]; // 40 px between ticks
+        opts.index = 0;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.eql(30);
+      });
+    });
+
+    describe('last tick', () => {
+      it('double distance to neighbouring tick is less than available edge bleed', () => {
+        const tick = { position: 1 };
+        opts.outerRect.width = 200; // 100 px edge bleed
+        opts.major = [{ position: 0.8 }, tick]; // 20 px between ticks
+        opts.index = 1;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.be.closeTo(16, 0.1);
+      });
+
+      it('distance to neighbouring tick is greater than double available edge bleed', () => {
+        const tick = { position: 1 };
+        opts.outerRect.width = 101; // 1 px edge bleed
+        opts.major = [{ position: 0.8 }, tick]; // 20 px between ticks
+        opts.index = 1;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.be.closeTo(8, 0.1);
+      });
+
+      it('double distance of edge bleed is greater than distance to neighbouring tick', () => {
+        const tick = { position: 0.9 };
+        opts.outerRect.width = 105; // 15 px edge bleed
+        opts.major = [{ position: 0.5 }, tick]; // 40 px between ticks
+        opts.index = 1;
+        opts.tick = tick;
+
+        width = getHorizontalWidth(opts);
+
+        expect(width).to.eql(30);
+      });
+    });
+  });
+
+  describe('Case 3 - Default', () => {
+    it('should return the shortest distance', () => {
+      const tick = { position: 0.5 };
+      opts.major = [{ position: 0.1 }, tick, { position: 0.7 }]; // 40 and 20 px between ticks
+      opts.index = 1;
+      opts.tick = tick;
+
+      width = getHorizontalWidth(opts);
+
+      expect(width).to.be.closeTo(16, 0.1);
+    });
+  });
+});

--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-node.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-node.js
@@ -15,21 +15,18 @@ function clampEnds(struct, buildOpts) {
     return;
   }
 
-  const outerBoundaryMultipler = 0.5;
   if (buildOpts.align === 'top' || buildOpts.align === 'bottom') {
     const leftBoundary = 0;
     const rightBoundary = buildOpts.outerRect.width;
-    const textWidth = Math.min((buildOpts.maxWidth * outerBoundaryMultipler) / 2, buildOpts.textRect.width / 2);
+    const textWidth = Math.min(buildOpts.maxWidth / 2, buildOpts.textRect.width / 2);
     const leftTextBoundary = struct.x - textWidth;
     const rightTextBoundary = struct.x + textWidth;
     if (leftTextBoundary < leftBoundary) {
       struct.anchor = 'start';
       struct.x = buildOpts.innerRect.x - buildOpts.outerRect.x;
-      struct.maxWidth *= outerBoundaryMultipler;
     } else if (rightTextBoundary > rightBoundary) {
       struct.anchor = 'end';
       struct.x = buildOpts.innerRect.width + buildOpts.innerRect.x;
-      struct.maxWidth *= outerBoundaryMultipler;
     }
   } else {
     const topBoundary = 0;

--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-node.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-node.js
@@ -15,7 +15,7 @@ function clampEnds(struct, buildOpts) {
     return;
   }
 
-  const outerBoundaryMultipler = 0.75;
+  const outerBoundaryMultipler = 0.5;
   if (buildOpts.align === 'top' || buildOpts.align === 'bottom') {
     const leftBoundary = 0;
     const rightBoundary = buildOpts.outerRect.width;

--- a/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
@@ -140,6 +140,7 @@ function discreteCalcMaxTextRect({
 function continuousCalcMaxTextRect({
   measureText, settings, innerRect, ticks, tilted, layered
 }) {
+  const PADDING = 0;
   const h = measureText({
     text: 'M',
     fontSize: settings.labels.fontSize,
@@ -150,12 +151,12 @@ function continuousCalcMaxTextRect({
   if (settings.align === 'left' || settings.align === 'right') {
     textRect.width = innerRect.width - labelsSpacing(settings) - settings.paddingEnd;
   } else if (layered) {
-    textRect.width = (innerRect.width / majorTicks(ticks).length) * 0.75 * 2;
+    textRect.width = ((innerRect.width / majorTicks(ticks).length) * 2) - PADDING;
   } else if (tilted) {
     const radians = Math.abs(settings.labels.tiltAngle) * (Math.PI / 180);
     textRect.width = (innerRect.height - labelsSpacing(settings) - settings.paddingEnd - (h * Math.cos(radians))) / Math.sin(radians);
   } else {
-    textRect.width = (innerRect.width / majorTicks(ticks).length) * 0.75;
+    textRect.width = (innerRect.width / majorTicks(ticks).length) - PADDING;
   }
 
   textRect.width = getClampedValue({ value: textRect.width, maxValue: settings.labels.maxLengthPx, minValue: settings.labels.minLengthPx });

--- a/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
@@ -5,6 +5,7 @@ import {
   testRectRect
 } from '../../math/narrow-phase-collision';
 import { getClampedValue } from './axis-label-size';
+import getHorizontalContinuousWidth from './get-continuous-label-rect';
 
 function tickSpacing(settings) {
   let spacing = 0;
@@ -49,23 +50,23 @@ function tickBandwidth(scale, tick) {
   return tick ? Math.abs(tick.end - tick.start) : scale.bandwidth();
 }
 
-function labelBuilder(ticks, buildOpts, tickFn) {
-  return ticks.map((tick) => {
-    tickFn(tick);
+function labelBuilder(ticks, buildOpts, resolveTickOpts) {
+  return ticks.map((tick, idx) => {
+    resolveTickOpts(tick, idx);
     const label = buildLabel(tick, buildOpts);
     label.data = tick.data;
     return label;
   });
 }
 
-function layeredLabelBuilder(ticks, buildOpts, settings, tickFn) {
+function layeredLabelBuilder(ticks, buildOpts, settings, resolveTickOpts) {
   const padding = buildOpts.padding;
   const spacing = labelsSpacing(settings);
-  return ticks.map((tick, i) => {
-    tickFn(tick);
+  return ticks.map((tick, idx) => {
+    resolveTickOpts(tick, idx);
     const padding2 = spacing + buildOpts.maxHeight + settings.labels.margin;
-    buildOpts.layer = i % 2;
-    buildOpts.padding = i % 2 === 0 ? padding : padding2;
+    buildOpts.layer = idx % 2;
+    buildOpts.padding = idx % 2 === 0 ? padding : padding2;
     const label = buildLabel(tick, buildOpts);
     label.data = tick.data;
     return label;
@@ -138,9 +139,8 @@ function discreteCalcMaxTextRect({
 }
 
 function continuousCalcMaxTextRect({
-  measureText, settings, innerRect, ticks, tilted, layered
+  measureText, settings, innerRect, outerRect, tilted, layered, tick, index, major
 }) {
-  const PADDING = 0;
   const h = measureText({
     text: 'M',
     fontSize: settings.labels.fontSize,
@@ -150,13 +150,18 @@ function continuousCalcMaxTextRect({
   const textRect = { width: 0, height: h };
   if (settings.align === 'left' || settings.align === 'right') {
     textRect.width = innerRect.width - labelsSpacing(settings) - settings.paddingEnd;
-  } else if (layered) {
-    textRect.width = ((innerRect.width / majorTicks(ticks).length) * 2) - PADDING;
   } else if (tilted) {
     const radians = Math.abs(settings.labels.tiltAngle) * (Math.PI / 180);
     textRect.width = (innerRect.height - labelsSpacing(settings) - settings.paddingEnd - (h * Math.cos(radians))) / Math.sin(radians);
   } else {
-    textRect.width = (innerRect.width / majorTicks(ticks).length) - PADDING;
+    textRect.width = getHorizontalContinuousWidth({
+      layered,
+      major,
+      innerRect,
+      outerRect,
+      tick,
+      index
+    });
   }
 
   textRect.width = getClampedValue({ value: textRect.width, maxValue: settings.labels.maxLengthPx, minValue: settings.labels.minLengthPx });
@@ -173,15 +178,15 @@ function getStepSizeFn({
 }
 
 export default function nodeBuilder(isDiscrete) {
-  let calcMaxTextRectFn;
+  let resolveLabelRect;
 
   function continuous() {
-    calcMaxTextRectFn = continuousCalcMaxTextRect;
+    resolveLabelRect = continuousCalcMaxTextRect;
     return continuous;
   }
 
   function discrete() {
-    calcMaxTextRectFn = discreteCalcMaxTextRect;
+    resolveLabelRect = discreteCalcMaxTextRect;
     return discrete;
   }
 
@@ -222,13 +227,13 @@ export default function nodeBuilder(isDiscrete) {
       buildOpts.angle = settings.labels.tiltAngle;
       buildOpts.paddingEnd = settings.paddingEnd;
       buildOpts.textBounds = textBounds;
-      const tickFn = (tick) => {
-        const maxSize = calcMaxTextRectFn({
-          measureText, settings, innerRect, ticks, scale, tilted, layered, tick
+      const resolveTickOpts = (tick, index) => {
+        buildOpts.textRect = calcActualTextRect({ tick, measureText, style: buildOpts.style });
+        const maxSize = resolveLabelRect({
+          measureText, settings, innerRect, outerRect, scale, tilted, layered, tick, major, index
         });
         buildOpts.maxWidth = maxSize.width;
         buildOpts.maxHeight = maxSize.height;
-        buildOpts.textRect = calcActualTextRect({ tick, measureText, style: buildOpts.style });
         buildOpts.stepSize = getStepSizeFn({
           innerRect, scale, ticks, settings, tick
         });
@@ -236,9 +241,9 @@ export default function nodeBuilder(isDiscrete) {
 
       let labelNodes = [];
       if (layered && (settings.align === 'top' || settings.align === 'bottom')) {
-        labelNodes = layeredLabelBuilder(major, buildOpts, settings, tickFn);
+        labelNodes = layeredLabelBuilder(major, buildOpts, settings, resolveTickOpts);
       } else {
-        labelNodes = labelBuilder(major, buildOpts, tickFn);
+        labelNodes = labelBuilder(major, buildOpts, resolveTickOpts);
       }
 
       // Remove labels (and paired tick) that are overlapping

--- a/packages/picasso.js/src/core/chart-components/axis/get-continuous-label-rect.js
+++ b/packages/picasso.js/src/core/chart-components/axis/get-continuous-label-rect.js
@@ -1,0 +1,68 @@
+const tickDistance = (rect, start, end) => rect.width * Math.abs(start.position - end.position);
+
+const getLeftEdgeWidth = ({
+  innerRect,
+  outerRect,
+  tick,
+  nextWidth
+}) => {
+  const leftEdgeBleed = innerRect.x - outerRect.x;
+  const left = (innerRect.width * tick.position) + leftEdgeBleed;
+  const minDubble = Math.min(nextWidth, left) * 2;
+
+  return Math.max(nextWidth, minDubble);
+};
+
+const getRightEdgeWidth = ({
+  innerRect,
+  outerRect,
+  tick,
+  prevWidth
+}) => {
+  const leftEdgeBleed = innerRect.x - outerRect.x;
+  const rightEdgeBleed = (outerRect.width - innerRect.width) - leftEdgeBleed;
+  const right = (innerRect.width - (innerRect.width * tick.position)) + rightEdgeBleed;
+  const minDubble = Math.min(prevWidth, right) * 2;
+
+  return Math.max(prevWidth, minDubble);
+};
+
+export default function getHorizontalWidth({
+  layered,
+  major,
+  innerRect,
+  outerRect,
+  tick,
+  index
+}) {
+  const PADDING = 2;
+  const step = layered ? 2 : 1;
+  const prev = major[index - step];
+  const next = major[index + step];
+  const prevWidth = prev ? (tickDistance(innerRect, tick, prev) / 2) - PADDING : Infinity;
+  const nextWidth = next ? (tickDistance(innerRect, tick, next) / 2) - PADDING : Infinity;
+
+  if (major.length < 2) {
+    return innerRect.width;
+  }
+
+  if (!prev) {
+    return getLeftEdgeWidth({
+      innerRect,
+      outerRect,
+      tick,
+      nextWidth
+    });
+  }
+
+  if (!next) {
+    return getRightEdgeWidth({
+      innerRect,
+      outerRect,
+      tick,
+      prevWidth
+    });
+  }
+
+  return Math.min(prevWidth, nextWidth) * 2;
+}


### PR DESCRIPTION
Aims to fix an issue where a continuous horizontal axis would be far too strict in the amount of space available for labels to render. 

Also fixes an issue where labels at the ends would be partially clipped.

Before - All ticks share the same amount of possible space to occupy and the spacing scales with the size of the chart.
![Screenshot 2019-03-29 at 13 41 28](https://user-images.githubusercontent.com/16608020/55233289-6a791380-5228-11e9-8c97-abdf240d8f98.png)

After - The space for each tick is calculated individually and uses static padding between them.
![Screenshot 2019-03-29 at 13 41 41](https://user-images.githubusercontent.com/16608020/55233298-71078b00-5228-11e9-8aff-0dc833fdede1.png)

