### PR TITLE
fix(text-metrics): height measurement

### DIFF
--- a/packages/picasso.js/src/web/text-manipulation/__tests__/font-size-to-height.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/font-size-to-height.spec.js
@@ -1,0 +1,37 @@
+import fontSizeToHeight from '../font-size-to-height';
+
+describe('font-size to height', () => {
+  it('should use 24px a base for determing height', () => {
+    // font-size + 4
+    expect(fontSizeToHeight('9px')).to.equal(13);
+    expect(fontSizeToHeight('12px')).to.equal(16);
+    expect(fontSizeToHeight('23.99px')).to.equal(27.99);
+
+    // font-size + 8
+    expect(fontSizeToHeight('24px')).to.equal(32);
+    expect(fontSizeToHeight('36px')).to.equal(44);
+    expect(fontSizeToHeight('47.99px')).to.equal(55.99);
+
+    // font-size + 12
+    expect(fontSizeToHeight('48px')).to.equal(60);
+    expect(fontSizeToHeight('71.99px')).to.equal(83.99);
+  });
+
+  it('should only accept valid font-size format', () => {
+    // Valid
+    expect(fontSizeToHeight('16px')).to.equal(20);
+    expect(fontSizeToHeight(' 16px ')).to.equal(20);
+    expect(fontSizeToHeight(' 16PX ')).to.equal(20);
+    expect(fontSizeToHeight('16.0123456789px')).to.equal(20.0123456789);
+
+    // Invalid
+    expect(fontSizeToHeight('123')).to.equal(16);
+    expect(fontSizeToHeight('123 px')).to.equal(16);
+    expect(fontSizeToHeight(123)).to.equal(16);
+    expect(fontSizeToHeight(null)).to.equal(16);
+    expect(fontSizeToHeight([])).to.equal(16);
+    expect(fontSizeToHeight(false)).to.equal(16);
+    expect(fontSizeToHeight(() => {})).to.equal(16);
+    expect(fontSizeToHeight({})).to.equal(16);
+  });
+});

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
@@ -44,7 +44,7 @@ describe('text-metrics', () => {
 
       const result = measureText(argument);
 
-      expect(result).to.deep.equal({ width: 150, height: 180 });
+      expect(result).to.deep.equal({ width: 150, height: 16 });
     });
 
     it('should set the correct font before firing measureText', () => {
@@ -61,9 +61,8 @@ describe('text-metrics', () => {
 
       measureText(argument);
 
-      expect(canvasContextMock.measureText).to.have.been.calledTwice;
+      expect(canvasContextMock.measureText).to.have.been.calledOnce;
       expect(canvasContextMock.measureText).to.have.been.calledWith('Test');
-      expect(canvasContextMock.measureText).to.have.been.calledWith('M');
     });
 
     it('should reuse the previously created canvas element', () => {
@@ -106,32 +105,6 @@ describe('text-metrics', () => {
       measureText(argument);
 
       expect(canvasContextMock.measureText.withArgs('Test').calledTwice).to.equal(true);
-    });
-
-    it('should reuse past height calculations if arguments match previous use case', () => {
-      argument.fontSize = ++cacheId;
-
-      measureText(argument);
-
-      expect(canvasContextMock.measureText.withArgs('M').calledOnce).to.equal(true);
-
-      measureText(argument);
-
-      expect(canvasContextMock.measureText.withArgs('M').calledOnce).to.equal(true);
-    });
-
-    it('should not reuse past height calculations if arguments does not match previous use case', () => {
-      argument.fontSize = ++cacheId;
-
-      measureText(argument);
-
-      expect(canvasContextMock.measureText.withArgs('M').calledOnce).to.equal(true);
-
-      argument.fontSize = ++cacheId;
-
-      measureText(argument);
-
-      expect(canvasContextMock.measureText.withArgs('M').calledTwice).to.equal(true);
     });
   });
 

--- a/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
+++ b/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
@@ -2,7 +2,7 @@ const BASE = 24;
 const PAD = 4;
 const BUMP = 1e-12;
 const DEFAULT_HEIGHT = 16;
-const TEXT_REGEX = /^\s*([0-9]+|[0-9]+\.{1}[0-9]+)[px]{2}\s*$/i;
+const TEXT_REGEX = /^\s*\d+(\.\d+)?px\s*$/i;
 
 function isValidFontSize(val) {
   const type = typeof val;

--- a/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
+++ b/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
@@ -1,0 +1,25 @@
+const BASE = 24;
+const PAD = 4;
+const BUMP = 1e-12;
+const DEFAULT_HEIGHT = 16;
+const TEXT_REGEX = /^\s*([0-9]+|[0-9]+\.{1}[0-9]+)[px]{2}\s*$/i;
+
+function isValidFontSize(val) {
+  const type = typeof val;
+  if (type === 'string') {
+    return TEXT_REGEX.test(val);
+  }
+
+  return false;
+}
+
+export default function fontSizeToHeight(fontSize) {
+  if (isValidFontSize(fontSize)) {
+    const size = parseFloat(fontSize);
+    const m = PAD * Math.ceil((size + BUMP) / BASE);
+
+    return size + m;
+  }
+
+  return DEFAULT_HEIGHT;
+}

--- a/packages/picasso.js/src/web/text-manipulation/text-metrics.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-metrics.js
@@ -5,9 +5,7 @@ import {
   DEFAULT_LINE_HEIGHT,
   ELLIPSIS_CHAR
 } from './text-const';
-
-const BASE_HEIGHT_CHAR = 'M';
-const WIDTH_TO_HEIGHT_MULTIPLIER = 1.2;
+import fontSizeToHeight from './font-size-to-height';
 
 const heightCache = {};
 const widthCache = {};
@@ -42,14 +40,12 @@ function measureTextWidth(text, fontSize, fontFamily) {
   return widthCache[key];
 }
 
-function measureTextHeight(fontSize, fontFamily) {
-  const key = fontSize + fontFamily;
-
-  if (typeof heightCache[key] !== 'number') {
-    heightCache[key] = measureTextWidth(BASE_HEIGHT_CHAR, fontSize, fontFamily) * WIDTH_TO_HEIGHT_MULTIPLIER;
+function measureTextHeight(fontSize) {
+  if (typeof heightCache[fontSize] !== 'number') {
+    heightCache[fontSize] = fontSizeToHeight(fontSize);
   }
 
-  return heightCache[key];
+  return heightCache[fontSize];
 }
 
 /**
@@ -68,7 +64,7 @@ function measureTextHeight(fontSize, fontFamily) {
  */
 export function measureText({ text, fontSize, fontFamily }) {
   const w = measureTextWidth(text, fontSize, fontFamily);
-  const h = measureTextHeight(fontSize, fontFamily);
+  const h = measureTextHeight(fontSize);
   return { width: w, height: h };
 }
 


### PR DESCRIPTION
Changes how the height of a text is measured to a method based on the font-size pixel value. This will make it less prone to issue with fonts that have narrow style for the character `M`.

See example below using `Arial` for the difference when computing the bounding rectangle of a text. Where the red rectangle is the bounds.

**Before**
![Screenshot 2019-04-24 at 13 58 47](https://user-images.githubusercontent.com/16608020/56657750-22b7a180-6699-11e9-9558-d77bcbc63bf0.png)

**After**
![Screenshot 2019-04-24 at 13 58 33](https://user-images.githubusercontent.com/16608020/56657737-1c292a00-6699-11e9-9c86-9e27a993c6bd.png)
