### PR TITLE
feat(renderer): rounded rectangle

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/rect.js
@@ -22,7 +22,13 @@ export default class Rect extends DisplayObject {
 
   set(v = {}) {
     const {
-      x = 0, y = 0, width = 0, height = 0, collider
+      x = 0,
+      y = 0,
+      width = 0,
+      height = 0,
+      rx = NaN,
+      ry = NaN,
+      collider
     } = v;
     const opts = extend({
       type: 'rect', x, y, width, height
@@ -45,6 +51,9 @@ export default class Rect extends DisplayObject {
       this.attrs.y = y + height;
       this.attrs.height = -height;
     }
+
+    this.attrs.rx = Math.max(0, rx);
+    this.attrs.ry = Math.max(0, ry);
 
     this.collider = opts;
     this.__boundingRect = { true: null, false: null };

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/rect.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/rect.spec.js
@@ -15,7 +15,10 @@ describe('rect', () => {
         beginPath: sandbox.spy(),
         rect: sandbox.spy(),
         fill: sandbox.spy(),
-        stroke: sandbox.spy()
+        stroke: sandbox.spy(),
+        moveTo: sandbox.spy(),
+        lineTo: sandbox.spy(),
+        quadraticCurveTo: sandbox.spy()
       };
 
       falsys = [false, null, undefined, 0, NaN, ''];
@@ -86,6 +89,32 @@ describe('rect', () => {
       expect(g.beginPath.calledBefore(g.rect)).to.equal(true);
       expect(g.rect.calledBefore(g.fill)).to.equal(true);
       expect(g.fill.calledBefore(g.stroke)).to.equal(true);
+    });
+
+    describe('rounded rect', () => {
+      it('should call context methods in correct order and with correct arguments', () => {
+        rect.rx = 3;
+        rect.ry = 4;
+
+        render(rect, { g, doFill: true, doStroke: true });
+
+        expect(g.moveTo.getCall(0).args).to.eql([1, 6]);
+        expect(g.lineTo.getCall(0).args).to.eql([1, 18]);
+        expect(g.quadraticCurveTo.getCall(0).args).to.eql([1, 22, 4, 22]);
+
+        expect(g.lineTo.getCall(1).args).to.eql([8, 22]);
+        expect(g.quadraticCurveTo.getCall(1).args).to.eql([11, 22, 11, 18]);
+
+        expect(g.lineTo.getCall(2).args).to.eql([11, 6]);
+        expect(g.quadraticCurveTo.getCall(2).args).to.eql([11, 2, 8, 2]);
+
+        expect(g.lineTo.getCall(3).args).to.eql([4, 2]);
+        expect(g.quadraticCurveTo.getCall(3).args).to.eql([1, 2, 1, 6]);
+
+        expect(g.moveTo).to.have.callCount(1);
+        expect(g.lineTo).to.have.callCount(4);
+        expect(g.quadraticCurveTo).to.have.callCount(4);
+      });
     });
   });
 });

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/rect.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/rect.js
@@ -1,6 +1,39 @@
+function clampRadius(max, value) {
+  return Math.max(0, Math.min(max, value));
+}
+
+/**
+ * Implementation details follow rx/ry restrictions from https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx#rect
+ *
+ * Solution based on roundedRect function from https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#Making_combinations
+ *
+ * Using Quadratic Bézier curve it's not possible accurately represent a circle or ellipse but should for the case of a rounded rectangle be sufficent.
+ * @private
+ */
+function quadraticRoundedRect(g, x, y, width, height, rx, ry) {
+  rx = clampRadius(width / 2, rx > 0 ? rx : ry);
+  ry = clampRadius(height / 2, ry > 0 ? ry : rx);
+
+  g.moveTo(x, y + ry);
+  g.lineTo(x, y + height - ry);
+  g.quadraticCurveTo(x, y + height, x + rx, y + height);
+  g.lineTo(x + width - rx, y + height);
+  g.quadraticCurveTo(x + width, y + height, x + width, y + height - ry);
+  g.lineTo(x + width, y + ry);
+  g.quadraticCurveTo(x + width, y, x + width - rx, y);
+  g.lineTo(x + rx, y);
+  g.quadraticCurveTo(x, y, x, y + ry);
+}
+
 export default function render(rect, { g, doFill, doStroke }) {
   g.beginPath();
-  g.rect(rect.x, rect.y, rect.width, rect.height);
+
+  if (rect.rx > 0 || rect.ry > 0) {
+    quadraticRoundedRect(g, rect.x, rect.y, rect.width, rect.height, rect.rx, rect.ry);
+  } else {
+    g.rect(rect.x, rect.y, rect.width, rect.height);
+  }
+
   if (doFill) {
     g.fill();
   }

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/rect.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/rect.js
@@ -3,9 +3,7 @@ function clampRadius(max, value) {
 }
 
 /**
- * Implementation details follow rx/ry restrictions from https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx#rect
- *
- * Solution based on roundedRect function from https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#Making_combinations
+ * Implementation details follow rx/ry restrictions from https://svgwg.org/svg2-draft/geometry.html#RX
  *
  * Using Quadratic Bézier curve it's not possible accurately represent a circle or ellipse but should for the case of a rounded rectangle be sufficent.
  * @private


### PR DESCRIPTION
Adds support for rounded rectangle in the scene graph and svg/cavans renderer.

Usage:
```js
{ type: 'rect', rx: 10, ry: 5 }
```

There are a couple instance where the svg and canvas output may be different:
- There is a known implementation limitation that affects the canvas renderer. The method used to approximate a rounded rectangle is not precise enough when the radius approaches half the width or height.
- When using the svg renderer, chrome v73 doesn't handle the case when either the rx or ry property is missing.

