### PR TITLE
feat: log warning for unintentional registry use

### DIFF
--- a/packages/picasso.js/src/core/utils/__tests__/registry.spec.js
+++ b/packages/picasso.js/src/core/utils/__tests__/registry.spec.js
@@ -2,8 +2,13 @@ import registry from '../registry';
 
 describe('Registry', () => {
   let reg;
+  let logger;
+
   beforeEach(() => {
-    reg = registry();
+    logger = {
+      warn: sinon.spy()
+    };
+    reg = registry('', 'myRegistry', logger);
   });
 
   describe('add', () => {
@@ -29,6 +34,13 @@ describe('Registry', () => {
       reg.register('a', () => {});
       const registered = reg.register('a', () => {});
       expect(registered).to.equal(false);
+    });
+
+    it('should warn if key does not exist', () => {
+      reg.register('spelledCorrect', () => {});
+      const attempt = reg('spelledWrong');
+      expect(attempt).to.equal(undefined);
+      expect(logger.warn).to.have.been.calledOnce;
     });
   });
 });

--- a/packages/picasso.js/src/core/utils/registry.js
+++ b/packages/picasso.js/src/core/utils/registry.js
@@ -1,4 +1,4 @@
-export default function registryFactory(parentRegistry) {
+export default function registryFactory(parentRegistry, registerName = 'unspecified', logger) {
   let defaultValue;
   const reg = {};
   const parent = parentRegistry || {
@@ -72,7 +72,11 @@ export default function registryFactory(parentRegistry) {
     if (typeof value !== 'undefined') {
       return add(key, value);
     }
-    return get(key || defaultValue);
+    const ret = get(key);
+    if (logger && typeof ret === 'undefined') {
+      logger.warn(`${key} does not exist in ${registerName} registry`);
+    }
+    return ret || get(defaultValue);
   }
 
   registry.add = add;

--- a/packages/picasso.js/src/index.js
+++ b/packages/picasso.js/src/index.js
@@ -42,38 +42,38 @@ function pic(config = {}, registries = {}) {
      * Component registry
      * @type {registry}
      */
-    component: registry(registries.component),
+    component: registry(registries.component, 'component', logger),
     /**
      * Data registry
      * @type {registry}
      */
-    data: registry(registries.data),
+    data: registry(registries.data, 'data', logger),
     /**
      * Formatter registry
      * @type {registry}
      */
-    formatter: registry(registries.formatter),
+    formatter: registry(registries.formatter, 'formatter', logger),
     /**
      * Interaction registry
      * @type {registry}
      */
-    interaction: registry(registries.interaction),
+    interaction: registry(registries.interaction, 'interaction', logger),
     /**
      * Renderer registry
      * @type {registry}
      */
-    renderer: renderer(registries.renderer),
+    renderer: renderer(registries.renderer, 'renderer', logger),
     /**
      * Scale registry
      * @type {registry}
      */
-    scale: registry(registries.scale),
+    scale: registry(registries.scale, 'scale', logger),
     /**
      * Symbol registry
      * @type {registry}
      * @private
      */
-    symbol: registry(registries.symbol),
+    symbol: registry(registries.symbol, 'symbol', logger),
     // -- misc --
     /**
      * log some some stuff


### PR DESCRIPTION
When accessing registries with a wrongful key we're now logging a warning.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
