### PR TITLE
perf: text metrics

### DIFF
--- a/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
@@ -4,7 +4,6 @@ describe('text-metrics', () => {
   describe('measureText', () => {
     let sandbox,
       canvasContextMock,
-      canvasMock,
       cacheId = 0,
       fontWasUnset = false;
 
@@ -14,7 +13,7 @@ describe('text-metrics', () => {
       fontFamily: 'Arial'
     };
 
-    beforeEach(() => {
+    before(() => {
       sandbox = sinon.createSandbox();
 
       canvasContextMock = {
@@ -25,19 +24,15 @@ describe('text-metrics', () => {
         })
       };
 
-      canvasMock = {
-        getContext: sandbox.spy(() => canvasContextMock)
-      };
-
       global.document = {
-        createElement: sandbox.spy(() => canvasMock)
+        createElement: sandbox.spy(() => ({ getContext: () => canvasContextMock }))
       };
     });
 
     afterEach(() => {
       fontWasUnset = false;
       canvasContextMock.font = '';
-      sandbox.restore();
+      sandbox.resetHistory();
     });
 
     after(() => {
@@ -61,14 +56,14 @@ describe('text-metrics', () => {
       expect(fontWasUnset).to.equal(false);
     });
 
-    it('should fire measureText twice with correct arguments', () => {
+    it('should fire measureText once with correct arguments', () => {
       argument.fontSize = ++cacheId;
 
       measureText(argument);
 
-      expect(canvasContextMock.measureText.calledTwice).to.equal(true);
-      expect(canvasContextMock.measureText.calledWith('Test')).to.equal(true);
-      expect(canvasContextMock.measureText.calledWith('M')).to.equal(true);
+      expect(canvasContextMock.measureText).to.have.been.calledTwice;
+      expect(canvasContextMock.measureText).to.have.been.calledWith('Test');
+      expect(canvasContextMock.measureText).to.have.been.calledWith('M');
     });
 
     it('should reuse the previously created canvas element', () => {


### PR DESCRIPTION
This PR aims to improve the performance of the measure text function for a specific use case, that is when multiple calls to measure text function share the same font size and font family, which is typically the case when the ellipsis function iterates over some text to find a suitable break point.

As always with these kinds of micro-optimisations it's hard to determine the impact. But in one case when never hitting the cache and using same font styling - latest chrome version seem to yield up to 30% better performance. In most of other cases it appears to stay more or less the same. 