### PR TITLE
fix(legend-cat): fix setting initial legend scroll offset

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
@@ -276,7 +276,7 @@ export default function (legend, {
   const api = {
     itemize: (obj) => {
       itemized = itemize(obj, legend.renderer);
-      offset = offset === null && !isNaN(itemized.layout.scrollOffset) ? itemized.layout.scrollOffset : offset; // Set the initial offset
+      offset = !isNaN(itemized.layout.scrollOffset) ? itemized.layout.scrollOffset : offset; // Set the initial offset
     },
     getItemsToRender: (obj) => {
       viewRect = obj.viewRect;


### PR DESCRIPTION
Problem:
When legend scroll offset is set before the data is set, the legend scroll offset will be reset to zero after the data is set (through getItemsToRender).
The problem comes from the fact that after the offset is set to zero, it is never reinitialized again by the checking offset === null in itemize function.

Solution:
Remove checking offset === null in the itemize function.

This will fix the problem of legend scroll offset is always at zero in the snapshot mode when a bar chart has 2 dimensions.

Before this fix:
![image](https://user-images.githubusercontent.com/20044781/56571002-52dd4280-65bc-11e9-98cf-7784f3283753.png)

After this fix:
![image](https://user-images.githubusercontent.com/20044781/56570899-1c9fc300-65bc-11e9-9f33-c8cbb0f35044.png)
