### PR TITLE
fix(range-brush): only render nodes from observed or active brush

### DIFF
--- a/packages/picasso.js/src/web/components/brush-range/__tests__/brush-range.spec.js
+++ b/packages/picasso.js/src/web/components/brush-range/__tests__/brush-range.spec.js
@@ -246,17 +246,44 @@ describe('Brush Range', () => {
     });
   });
 
-  describe('should renderer linear range', () => {
+  describe('linear', () => {
     beforeEach(() => {
       const scale = linearScale();
       scale.type = 'linear';
       scale.data = () => ({
         fields: [{
-          id: () => '',
+          id: () => 'foo',
           formatter: () => (v => v)
         }]
       });
       chartMock.scale = sandbox.stub().returns(scale);
+    });
+
+    describe('on render', () => {
+      it('should return empty when not observed nor brushed from this component', () => {
+        instance = componentFixture.simulateCreate(brushRange, config);
+        chartMock.brush().setRange('foo', { min: 0, max: 10 });
+        componentFixture.simulateRender(size);
+        rendererOutput = componentFixture.getRenderOutput();
+        expect(rendererOutput.length).to.equal(0);
+      });
+
+      it('should return nodes from existing brush when observed', () => {
+        instance = componentFixture.simulateCreate(brushRange, {
+          settings: {
+            scale: 'a',
+            direction: 'horizontal',
+            target: null,
+            brush: {
+              observe: true
+            }
+          }
+        });
+        chartMock.brush().setRange('foo', { min: 0, max: 10 });
+        componentFixture.simulateRender(size);
+        rendererOutput = componentFixture.getRenderOutput();
+        expect(rendererOutput.length).to.equal(1);
+      });
     });
 
     describe('horizontal', () => {

--- a/packages/picasso.js/src/web/components/brush-range/brush-range.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-range.js
@@ -324,7 +324,7 @@ const brushRangeComponent = {
 
     this.state.ranges = ranges(this.state, this.state.brushInstance);
 
-    return [nodes(this.state)];
+    return (this.state.observeBrush || this.state.sourcedFromThisComponent) ? [nodes(this.state)] : [];
   },
   mounted() {
     if (this.state.observeBrush && this.state.brushInstance) {
@@ -351,6 +351,7 @@ const brushRangeComponent = {
     }
     end(this.state, ranges);
     render(this.state);
+    this.state.sourcedFromThisComponent = true;
     this.state.active = null;
   },
   move(e) {
@@ -368,6 +369,7 @@ const brushRangeComponent = {
     this.state.renderer.render([]);
     this.state.started = false;
     this.state.active = null;
+    this.state.sourcedFromThisComponent = false;
   },
   bubbleStart(e) {
     if (!this.state.editable) {


### PR DESCRIPTION
Fixes so that `range-brush` only renders nodes from an observed brush or when the brushing occurred from the component itself.
This is to avoid the component rendering nodes from brushes that were activated by other components.
