### PR TITLE
refactor: userSettings in component definition

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.22.1",
+    "version": "0.23.0",
     "license": "MIT"
   },
   "entries": {

--- a/packages/picasso.js/src/core/chart-components/axis/axis.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis.js
@@ -38,14 +38,14 @@ function resolveAlign(align, dock) {
 function resolveLocalSettings({
   state,
   style,
-  settings
+  userSettings
 }) {
   const defaultStgns = extend(true, {}, state.isDiscrete ? DEFAULT_DISCRETE_SETTINGS : DEFAULT_CONTINUOUS_SETTINGS, style);
-  const localStgns = extend(true, {}, defaultStgns, settings.settings);
+  const localStgns = extend(true, {}, defaultStgns, userSettings.settings);
 
-  const dock = settings.layout.dock || state.defaultDock;
+  const dock = userSettings.layout.dock || state.defaultDock;
   localStgns.dock = dock;
-  localStgns.align = resolveAlign(settings.settings.align, dock);
+  localStgns.align = resolveAlign(userSettings.settings.align, dock);
   localStgns.labels.tiltAngle = Math.max(-90, Math.min(localStgns.labels.tiltAngle, 90));
 
   return localStgns;
@@ -108,7 +108,7 @@ const axisComponent = {
       this.state.defaultDock = 'left';
     }
 
-    this.setState(this.settings);
+    this.setState(this.userSettings);
   },
   setState() {
     this.state.isDiscrete = !!this.scale.bandwidth;

--- a/packages/picasso.js/src/core/chart-components/box/box.js
+++ b/packages/picasso.js/src/core/chart-components/box/box.js
@@ -63,11 +63,11 @@ const component = {
   render({ data }) {
     const { width, height } = this.rect;
 
-    const flipXY = this.settings.settings.orientation === 'horizontal';
+    const flipXY = this.userSettings.settings.orientation === 'horizontal';
 
     const { style, resolver, symbol } = this;
 
-    const keys = dataKeys.filter(key => !this.settings.settings[key] || this.settings.settings[key].show !== false);
+    const keys = dataKeys.filter(key => !this.userSettings.settings[key] || this.userSettings.settings[key].show !== false);
     const defaultSettings = {};
 
     keys.forEach(key => defaultSettings[key] = DEFAULT_DATA_SETTINGS[key]);
@@ -77,7 +77,7 @@ const component = {
       data,
       defaultSettings,
       style,
-      settings: this.settings.settings,
+      settings: this.userSettings.settings,
       width,
       height,
       resolver

--- a/packages/picasso.js/src/core/chart-components/brush-lasso/brush-lasso.js
+++ b/packages/picasso.js/src/core/chart-components/brush-lasso/brush-lasso.js
@@ -262,12 +262,12 @@ const brushLassoComponent = {
   },
   start(e) {
     this.state.active = true;
-    this.state.path = initPath(this.settings.settings.lasso);
-    this.state.snapIndicator = initSnapIndicator(this.settings.settings.snapIndicator);
-    this.state.startPoint = initStartPoint(this.settings.settings.startPoint);
+    this.state.path = initPath(this.userSettings.settings.lasso);
+    this.state.snapIndicator = initSnapIndicator(this.userSettings.settings.snapIndicator);
+    this.state.startPoint = initStartPoint(this.userSettings.settings.startPoint);
     this.state.rendererBounds = this.renderer.element().getBoundingClientRect();
     this.state.componentDelta = getComponentDelta(this.chart, this.state.rendererBounds);
-    this.state.brushConfig = getBrushConfig(this.settings);
+    this.state.brushConfig = getBrushConfig(this.userSettings);
 
     const p = getPoint(this.state.rendererBounds, e);
 
@@ -282,7 +282,7 @@ const brushLassoComponent = {
 
     const p = getPoint(this.state.rendererBounds, e);
 
-    if (withinThreshold(p, this.state, this.settings)) {
+    if (withinThreshold(p, this.state, this.userSettings)) {
       showSnapIndicator(this.state, true);
     } else {
       showSnapIndicator(this.state, false);
@@ -304,7 +304,7 @@ const brushLassoComponent = {
 
     showSnapIndicator(this.state, false);
     const p = getPoint(this.state.rendererBounds, e);
-    const shouldSnap = withinThreshold(p, this.state, this.settings);
+    const shouldSnap = withinThreshold(p, this.state, this.userSettings);
 
     if (shouldSnap) {
       doPolygonBrush(this.state, this.chart);

--- a/packages/picasso.js/src/core/chart-components/debug/debug-collider.js
+++ b/packages/picasso.js/src/core/chart-components/debug/debug-collider.js
@@ -29,7 +29,7 @@ const debugColliderDef = {
     this.renderer.render(colliders);
   },
   created() {
-    this.props = this.settings.settings;
+    this.props = this.userSettings.settings;
   },
   resize({ outer, inner }) {
     if (this.props.useOuterRect) {
@@ -42,7 +42,7 @@ const debugColliderDef = {
     this.draw();
   },
   updated() {
-    this.props = this.settings.settings;
+    this.props = this.userSettings.settings;
     this.draw();
   }
 };

--- a/packages/picasso.js/src/core/chart-components/debug/debug-path-to-points.js
+++ b/packages/picasso.js/src/core/chart-components/debug/debug-path-to-points.js
@@ -41,7 +41,7 @@ const debugPathToPointsDef = {
     this.renderer.render(circles);
   },
   created() {
-    this.props = this.settings.settings;
+    this.props = this.userSettings.settings;
   },
   resize({ outer, inner }) {
     if (this.props.useOuterRect) {
@@ -54,7 +54,7 @@ const debugPathToPointsDef = {
     this.draw();
   },
   updated() {
-    this.props = this.settings.settings;
+    this.props = this.userSettings.settings;
     this.draw();
   }
 };

--- a/packages/picasso.js/src/core/chart-components/grid/line.js
+++ b/packages/picasso.js/src/core/chart-components/grid/line.js
@@ -45,8 +45,8 @@ const gridLineComponent = {
 
   render() {
     // Setup scales
-    this.x = this.settings.x ? this.chart.scale(this.settings.x) : null;
-    this.y = this.settings.y ? this.chart.scale(this.settings.y) : null;
+    this.x = this.userSettings.x ? this.chart.scale(this.userSettings.x) : null;
+    this.y = this.userSettings.y ? this.chart.scale(this.userSettings.y) : null;
     updateScaleSize(this, 'x', this.rect.width);
     updateScaleSize(this, 'y', this.rect.height);
 
@@ -55,8 +55,8 @@ const gridLineComponent = {
       return [];
     }
 
-    this.settings.ticks = extend({ show: true }, this.style.ticks, this.settings.ticks || {});
-    this.settings.minorTicks = extend({ show: false }, this.style.minorTicks, this.settings.minorTicks || {});
+    this.userSettings.ticks = extend({ show: true }, this.style.ticks, this.userSettings.ticks || {});
+    this.userSettings.minorTicks = extend({ show: false }, this.style.minorTicks, this.userSettings.minorTicks || {});
 
     // Setup lines for X and Y
     this.lines = {
@@ -74,7 +74,7 @@ const gridLineComponent = {
 
     let addTicks = ({ dir, isMinor }) => {
       let items = this.lines[dir].filter(tick => !!tick.isMinor === isMinor);
-      let settings = isMinor ? this.settings.minorTicks : this.settings.ticks;
+      let settings = isMinor ? this.userSettings.minorTicks : this.userSettings.ticks;
       let ticks = this.resolver.resolve({
         settings,
         data: {

--- a/packages/picasso.js/src/core/chart-components/labels/labels.js
+++ b/packages/picasso.js/src/core/chart-components/labels/labels.js
@@ -50,7 +50,7 @@ const labelsComponent = {
     }
   },
   render() {
-    const stngs = this.settings.settings;
+    const stngs = this.userSettings.settings;
     const labels = [];
 
     (stngs.sources || []).forEach((source) => {

--- a/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/legend-resolver.spec.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/legend-resolver.spec.js
@@ -9,7 +9,7 @@ describe('legend-resolver', () => {
         labels: () => ['alpha', 'beta'],
         datum: () => ({ value: 'does not matter' }) // the value in datum is taken from domain
       },
-      settings: {
+      userSettings: {
         layout: {},
         settings: {}
       },
@@ -47,7 +47,7 @@ describe('legend-resolver', () => {
         }),
         domain: () => [2, 5, 7]
       },
-      settings: {
+      userSettings: {
         layout: {},
         settings: {}
       },
@@ -81,7 +81,7 @@ describe('legend-resolver', () => {
         }),
         domain: () => [2, 5, 7]
       },
-      settings: {
+      userSettings: {
         layout: {},
         formatter: v => `${v}kr`,
         settings: {}
@@ -110,15 +110,15 @@ describe('legend-resolver', () => {
 
   describe('resolveSettings', () => {
     let resolved;
-    let settings;
+    let component;
     beforeEach(() => {
-      settings = {
+      component = {
         scale: {
           data: () => ({ fields: [{}] }),
           domain: () => ['a', 'b'],
           datum: d => ({ value: d })
         },
-        settings: {
+        userSettings: {
           layout: {},
           settings: {
             item: {
@@ -142,7 +142,7 @@ describe('legend-resolver', () => {
         }
       };
 
-      resolved = resolveSettings(settings);
+      resolved = resolveSettings(component);
     });
 
     it('should resolve labels per datum', () => {
@@ -162,18 +162,18 @@ describe('legend-resolver', () => {
     });
 
     it('should resolve labels by `label` function if available', () => {
-      settings.scale.label = d => `label ${d}`;
-      settings.scale.domain = () => ['b', 'a'];
-      resolved = resolveSettings(settings);
+      component.scale.label = d => `label ${d}`;
+      component.scale.domain = () => ['b', 'a'];
+      resolved = resolveSettings(component);
 
       expect(resolved.labels.data.items[0]).to.eql({ value: 'b', label: 'label b' });
       expect(resolved.labels.data.items[1]).to.eql({ value: 'a', label: 'label a' });
     });
 
     it('should resolve labels by `labels` function if available', () => {
-      settings.scale.labels = () => ['1', '2']; // Resolved by index
-      settings.scale.domain = () => ['b', 'a'];
-      resolved = resolveSettings(settings);
+      component.scale.labels = () => ['1', '2']; // Resolved by index
+      component.scale.domain = () => ['b', 'a'];
+      resolved = resolveSettings(component);
 
       expect(resolved.labels.data.items[0]).to.eql({ value: 'b', label: '1' });
       expect(resolved.labels.data.items[1]).to.eql({ value: 'a', label: '2' });

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-cat.js
@@ -9,16 +9,16 @@ function update(comp) {
   comp.state.resolved = resolveSettings(comp);
   comp.titleRenderer.itemize({
     resolved: comp.state.resolved,
-    dock: comp.settings.layout.dock || 'center'
+    dock: comp.userSettings.layout.dock || 'center'
   });
   comp.itemRenderer.itemize({
     resolved: comp.state.resolved,
-    dock: comp.settings.layout.dock || 'center'
+    dock: comp.userSettings.layout.dock || 'center'
   });
   comp.navigationRenderer.itemize({
     resolved: comp.state.resolved,
-    dock: comp.settings.layout.dock || 'center',
-    navigation: comp.settings.settings.navigation
+    dock: comp.userSettings.layout.dock || 'center',
+    navigation: comp.userSettings.settings.navigation
   });
 
   comp.state.display = {
@@ -28,7 +28,7 @@ function update(comp) {
 
 function preferredSize(comp, size) {
   let s = 0;
-  const dock = comp.settings.layout.dock || 'center';
+  const dock = comp.userSettings.layout.dock || 'center';
   const orientation = dock === 'top' || dock === 'bottom' ? 'horizontal' : 'vertical';
   const d = comp.state.display;
   const tempLayout = layout(size.inner, d, orientation, {
@@ -46,13 +46,13 @@ function preferredSize(comp, size) {
 function render(legend) {
   const {
     rect,
-    settings,
+    userSettings,
     state,
     itemRenderer,
     navigationRenderer,
     titleRenderer
   } = legend;
-  const dock = settings.layout.dock;
+  const dock = userSettings.layout.dock;
   const orientation = dock === 'top' || dock === 'bottom' ? 'horizontal' : 'vertical';
   const l = layout(rect, state.display, orientation, {
     itemRenderer,
@@ -92,7 +92,7 @@ function render(legend) {
 }
 
 const component = {
-  require: ['chart', 'settings', 'renderer', 'update', 'resolver', 'registries'],
+  require: ['chart', 'renderer', 'update', 'resolver', 'registries'],
   defaultSettings: {
     settings: {},
     style: {
@@ -171,7 +171,7 @@ const component = {
     this.navigationRenderer = navigationRendererFactory(this);
     this.titleRenderer = titleRendererFactory(this);
     this.navigationRenderer.renderer = this.registries.renderer('dom')();
-    this.titleRenderer.renderer = this.registries.renderer(this.settings.renderer)();
+    this.titleRenderer.renderer = this.registries.renderer(this.userSettings.renderer)();
     update(this);
   },
   preferredSize(obj) {

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
@@ -113,14 +113,14 @@ const DEFAULT_SETTINGS = {
 export default function resolveSettings(comp) {
   const domain = comp.scale.domain();
   let data = { items: [] };
-  const dock = comp.settings.layout.dock;
+  const dock = comp.userSettings.layout.dock;
   if (comp.scale.type === 'threshold-color') {
     const fields = comp.scale.data().fields;
     const sourceField = fields[0];
     let formatter = v => String(v);
 
-    if (comp.settings.formatter) {
-      formatter = comp.chart.formatter(comp.settings.formatter);
+    if (comp.userSettings.formatter) {
+      formatter = comp.chart.formatter(comp.userSettings.formatter);
     } else if (sourceField) {
       formatter = sourceField.formatter();
     }
@@ -163,7 +163,7 @@ export default function resolveSettings(comp) {
       fields: comp.scale.data().fields
     },
     defaults: extend(true, {}, DEFAULT_SETTINGS.title, comp.style.title),
-    settings: comp.settings.settings.title
+    settings: comp.userSettings.settings.title
   });
 
   const layout = comp.resolver.resolve({
@@ -171,20 +171,20 @@ export default function resolveSettings(comp) {
       fields: comp.scale.data().fields
     },
     defaults: DEFAULT_SETTINGS.layout,
-    settings: comp.settings.settings.layout
+    settings: comp.userSettings.settings.layout
   });
 
   const labels = comp.resolver.resolve({
     data,
     defaults: extend(true, {}, DEFAULT_SETTINGS.item.label, comp.style.item.label),
-    settings: (comp.settings.settings.item || {}).label
+    settings: (comp.userSettings.settings.item || {}).label
   });
 
-  const shapeSettings = extend(true, {}, (comp.settings.settings.item || {}).shape);
+  const shapeSettings = extend(true, {}, (comp.userSettings.settings.item || {}).shape);
 
-  if (typeof shapeSettings.fill === 'undefined' && comp.settings.scale) {
+  if (typeof shapeSettings.fill === 'undefined' && comp.userSettings.scale) {
     shapeSettings.fill = {
-      scale: comp.settings.scale
+      scale: comp.userSettings.scale
     };
   }
 
@@ -200,7 +200,7 @@ export default function resolveSettings(comp) {
       show: DEFAULT_SETTINGS.item.show
     }),
     settings: {
-      show: (comp.settings.settings.item || {}).show
+      show: (comp.userSettings.settings.item || {}).show
     }
   });
 

--- a/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/legend-seq.js
@@ -296,7 +296,7 @@ const legendDef = {
     return prefSize;
   },
   created() {
-    this.stgns = this.settings.settings;
+    this.stgns = this.userSettings.settings;
 
     this.state = initState(this);
   },

--- a/packages/picasso.js/src/core/chart-components/line/line.js
+++ b/packages/picasso.js/src/core/chart-components/line/line.js
@@ -331,7 +331,7 @@ const lineMarkerComponent = {
   },
   render({ data }) {
     const { width, height } = this.rect;
-    this.stngs = this.settings.settings || {};
+    this.stngs = this.userSettings.settings || {};
     const missingMinor0 = !this.stngs.coordinates || typeof this.stngs.coordinates.minor0 === 'undefined';
 
     const visibleLayers = calculateVisibleLayers({

--- a/packages/picasso.js/src/core/chart-components/pie/pie.js
+++ b/packages/picasso.js/src/core/chart-components/pie/pie.js
@@ -153,7 +153,7 @@ const pieComponent = {
   render({ data }) {
     const arcValues = [];
     const slices = [];
-    const stngs = this.settings.settings;
+    const stngs = this.userSettings.settings;
     const { items } = this.resolver.resolve({
       data,
       defaults: extend({}, DEFAULT_DATA_SETTINGS.slice, this.style.slice),

--- a/packages/picasso.js/src/core/chart-components/point/point.js
+++ b/packages/picasso.js/src/core/chart-components/point/point.js
@@ -144,17 +144,17 @@ const component = {
     const resolved = this.resolver.resolve({
       data,
       defaults: extend({}, DEFAULT_DATA_SETTINGS, this.style.item),
-      settings: this.settings.settings,
+      settings: this.userSettings.settings,
       scaled: {
         x: this.rect.width,
         y: this.rect.height
       }
     });
     const { width, height } = this.rect;
-    const limits = extend({}, SIZE_LIMITS, this.settings.settings.sizeLimits);
+    const limits = extend({}, SIZE_LIMITS, this.userSettings.settings.sizeLimits);
     const points = resolved.items;
     const pointSize = getPointSizeLimits(resolved.settings.x, resolved.settings.y, width, height, limits);
-    return createDisplayPoints(points, this.rect, pointSize, this.settings.shapeFn || shapeFactory);
+    return createDisplayPoints(points, this.rect, pointSize, this.userSettings.shapeFn || shapeFactory);
   }
 };
 

--- a/packages/picasso.js/src/core/chart-components/range/__tests__/range.spec.js
+++ b/packages/picasso.js/src/core/chart-components/range/__tests__/range.spec.js
@@ -18,12 +18,14 @@ describe('range component', () => {
       render: sinon.stub()
     };
 
-    settings = {};
+    settings = {
+      layout: {}
+    };
 
     context = {
       chart,
       renderer,
-      settings: {
+      userSettings: {
         settings
       },
       rect: {

--- a/packages/picasso.js/src/core/chart-components/range/range.js
+++ b/packages/picasso.js/src/core/chart-components/range/range.js
@@ -123,7 +123,7 @@ const rangeComponent = {
     this.state = {};
   },
   render() {
-    const stngs = this.settings.settings;
+    const stngs = this.userSettings.settings;
     const brush = this.chart.brush(stngs.brush);
     const direction = stngs.direction || 'horizontal';
     const distance = direction === 'horizontal' ? this.rect.width : this.rect.height;

--- a/packages/picasso.js/src/core/chart-components/ref-line/refline.js
+++ b/packages/picasso.js/src/core/chart-components/ref-line/refline.js
@@ -163,7 +163,7 @@ const refLineComponent = {
   },
 
   render() {
-    let settings = this.settings;
+    let settings = this.userSettings;
 
     // Setup lines for X and Y
     this.lines = {

--- a/packages/picasso.js/src/core/chart-components/scrollbar/index.js
+++ b/packages/picasso.js/src/core/chart-components/scrollbar/index.js
@@ -130,25 +130,25 @@ const scrollbarComponent = {
   },
 
   preferredSize: function preferredSize(rect) {
-    const scrollState = this.chart.scroll(this.settings.scroll).getState();
+    const scrollState = this.chart.scroll(this.userSettings.scroll).getState();
     // hide the scrollbar if it is not possible to scroll
     if (scrollState.viewSize >= scrollState.max - scrollState.min) {
       const toLargeSize = Math.max(rect.width, rect.height);
       return toLargeSize;
     }
-    return this.settings.settings.width;
+    return this.userSettings.settings.width;
   },
 
   render: function render(h) {
-    const dock = this.settings.layout.dock;
-    const invert = this.settings.settings.invert;
+    const dock = this.userSettings.layout.dock;
+    const invert = this.userSettings.settings.invert;
     const horizontal = dock === 'top' || dock === 'bottom';
     const lengthAttr = horizontal ? 'width' : 'height';
 
     const _rect = this.rect;
     const length = _rect[lengthAttr];
 
-    const scrollState = this.chart.scroll(this.settings.scroll).getState();
+    const scrollState = this.chart.scroll(this.userSettings.scroll).getState();
     let thumbStart = (length * (scrollState.start - scrollState.min)) / (scrollState.max - scrollState.min);
     const thumbRange = (length * scrollState.viewSize) / (scrollState.max - scrollState.min);
 
@@ -163,7 +163,7 @@ const scrollbarComponent = {
           position: 'relative',
           width: '100%',
           height: '100%',
-          background: this.settings.settings.backgroundColor,
+          background: this.userSettings.settings.backgroundColor,
           pointerEvents: 'auto'
         }
       },
@@ -175,7 +175,7 @@ const scrollbarComponent = {
           [horizontal ? 'top' : 'left']: '25%',
           [horizontal ? 'height' : 'width']: '50%', // ${width}px
           [lengthAttr]: `${Math.max(1, thumbRange)}px`,
-          background: this.settings.settings.thumbColor
+          background: this.userSettings.settings.thumbColor
         }
       }))
     );

--- a/packages/picasso.js/src/core/chart-components/text/text.js
+++ b/packages/picasso.js/src/core/chart-components/text/text.js
@@ -146,9 +146,9 @@ const textComponent = {
   },
 
   created() {
-    this.definitionSettings = this.settings.settings;
+    this.definitionSettings = this.userSettings.settings;
 
-    const text = this.settings.text;
+    const text = this.userSettings.text;
     const join = this.definitionSettings.join;
     this.title = parseTitle(text, join, this.scale);
   },
@@ -171,7 +171,7 @@ const textComponent = {
     const nodes = [];
     nodes.push(generateTitle({
       title,
-      dock: this.settings.layout.dock,
+      dock: this.userSettings.layout.dock,
       definitionSettings,
       rect,
       measureText: this.renderer.measureText,
@@ -182,10 +182,10 @@ const textComponent = {
 
   beforeUpdate(opts) {
     if (opts.settings) {
-      extend(this.settings, opts.settings);
+      extend(this.userSettings, opts.settings);
       this.definitionSettings = opts.settings.settings;
     }
-    const text = this.settings.text;
+    const text = this.userSettings.text;
     const join = this.definitionSettings.join;
     this.title = parseTitle(text, join, this.scale);
   }

--- a/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
@@ -349,4 +349,10 @@ describe('Component', () => {
       expect(spy).to.have.been.calledWith({ x: 0 }, ['x'], 'xor');
     });
   });
+  describe('userSettings on a component', () => {
+    it('should contain a userSetting property', () => {
+      const instance = createInstance();
+      expect(instance.ctx.userSettings).to.not.equal(undefined);
+    });
+  });
 });

--- a/packages/picasso.js/src/web/components/brush-area/brush-area.js
+++ b/packages/picasso.js/src/web/components/brush-area/brush-area.js
@@ -193,7 +193,7 @@ const definition = {
       return;
     }
 
-    this.state.brushConfig = getBrushConfig(this.settings);
+    this.state.brushConfig = getBrushConfig(this.userSettings);
     this.state.start = getLocalPoint(this, e);
     this.state.active = true;
   },

--- a/packages/picasso.js/src/web/components/brush-range/brush-area-dir.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-area-dir.js
@@ -173,13 +173,13 @@ const brushAreaDirectionalComponent = {
   },
   created() {
     this.state = {
-      key: this.settings.key || 'brush-area-dir'
+      key: this.userSettings.key || 'brush-area-dir'
     };
   },
   render(h) {
     this.state.rect = this.rect;
 
-    const stngs = this.settings.settings;
+    const stngs = this.userSettings.settings;
     const direction = stngs.direction === 'vertical' ? VERTICAL : HORIZONTAL;
     const size = this.state.rect[direction === VERTICAL ? 'height' : 'width'];
     const offset = this.renderer.element().getBoundingClientRect();

--- a/packages/picasso.js/src/web/components/brush-range/brush-range.js
+++ b/packages/picasso.js/src/web/components/brush-range/brush-range.js
@@ -250,7 +250,7 @@ const brushRangeComponent = {
   },
   created() {
     this.state = {
-      key: this.settings.key || 'brush-range'
+      key: this.userSettings.key || 'brush-range'
     };
   },
   beforeRender(opts) {
@@ -264,7 +264,7 @@ const brushRangeComponent = {
     }
   },
   render(h) {
-    const stngs = this.settings.settings;
+    const stngs = this.userSettings.settings;
     this.state.direction = stngs.direction === 'vertical' ? VERTICAL : HORIZONTAL;
     const offset = this.renderer.element().getBoundingClientRect();
     const size = this.state.rect[this.state.direction === VERTICAL ? 'height' : 'width'];

--- a/packages/picasso.js/src/web/components/tooltip/tooltip.js
+++ b/packages/picasso.js/src/web/components/tooltip/tooltip.js
@@ -336,7 +336,7 @@ const component = {
     });
   },
   created() {
-    this.init(this.settings);
+    this.init(this.userSettings);
   },
   beforeUpdate({ settings }) {
     if (this.dispatcher) {

--- a/packages/picasso.js/test/component/chart/chart.comp.js
+++ b/packages/picasso.js/test/component/chart/chart.comp.js
@@ -235,7 +235,7 @@ describe('Chart', () => {
     let renderOrder = [];
     p.component('custom-log-render', {
       render() {
-        renderOrder.push(this.settings.key);
+        renderOrder.push(this.userSettings.key);
         return [];
       }
     });


### PR DESCRIPTION
## DEPRECATION
`this.settings` in component definition is now deprecated.

This PR will increase the dev experience for defining chart components and prepare for compose API.

Before (DEPRECATED):
A component definition used to access the user's settings with `this.settings`

After:
A component can now access the user's settings `this.userSettings`

These are the settings used to instantiate a component in the chart. This will eliminate the frequent accessor `this.settings.settings`  that exists in many of the component definitions.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
