### PR TITLE
fix: computedInner and computerOuter rect is undefined

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -365,12 +365,12 @@ function componentFactory(definition, context = {}) {
     }
     instanceContext.rect = extend(true, {
       computedPhysical: size.computedPhysical,
-      computedOuter: outer.computed,
-      computedInner: inner.computed
+      computedOuter: outer.computed || outer,
+      computedInner: inner.computed || inner
     }, inner);
     size = extend(true, {
-      computedOuter: outer.computed,
-      computedInner: inner.computed
+      computedOuter: outer.computed || outer,
+      computedInner: inner.computed || inner
     }, size);
   };
 


### PR DESCRIPTION
Fixes an issue where computedInner and computerOuter rect would be undefined if a component was hidden by the dock layout. Causing a cascade of outer issues when components would expect them to be available.