### PR TITLE
docs: update dockLayout references

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "license": "MIT"
   },
   "entries": {
@@ -780,7 +780,7 @@
               "type": "number"
             },
             "minimumLayoutMode": {
-              "description": "Refer to layout sizes defined by layoutModes in dockLayout",
+              "description": "Refer to layout sizes defined by layoutModes in `strategy`",
               "optional": true,
               "kind": "union",
               "items": [

--- a/docs/src/input/chart.md
+++ b/docs/src/input/chart.md
@@ -15,7 +15,7 @@ The `picasso.chart` function will create and render a chart.
     * `components` Array. [More](./components.md).
     * `scales` Object (optional). Scales to use when rendering. [More](./scales.md).
     * `formatters` Object (optional). Formatters that can be referenced from other components. [More](./formatters.md).
-    * `dockLayout` Object (optional). Layout behavior and responsiveness. [More](./dock-layout.md).
+    * `strategy` Object (optional). Layout behavior and responsiveness. [More](./dock-layout.md).
   * `created` Function (optional). Lifecycle hook.
   * `beforeMount` Function (optional). Lifecycle hook.
   * `mounted` Function (optional). Lifecycle hook.

--- a/docs/src/input/dock-layout.md
+++ b/docs/src/input/dock-layout.md
@@ -1,5 +1,5 @@
 ---
-title: Dock layout
+title: Dock layout strategy
 ---
 
 The dock layout is the engine that controls how different components are positioned and whether a component is rendered or not, depending on available space, that is, the responsiveness.
@@ -22,7 +22,7 @@ The input value is specified as a number and represents the size in pixels.
 
 **Example**
   ```js
-  dockLayout: {
+  strategy: {
     size: {
       width: 100,
       height: 100
@@ -40,7 +40,7 @@ The input value is specified as a number and represents the size in pixels.
 
 **Example**
   ```js
-  dockLayout: {
+  strategy: {
     logicalSize: {
       width: 150,
       height: 150,
@@ -70,7 +70,7 @@ When configured with either `minWidth/minHeight` or `minWidthRatio/minHeightRati
 
 **Example**
   ```js
-  dockLayout: {
+  strategy: {
     center: {
       minWidthRatio: 0.5,
       minHeightRatio: 0.5,
@@ -86,7 +86,7 @@ The minimum layout mode is a way to tell the layout engine that a component shou
 
 **Example**
   ```js
-  dockLayout: {
+  strategy: {
     layoutModes: {
       S: { width: 150, height: 150 }
       L: { width: 300, height: 300 }

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -33,7 +33,7 @@ import themeFn from '../theme';
  * @property {object} [layout] Layout settings
  * @property {number} [layout.displayOrder = 0]
  * @property {number} [layout.prioOrder = 0]
- * @property {string | {width: string, height: string}} [layout.minimumLayoutMode] Refer to layout sizes defined by layoutModes in dockLayout
+ * @property {string | {width: string, height: string}} [layout.minimumLayoutMode] Refer to layout sizes defined by layoutModes in `strategy`
  * @property {string} [layout.dock] left, right, top or bottom
  * @property {boolean} [show = true] If the component should be rendered
  * @property {string} [scale] Named scale. Will be provided to the component if it ask for it.
@@ -252,7 +252,7 @@ function chartFn(definition, context) {
     });
     let layoutSettings;
     if (settings.dockLayout) {
-      logger.warn('Deprecation Warning: dockLayout property should be renamed to "strategy"');
+      logger.warn('Deprecation Warning: "dockLayout" property should be renamed to "strategy"');
       layoutSettings = settings.dockLayout;
     } else {
       layoutSettings = settings.strategy;


### PR DESCRIPTION
BREAKING CHANGE: rect is now a reserved keyword for components


## Breaking

A lot of examples used the `beforeRender` lifecycle method to set `this.rect` on the component:

```js
beforeRender(opts) {	
  this.rect = opts.size;	
},
```

💥 **`rect` is now a reserved keyword and automatically set on all components by the layout strategy**. Trying to assign a value to `rect` inside a component will throw an error.

> The actual breaking PR is https://github.com/qlik-oss/picasso.js/pull/354, but it did not contain any BREAKING CHANGE comment, so adding it in this commit instead.

## Deprecated

Properties related to the layout strategy have been moved one step down into a `layout` object, while `dockLayout` has been renamed to `strategy`:

**Before**
```js
picasso.chart({
  settings: {
    dockLayout: { // deprecated, use strategy instead
      logicalSize: { width: 400, height: 300 }
    },
    components: [{
      type: 'point',
      dock: 'left', // deprecated, use layout.dock instead 
      prioOrder: 1, // deprecated, use layout.prioOrder instead
      displayOrder: 2, // deprecated, use layout.displayOrder instead
      minimumLayoutMode: 'SMALL' // deprecated, use layout.minimumLayoutMode instead
    }]
  }
});
```

**After**
```js
picasso.chart({
  settings: {
    strategy: {
      logicalSize: { width: 400, height: 300 }
    },
    components: [{
      type: 'point',
      layout: {
        dock: 'left',
        prioOrder: 1,
        displayOrder: 2,
        minimumLayoutMode: 'SMALL'
      }
    }]
  }
});
```
