### PR TITLE
refactor: keep preferredSize api

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -245,7 +245,7 @@ function chartFn(definition, context) {
       return {
         instance: c.instance,
         resize: c.instance.resize,
-        getPreferredSize: dockConfig.computePreferredSize.bind(dockConfig),
+        preferredSize: dockConfig.computePreferredSize.bind(dockConfig),
         userSettings: c.settings,
         layoutComponents: () => {}
       };

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -240,17 +240,15 @@ function componentFactory(definition, context = {}) {
   const instanceContext = extend({}, config);
 
   // Create a callback that calls lifecycle functions in the definition and config (if they exist).
-  function createCallback(method, defaultMethod = () => { }, canBeValue = false, alternateMethod) {
+  function createCallback(method, defaultMethod = () => { }, canBeValue = false) {
     return function cb(...args) {
-      const inDefinition = typeof definition[method] !== 'undefined' || typeof definition[alternateMethod] !== 'undefined';
-      const inConfig = typeof config[method] !== 'undefined' || typeof config[alternateMethod] !== 'undefined';
+      const inDefinition = typeof definition[method] !== 'undefined';
+      const inConfig = typeof config[method] !== 'undefined';
 
       let returnValue;
       if (inDefinition) {
         if (typeof definition[method] === 'function') {
           returnValue = definition[method].call(definitionContext, ...args);
-        } else if (typeof definition[alternateMethod] === 'function') {
-          returnValue = definition[alternateMethod].call(definitionContext, ...args);
         } else if (canBeValue) {
           returnValue = definition[method];
         }
@@ -259,8 +257,6 @@ function componentFactory(definition, context = {}) {
       if (inConfig) {
         if (typeof config[method] === 'function') {
           returnValue = config[method].call(instanceContext, ...args);
-        } else if (typeof config[alternateMethod] === 'function') {
-          returnValue = config[alternateMethod].call(instanceContext, ...args);
         } else if (canBeValue) {
           returnValue = config[method];
         }
@@ -274,7 +270,7 @@ function componentFactory(definition, context = {}) {
     };
   }
 
-  const preferredSize = createCallback('preferredSize', () => 0, true, 'getPreferredSize');
+  const preferredSize = createCallback('preferredSize', () => 0, true);
   const resize = createCallback('resize', ({ inner }) => inner);
   const created = createCallback('created');
   const beforeMount = createCallback('beforeMount');

--- a/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
@@ -25,7 +25,7 @@ describe('Dock Layout', () => {
       }
     };
 
-    dummy.getPreferredSize = () => ({ width: size, height: size, edgeBleed });
+    dummy.preferredSize = () => ({ width: size, height: size, edgeBleed });
 
     let outerRect = createRect();
     let innerRect = createRect();
@@ -210,7 +210,7 @@ describe('Dock Layout', () => {
       expect(fn).to.throw('Invalid component settings');
       expect(fn2).to.throw('Component is missing resize function');
       expect(fn3).to.throw('Component is missing resize function');
-      expect(fn4).to.throw('Component is missing getPreferredSize function');
+      expect(fn4).to.throw('Component is missing preferredSize function');
     });
 
     it("should remove components that don't fit", () => {

--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -6,7 +6,7 @@ import createRect from './create-rect';
 
 function cacheSize(c, reducedRect, layoutRect) {
   if (typeof c.cachedSize === 'undefined') {
-    let size = c.comp.getPreferredSize(reducedRect, layoutRect);
+    let size = c.comp.preferredSize(reducedRect, layoutRect);
     // backwards compatibility
     if (!isNaN(size)) {
       size = { width: size, height: size };
@@ -348,8 +348,8 @@ function validateComponent(component) {
   if (!component.resize || typeof component.resize !== 'function') {
     throw new Error('Component is missing resize function');
   }
-  if (!component.dockConfig && !component.getPreferredSize) {
-    throw new Error('Component is missing getPreferredSize function');
+  if (!component.dockConfig && !component.preferredSize) {
+    throw new Error('Component is missing preferredSize function');
   }
 }
 


### PR DESCRIPTION
in PR #354 we prepared for the compose api where we were thinking to rename the `preferredSize` method in components to `getPreferredSize` but there is no need to break this api. This PR reverts the change.

**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
