### PR TITLE
fix(layout): maintain display-order

### DIFF
--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -167,6 +167,109 @@ describe('Chart', () => {
       expect(comp1UpdatedCb).to.have.been.calledTwice;
       expect(comp2UpdatedCb).to.have.been.calledTwice;
     });
+
+    it('should maintain displayOrder of components after initial render', () => {
+      const components = {
+        point: {
+          has: () => true,
+          render: sinon.stub()
+        }
+      };
+      const comp = key => components[key];
+      comp.has = () => true;
+      const first = componentFactoryFixture().mocks().renderer;
+      const second = componentFactoryFixture().mocks().renderer;
+      const rendererFactory = sinon.stub();
+      rendererFactory.onFirstCall().returns(() => first);
+      rendererFactory.onSecondCall().returns(() => second);
+
+      chart({
+        ...definition,
+        settings: {
+          components: [{
+            type: 'point',
+            key: 'comp1',
+            layout: {
+              dock: 'left',
+              displayOrder: 2
+            }
+          }, {
+            type: 'point',
+            key: 'comp2',
+            layout: {
+              dock: '@comp1',
+              displayOrder: 1
+            }
+          }]
+        }
+      }, {
+        registries: {
+          component: comp,
+          renderer: rendererFactory
+        }
+      });
+      const order = element.children.map(c => c.attributes['data-key']);
+      expect(order).to.eql(['comp2', 'comp1']);
+    });
+
+    it('should maintain displayOrder of components after update', () => {
+      const components = {
+        point: {
+          has: () => true,
+          render: sinon.stub()
+        }
+      };
+      const comp = key => components[key];
+      comp.has = () => true;
+      const first = componentFactoryFixture().mocks().renderer;
+      const second = componentFactoryFixture().mocks().renderer;
+      const rendererFactory = sinon.stub();
+      rendererFactory.onFirstCall().returns(() => first);
+      rendererFactory.onSecondCall().returns(() => second);
+
+      const chartInstance = chart({
+        ...definition,
+        settings: {
+          components: [{
+            type: 'point',
+            key: 'comp1',
+            layout: {
+              dock: 'left',
+              displayOrder: 1
+            }
+          }, {
+            type: 'point',
+            key: 'comp2',
+            layout: {
+              dock: 'left',
+              displayOrder: 2
+            }
+          }]
+        }
+      }, {
+        registries: {
+          component: comp,
+          renderer: rendererFactory
+        }
+      });
+      expect(element.children.map(c => c.attributes['data-key'])).to.eql(['comp1', 'comp2']);
+      chartInstance.update({
+        settings: {
+          components: [{
+            key: 'comp1',
+            layout: {
+              displayOrder: 2
+            }
+          }, {
+            key: 'comp2',
+            layout: {
+              displayOrder: 1
+            }
+          }]
+        }
+      });
+      expect(element.children.map(c => c.attributes['data-key'])).to.eql(['comp2', 'comp1']);
+    });
   });
 
   describe('orderComponents', () => {

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -262,11 +262,11 @@ function chartFn(definition, context) {
 
     const rect = getElementRect(element);
 
-    const { visible, hidden } = dockLayout.layout(rect, vcomponents);
+    const { visible, hidden, order } = dockLayout.layout(rect, vcomponents);
     return {
       visible: visible.map(v => findComponent(v.instance)),
       hidden: hidden.map(h => findComponent(h.instance)),
-      order: visible
+      order
     };
   };
 
@@ -317,7 +317,7 @@ function chartFn(definition, context) {
       createComponent(compSettings, element)
     )).filter(c => !!c);
 
-    const { visible, hidden } = layout(currentComponents);
+    const { visible, hidden, order } = layout(currentComponents);
     visibleComponents = visible;
 
     hidden.forEach((comp) => {
@@ -332,6 +332,7 @@ function chartFn(definition, context) {
     visible.forEach(comp => comp.instance.render());
     visible.forEach(comp => comp.instance.mounted());
     visible.forEach((comp) => { comp.visible = true; });
+    orderComponents(element, visibleComponents, order);
   };
 
   function setInteractions(interactions = []) {

--- a/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
@@ -776,4 +776,21 @@ describe('Dock Layout', () => {
       expect(visible[2]).to.equal(mainComp); // Prio 0
     });
   });
+
+  describe('displayOrder', () => {
+    it('should maintain order of visible components', () => {
+      const mainComp = componentMock({ key: 'main' });
+      const leftComp = componentMock({ displayOrder: 1, dock: 'left', key: 'y' });
+      const onLeft = componentMock({ displayOrder: 0, dock: '@y', key: 'dockAtY' });
+      const onMain = componentMock({ displayOrder: -1, dock: '@main', key: 'dockAtMain' });
+
+      const rect = createRect(0, 0, 1000, 1000);
+      const dl = dockLayout();
+
+      const { visible, order } = dl.layout(rect, [mainComp, leftComp, onLeft, onMain]);
+
+      expect(visible.map(v => v.userSettings.key)).to.eql(['main', 'y', 'dockAtY', 'dockAtMain']);
+      expect(order).to.eql([1, 3, 2, 0]);
+    });
+  });
 });

--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -227,6 +227,7 @@ function positionComponents({
 
   const referencedComponents = {};
   const referenceArray = visible.slice();
+  const elementOrder = referenceArray.slice().sort((a, b) => a.config.displayOrder() - b.config.displayOrder());
   visible
     .sort((a, b) => {
       if (b.referencedDocks.length > 0) {
@@ -322,6 +323,7 @@ function positionComponents({
       c.cachedSize = undefined;
       c.edgeBleed = undefined;
     });
+  return visible.map(c => elementOrder.indexOf(c));
 }
 
 function checkShowSettings(strategySettings, dockSettings, logicalContainerRect) {
@@ -426,7 +428,7 @@ function dockLayout(initialSettings) {
       hidden,
       settings
     });
-    positionComponents({
+    const order = positionComponents({
       visible,
       layoutRect: logicalContainerRect,
       reducedRect,
@@ -438,7 +440,7 @@ function dockLayout(initialSettings) {
       const r = createRect();
       c.comp.resize(r, r);
     });
-    return { visible: visible.map(v => v.comp), hidden: hidden.map(h => h.comp) };
+    return { visible: visible.map(v => v.comp), hidden: hidden.map(h => h.comp), order };
   };
 
   docker.settings = function settingsFn(s) {

--- a/packages/picasso.js/src/web/components/tooltip/__tests__/tooltip.spec.js
+++ b/packages/picasso.js/src/web/components/tooltip/__tests__/tooltip.spec.js
@@ -1,4 +1,5 @@
 import extend from 'extend';
+import elementMock from 'test-utils/mocks/element-mock';
 import tooltip from '../tooltip';
 import componentFactoryFixture from '../../../../../test/helpers/component-factory-fixture';
 import * as instanceHandler from '../instance-handler';
@@ -16,6 +17,7 @@ function chartMock() {
     brushFromShapes: sinon.stub(),
     component: sinon.stub().returns(componentMock()),
     element: {
+      ...elementMock(),
       getBoundingClientRect: sinon.stub().returns({
         left: 0,
         top: 0
@@ -224,7 +226,7 @@ describe('Tooltip', () => {
     });
 
     it('should apply appendTo on mounted', () => {
-      const stub = sandbox.stub().returns({ getBoundingClientRect: () => container });
+      const stub = sandbox.stub().returns({ getBoundingClientRect: () => container, appendChild: sandbox.stub() });
       instance.def.props.appendTo = stub;
       componentFixture.simulateRender({ inner: container, outer: container });
 
@@ -233,7 +235,7 @@ describe('Tooltip', () => {
     });
 
     it('should apply appendTo on updated', () => {
-      const stub = sandbox.stub().returns({ getBoundingClientRect: () => container });
+      const stub = sandbox.stub().returns({ getBoundingClientRect: () => container, appendChild: sandbox.stub() });
       config.settings.appendTo = stub;
       componentFixture.simulateUpdate(config);
 

--- a/packages/picasso.js/test/helpers/component-factory-fixture.js
+++ b/packages/picasso.js/test/helpers/component-factory-fixture.js
@@ -20,7 +20,7 @@ export default function componentFactoryFixture() {
   let themeMock;
   let registriesMock;
   const sandbox = sinon.createSandbox();
-  const container = elementMock();
+  let rendererElement;
 
   const fn = function func() {
     chartMock = {
@@ -66,7 +66,13 @@ export default function componentFactoryFixture() {
         return s;
       },
       render: (nodes) => { rendererOutput = nodes; },
-      appendTo: () => {},
+      appendTo: (el) => {
+        if (!rendererElement) {
+          rendererElement = elementMock();
+        }
+        el.appendChild(rendererElement);
+        return rendererElement;
+      },
       measureText: ({ text }) => ({
         width: text.toString().length,
         height: 5
@@ -77,9 +83,10 @@ export default function componentFactoryFixture() {
         width: text.toString().length,
         height: 5
       }),
-      element: () => container,
+      element: () => rendererElement,
       clear: () => {},
-      destroy: () => {}
+      destroy: () => {},
+      setKey: key => rendererElement.setAttribute('data-key', key)
     };
 
     mediatorMock = {
@@ -114,6 +121,8 @@ export default function componentFactoryFixture() {
       theme: themeMock,
       registries: registriesMock
     });
+
+    rendererMock.appendTo(chartMock.element);
 
     return comp;
   };


### PR DESCRIPTION
Fixes so that elements in the DOM are ordered according to `displayOrder`.