### PR TITLE
refactor: revert userSettings

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -246,7 +246,7 @@ function chartFn(definition, context) {
         instance: c.instance,
         resize: c.instance.resize,
         preferredSize: dockConfig.computePreferredSize.bind(dockConfig),
-        userSettings: c.settings,
+        settings: c.settings,
         layoutComponents: () => {}
       };
     });

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -53,9 +53,6 @@ function prepareContext(ctx, definition, opts) {
   }
 
   // TODO add setters and log warnings / errors to console
-  Object.defineProperty(ctx, 'userSettings', {
-    get: settings
-  });
   Object.defineProperty(ctx, 'settings', {
     get: settings
   });

--- a/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
@@ -14,7 +14,7 @@ describe('Dock Layout', () => {
   } = {}) {
     const dummy = {};
 
-    dummy.userSettings = {
+    dummy.settings = {
       key,
       show,
       layout: {
@@ -192,9 +192,9 @@ describe('Dock Layout', () => {
 
     it('should throw an expection if needed properties are missing', () => {
       const mainComp = {};
-      const leftComp = { userSettings: { layout: { dock: 'left' } } };
-      const rightComp = { userSettings: { layout: { dock: 'right' } }, resize: {} };
-      const asfdComp = { userSettings: { layout: { dock: 'right' } }, resize: () => {} };
+      const leftComp = { settings: { layout: { dock: 'left' } } };
+      const rightComp = { settings: { layout: { dock: 'right' } }, resize: {} };
+      const asfdComp = { settings: { layout: { dock: 'right' } }, resize: () => {} };
       const fn = () => {
         dl.layout(rect, [mainComp]);
       };
@@ -814,7 +814,7 @@ describe('Dock Layout', () => {
 
       const { visible, order } = dl.layout(rect, [mainComp, leftComp, onLeft, onMain]);
 
-      expect(visible.map(v => v.userSettings.key)).to.eql(['main', 'y', 'dockAtY', 'dockAtMain']);
+      expect(visible.map(v => v.settings.key)).to.eql(['main', 'y', 'dockAtY', 'dockAtMain']);
       expect(order).to.eql([1, 3, 2, 0]);
     });
   });

--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -344,7 +344,7 @@ function checkShowSettings(strategySettings, dockSettings, logicalContainerRect)
 }
 
 function validateComponent(component) {
-  if (!component.settings && !component.userSettings) {
+  if (!component.settings && !component.settings) {
     throw new Error('Invalid component settings');
   }
   if (!component.resize || typeof component.resize !== 'function') {
@@ -367,9 +367,9 @@ function filterComponents(components, settings, rect) {
     if (comp.instance) {
       config = comp.instance.dockConfig();
     } else {
-      config = dockConfig(comp.userSettings.layout);
+      config = dockConfig(comp.settings.layout);
     }
-    const key = comp.userSettings.key;
+    const key = comp.settings.key;
     const d = config.dock();
     const referencedDocks = /@/.test(d) ? d.split(',').map(s => s.replace(/^\s*@/, '')) : [];
     if (checkShowSettings(settings, config, rect)) {


### PR DESCRIPTION
in #354 we introduced that component definition can access the settings provided by the user with `this.userSettings`. This reverts the change

**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
