### PR TITLE
fix(q-time-format): floating point precision

### DIFF
--- a/plugins/q/src/formatter/__tests__/timeFormat.spec.js
+++ b/plugins/q/src/formatter/__tests__/timeFormat.spec.js
@@ -367,7 +367,9 @@ describe('qlik timeFormat', () => {
       preNoon,
       noon,
       noon59,
-      noon60;
+      noon60,
+      roundingError1,
+      roundingError2;
     beforeEach(() => {
       n = timeFormat(null);
       midnight = 41753; // 00:00:00 -> 12:00:00 am
@@ -377,6 +379,8 @@ describe('qlik timeFormat', () => {
       noon = 41753.5; // 12:00:00 -> 12:00:00 pm
       noon59 = 41753.54098; // 12:59:00 -> 12:59:00 pm
       noon60 = 41753.54167; // 13:00:00 -> 1:00:00 pm
+      roundingError1 = 40039.229166666664;
+      roundingError2 = 40331.416666666664;
     });
 
     describe('Hours', () => {
@@ -402,6 +406,8 @@ describe('qlik timeFormat', () => {
         expect(n.format('h TT', noon)).to.equal('12 PM');
         expect(n.format('h tT', noon59)).to.equal('12 pP');
         expect(n.format('h Tt', noon60)).to.equal('1 Pp');
+        expect(n.format('hh:mm tt', roundingError1)).to.equal('05:30 am');
+        expect(n.format('hh:mm tt', roundingError2)).to.equal('10:00 am');
 
         expect(n.format('ttTTTttTt', noon)).to.equal('pmPMPpmPp');
       });
@@ -471,8 +477,8 @@ describe('qlik timeFormat', () => {
 
       // expect( n.format( new Date(Date.UTC( 2014, 0, 1, 13, 55, 30, 123 ), 'h:m:s[.ffff]' ) ).to.equal( '13:55.30.1230' ); // TODO?
 
-      expect(n.format('YYYY-MM-DD hh:mm:ss.ffff', d)).to.equal('2014-04-24 13:55:40.9870');
-      expect(n.format('DD/MM -YY h:m:s.fff TT', d)).to.equal('24/04 -14 1:55:40.987 PM');
+      expect(n.format('YYYY-MM-DD hh:mm:ss.ffff', d)).to.equal('2014-04-24 13:55:40.9880');
+      expect(n.format('DD/MM -YY h:m:s.fff TT', d)).to.equal('24/04 -14 1:55:40.988 PM');
 
       expect(n.format('WWWW MMMMMM DD YYYY @ hh:mm:ss', d)).to.equal('Thursday April 24 2014 @ 13:55:40');
     });

--- a/plugins/q/src/formatter/parts/qs-date-formatter.js
+++ b/plugins/q/src/formatter/parts/qs-date-formatter.js
@@ -5,6 +5,8 @@ const DAYS_ABBR = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 const MONTHS_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+const SECONDS_PER_DAY = 86400;
+
 function pad(s, n) {
   for (let i = s.length; i < n; i++) {
     s = `0${s}`;
@@ -76,7 +78,14 @@ function parseInterval(days, pattern) {
     date;
 
   if (/w+|t+/gi.test(pattern)) {
-    date = new Date(Date.UTC(1899, 11, 30 + Math.floor(days), 0, 0, 24 * 60 * 60 * (days - Math.floor(days))));
+    date = new Date(Date.UTC(
+      1899,
+      11,
+      30 + Math.floor(days),
+      0,
+      0,
+      Math.round(SECONDS_PER_DAY * (days - Math.floor(days)))
+    ));
     if (isNaN(date.getTime())) {
       date = null;
     }

--- a/plugins/q/src/formatter/timeFormat.js
+++ b/plugins/q/src/formatter/timeFormat.js
@@ -2,8 +2,18 @@ import dateFormatFactory from './parts/qs-date-formatter';
 import { TYPES } from './constants';
 import memoize from './memoize';
 
+const MS_PER_DAY = 86400000;
+
 export function QlikTimeToDate(value) {
-  return new Date(Date.UTC(1899, 11, 30 + Math.floor(value), 0, 0, 0, 1000 * 24 * 60 * 60 * (value - Math.floor(value))));
+  return new Date(Date.UTC(
+    1899,
+    11,
+    30 + Math.floor(value),
+    0,
+    0,
+    0,
+    Math.round(MS_PER_DAY * (value - Math.floor(value)))
+  ));
 }
 
 export default function formatter(pattern, qtype = 'TS', localeInfo = null) {


### PR DESCRIPTION
Fixes an issue where some date values would return wrong formatted value.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
