### PR TITLE
feat: dock layout for rects not in origin

### DIFF
--- a/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
+++ b/packages/picasso.js/src/core/layout/dock/__tests__/dock-layout.spec.js
@@ -332,6 +332,94 @@ describe('Dock Layout', () => {
     });
   });
 
+  describe('Layout', () => {
+    let rect;
+    let dl;
+
+    beforeEach(() => {
+      rect = createRect(500, 500, 1000, 1000);
+      dl = dockLayout();
+    });
+
+    it('should set correct component rects when container rect is not starting in origin', () => {
+      const components = [
+        componentMock({ dock: 'left', size: 50 }),
+        componentMock({ dock: 'right', size: 100 }),
+        componentMock(),
+        componentMock({ dock: 'top', size: 150 }),
+        componentMock({ dock: 'bottom', size: 200 })
+      ];
+
+      dl.layout(rect, components);
+
+      // outer rects
+      expect(components[0].outer, 'Left outerRect had incorrect calculated size').to.deep.include({
+        x: 500,
+        y: 500,
+        width: 50,
+        height: 1000
+      });
+      expect(components[1].outer, 'Right outerRect had incorrect calculated size').to.deep.include({
+        x: 1400,
+        y: 500,
+        width: 100,
+        height: 1000
+      });
+      expect(components[2].outer, 'Main outerRect had incorrect calculated size').to.deep.include({
+        x: 550,
+        y: 650,
+        width: 850,
+        height: 650
+      });
+      expect(components[3].outer, 'Top outerRect had incorrect calculated size').to.deep.include({
+        x: 500,
+        y: 500,
+        width: 1000,
+        height: 150
+      });
+      expect(components[4].outer, 'Bottom outerRect had incorrect calculated size').to.deep.include(
+        {
+          x: 500,
+          y: 1300,
+          width: 1000,
+          height: 200
+        }
+      );
+
+      // main rects
+      expect(components[0].rect, 'Left rect had incorrect calculated size').to.deep.include({
+        x: 500,
+        y: 650,
+        width: 50,
+        height: 650
+      });
+      expect(components[1].rect, 'Right rect had incorrect calculated size').to.deep.include({
+        x: 1400,
+        y: 650,
+        width: 100,
+        height: 650
+      });
+      expect(components[2].rect, 'Main rect had incorrect calculated size').to.deep.include({
+        x: 550,
+        y: 650,
+        width: 850,
+        height: 650
+      });
+      expect(components[3].rect, 'Top rect had incorrect calculated size').to.deep.include({
+        x: 550,
+        y: 500,
+        width: 850,
+        height: 150
+      });
+      expect(components[4].rect, 'Bottom rect had incorrect calculated size').to.deep.include({
+        x: 550,
+        y: 1300,
+        width: 850,
+        height: 200
+      });
+    });
+  });
+
   describe('Settings', () => {
     let settings;
     let container;

--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -220,7 +220,7 @@ function boundingBox(rects) {
 }
 
 function positionComponents({
-  visible, layoutRect, reducedRect, containerRect
+  visible, layoutRect, reducedRect, containerRect, translation
 }) {
   const vRect = createRect(reducedRect.x, reducedRect.y, reducedRect.width, reducedRect.height);
   const hRect = createRect(reducedRect.x, reducedRect.y, reducedRect.width, reducedRect.height);
@@ -319,6 +319,10 @@ function positionComponents({
       rect.computed = computeRect(rect);
       outerRect.edgeBleed = c.edgeBleed;
       outerRect.computed = computeRect(outerRect);
+      rect.x += translation.x;
+      rect.y += translation.y;
+      outerRect.x += translation.x;
+      outerRect.y += translation.y;
       c.comp.resize(rect, outerRect);
       c.cachedSize = undefined;
       c.edgeBleed = undefined;
@@ -428,11 +432,15 @@ function dockLayout(initialSettings) {
       hidden,
       settings
     });
+
+    const translation = { x: rect.x, y: rect.y };
+
     const order = positionComponents({
       visible,
       layoutRect: logicalContainerRect,
       reducedRect,
-      containerRect
+      containerRect,
+      translation
     });
     hidden.forEach((c) => {
       c.comp.visible = false;


### PR DESCRIPTION
If the rect for the dock-layout was not originating from x:0 y:0 the laid out components got wrongly positioned as if they were originating from x:0 y:0

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
