### PR TITLE
refactor: correct call for preferredSize in dock layout

### DIFF
--- a/packages/picasso.js/src/core/layout/dock/config.js
+++ b/packages/picasso.js/src/core/layout/dock/config.js
@@ -49,7 +49,7 @@ function dockConfig(settings = {}, callbackContext = {}) {
      *  }
      * })); // Require a size of 150 in the dock direction and a bleed size of 50 to the left and right dock direction
      */
-    computePreferredSize(inner, outer) {
+    computePreferredSize({ inner, outer }) {
       if (typeof preferredSize === 'function') {
         return preferredSize({ inner, outer, dock: this.dock() }, callbackContext);
       }

--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -6,7 +6,8 @@ import createRect from './create-rect';
 
 function cacheSize(c, reducedRect, layoutRect) {
   if (typeof c.cachedSize === 'undefined') {
-    let size = c.comp.preferredSize(reducedRect, layoutRect);
+    const dock = c.config.dock();
+    let size = c.comp.preferredSize({ inner: reducedRect, outer: layoutRect, dock });
     // backwards compatibility
     if (!isNaN(size)) {
       size = { width: size, height: size };
@@ -15,7 +16,6 @@ function cacheSize(c, reducedRect, layoutRect) {
       size.height = size.size;
     }
 
-    const dock = c.config.dock();
     let relevantSize;
     if (dock === 'top' || dock === 'bottom') {
       relevantSize = size.height;

--- a/packages/picasso.js/test/helpers/component-factory-fixture.js
+++ b/packages/picasso.js/test/helpers/component-factory-fixture.js
@@ -158,7 +158,7 @@ export default function componentFactoryFixture() {
     return rendererOutput;
   };
 
-  fn.simulateLayout = opts => comp.dockConfig().computePreferredSize(opts.inner, opts.outer);
+  fn.simulateLayout = opts => comp.dockConfig().computePreferredSize(opts);
 
   fn.getRenderOutput = () => rendererOutput;
 


### PR DESCRIPTION
in the compose API the dock layout goes straight to the components to ask for preferredSize (not via the dock config object).  This PR makes is a preparation for that.

**Checklist**

- [x ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
