### PR TITLE
feat(brush-range): add support for multiple fill targets

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "license": "MIT"
   },
   "entries": {
@@ -5286,9 +5286,17 @@
           "kind": "object",
           "entries": {
             "component": {
-              "description": "Render matching overlay on target component",
+              "description": "Render matching overlay on target component. @deprecated Use `components` instead",
               "optional": true,
               "type": "string"
+            },
+            "components": {
+              "description": "Render matching overlay on target components",
+              "optional": true,
+              "kind": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "selector": {
               "description": "Instead of targeting a component, target one or more shapes",

--- a/docs/src/input/component-brush-range.md
+++ b/docs/src/input/component-brush-range.md
@@ -12,14 +12,14 @@ No [data](data.md) is required as input directly, instead the data is implicitly
 
 ## Layout
 
-There are two ways to set the layout, either by referencing a `target` component, in which case, the rendering area extends from the `target` component to the start of the opposite docking area. Ex. if `target` is docked to the `right`, then the rendering area includes the `right` area and the `center` area. The other option, which is default, is if no `target` component is configured, then the `center` area is used.
+There are two ways to set the layout, either by referencing a `target` components, in which case, the rendering area extends from the `target` components to the start of the opposite docking area. Ex. if `target` is docked to the `right`, then the rendering area includes the `right` area and the `center` area. The other option, which is default, is if no `target` component is configured, then the `center` area is used.
 
 A `target` is configured in the `target` property:
 
 ```js
 settings: {
   target: {
-    component: 'my-target-component'
+    components: ['my-target-component']
   }
 }
 ```
@@ -102,7 +102,7 @@ components: [
       scale: 'some-linear-scale'
     },
     target: {
-      component: 'target-this-component'
+      components: ['target-this-component']
     }
   },
   ...


### PR DESCRIPTION
Match the functionality of brush-area-dir added in #266 

Adds support for multiple fill targets:
```
{
  target: {
    components: ['a', 'b']
  }
}
```