### PR TITLE
fix(legend-cat): title baseline

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/title-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/title-renderer.js
@@ -46,7 +46,7 @@ function render({
     nodes.push(extend({}, itemized.displayObject, {
       x: align[itemized.displayObject.anchor] || 0,
       y: 0,
-      baseline: 'hanging',
+      baseline: 'text-before-edge',
       title: itemized.displayObject.text
     }));
   }


### PR DESCRIPTION
Fixes an issue where the title could clip the top of certain characters.
