### PR TITLE
fix(bar-label): add padding and background color to bar labels

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "license": "MIT"
   },
   "entries": {
@@ -2092,6 +2092,85 @@
                               "optional": true,
                               "defaultValue": false,
                               "type": "boolean"
+                            },
+                            "padding": {
+                              "description": "Padding between the label and the bar",
+                              "kind": "object",
+                              "entries": {
+                                "top": {
+                                  "description": "Padding-top between the label and the bar",
+                                  "optional": true,
+                                  "defaultValue": 4,
+                                  "type": "number"
+                                },
+                                "bottom": {
+                                  "description": "Padding-bottom between the label and the bar",
+                                  "optional": true,
+                                  "defaultValue": 4,
+                                  "type": "number"
+                                },
+                                "left": {
+                                  "description": "Padding-left between the label and the bar",
+                                  "optional": true,
+                                  "defaultValue": 4,
+                                  "type": "number"
+                                },
+                                "right": {
+                                  "description": "Padding-right between the label and the bar",
+                                  "optional": true,
+                                  "defaultValue": 4,
+                                  "type": "number"
+                                }
+                              }
+                            },
+                            "background": {
+                              "description": "Background of the label",
+                              "kind": "object",
+                              "entries": {
+                                "fill": {
+                                  "description": "Background color of the label",
+                                  "kind": "union",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "function"
+                                    }
+                                  ],
+                                  "type": "any"
+                                },
+                                "padding": {
+                                  "description": "Padding between the label and the background",
+                                  "kind": "object",
+                                  "entries": {
+                                    "top": {
+                                      "description": "Padding-top between the label and the background",
+                                      "optional": true,
+                                      "defaultValue": 4,
+                                      "type": "number"
+                                    },
+                                    "bottom": {
+                                      "description": "Padding-bottom between the label and the background",
+                                      "optional": true,
+                                      "defaultValue": 4,
+                                      "type": "number"
+                                    },
+                                    "left": {
+                                      "description": "Padding-left between the label and the background",
+                                      "optional": true,
+                                      "defaultValue": 4,
+                                      "type": "number"
+                                    },
+                                    "right": {
+                                      "description": "Padding-right between the label and the background",
+                                      "optional": true,
+                                      "defaultValue": 4,
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           },
                           "kind": "object"

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -16,7 +16,9 @@ function place(position, direction) {
     view: { width: 200, height: 100 },
     direction,
     position,
-    padding: 2
+    padding: {
+      top: 4, bottom: 4, left: 2, right: 2
+    }
   });
 }
 
@@ -26,43 +28,43 @@ describe('labeling - bars', () => {
   describe('bar rects', () => {
     it('inside', () => {
       expect(place('inside')).to.eql({
-        x: 12, y: 42, width: 16, height: 26
+        x: 12, y: 44, width: 16, height: 22
       });
     });
 
     it('outside-up/opposite-down', () => {
       expect(place('outside', 'up')).to.eql({
-        x: 12, y: 2, width: 16, height: 36
+        x: 12, y: 4, width: 16, height: 32
       });
       expect(place('opposite', 'down')).to.eql({
-        x: 12, y: 2, width: 16, height: 36
+        x: 12, y: 4, width: 16, height: 32
       });
     });
 
     it('outside-down/opposite-up', () => {
       expect(place('outside', 'down')).to.eql({
-        x: 12, y: 72, width: 16, height: 26
+        x: 12, y: 74, width: 16, height: 22
       });
       expect(place('opposite', 'up')).to.eql({
-        x: 12, y: 72, width: 16, height: 26
+        x: 12, y: 74, width: 16, height: 22
       });
     });
 
     it('outside-right/opposite-left', () => {
       expect(place('outside', 'right')).to.eql({
-        x: 32, y: 42, width: 166, height: 26
+        x: 32, y: 44, width: 166, height: 22
       });
       expect(place('opposite', 'left')).to.eql({
-        x: 32, y: 42, width: 166, height: 26
+        x: 32, y: 44, width: 166, height: 22
       });
     });
 
     it('outside-left/opposite-right', () => {
       expect(place('outside', 'left')).to.eql({
-        x: 2, y: 42, width: 6, height: 26
+        x: 2, y: 44, width: 6, height: 22
       });
       expect(place('opposite', 'right')).to.eql({
-        x: 2, y: 42, width: 6, height: 26
+        x: 2, y: 44, width: 6, height: 22
       });
     });
   });

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -415,6 +415,18 @@ export function precalculate({
  * @property {number} [labels[].placements[].align=0.5] - Placement of the label along the perpendicular direction of the bar
  * @property {string} [labels[].placements[].fill='#333'] - Color of the label
  * @property {boolean} [labels[].placements[].overflow=false] - True if the label is allowed to overflow the bar
+ * @property {object} labels[].placements[].padding - Padding between the label and the bar
+ * @property {number} [labels[].placements[].padding.top=4] - Padding-top between the label and the bar
+ * @property {number} [labels[].placements[].padding.bottom=4] - Padding-bottom between the label and the bar
+ * @property {number} [labels[].placements[].padding.left=4] - Padding-left between the label and the bar
+ * @property {number} [labels[].placements[].padding.right=4] - Padding-right between the label and the bar
+ * @property {object} labels[].placements[].background - Background of the label
+ * @property {string|function} labels[].placements[].background.fill - Background color of the label
+ * @property {object} labels[].placements[].background.padding - Padding between the label and the background
+ * @property {number} [labels[].placements[].background.padding.top=4] - Padding-top between the label and the background
+ * @property {number} [labels[].placements[].background.padding.bottom=4] - Padding-bottom between the label and the background
+ * @property {number} [labels[].placements[].background.padding.left=4] - Padding-left between the label and the background
+ * @property {number} [labels[].placements[].background.padding.right=4] - Padding-right between the label and the background
  */
 
 export function bars({

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -88,11 +88,14 @@ function limitBounds(bounds, view) {
   bounds.height = maxY - minY;
 }
 
-function pad(bounds, padding) {
-  bounds.x += padding;
-  bounds.width -= (padding * 2);
-  bounds.y += padding;
-  bounds.height -= (padding * 2);
+function pad(bounds, padding = {}) {
+  const {
+    top = PADDING, bottom = PADDING, left = PADDING, right = PADDING
+  } = padding;
+  bounds.x += left;
+  bounds.width -= (left + right);
+  bounds.y += top;
+  bounds.height -= (top + bottom);
 }
 
 export function getBarRect({
@@ -156,7 +159,8 @@ export function findBestPlacement({
       bar: node.localBounds,
       view: rect,
       direction,
-      position: placement.position
+      position: placement.position,
+      padding: placement.padding
     });
     boundaries.push(testBounds);
     largest = !p || testBounds.height > largest.height ? testBounds : largest;


### PR DESCRIPTION
This PR includes:
1. adding padding for bar labels which is used to calculate the label bound and check if the label bound is fit a bar or not,
2. adding background color to the label which is useful in case of showing stack total values when they are rendered inside bar segments.

![image](https://user-images.githubusercontent.com/20044781/55495843-12824880-563e-11e9-98cd-48d0b7cda384.png)

