### PR TITLE
fix(q): handle qMode: 'K' in q-brush

### DIFF
--- a/plugins/q/src/brush/__tests__/q-brush.spec.js
+++ b/plugins/q/src/brush/__tests__/q-brush.spec.js
@@ -229,6 +229,20 @@ describe('q-brush', () => {
       expect(selections[0].method).to.equal('selectPivotCells');
     });
 
+    it('should have method="selectPivotCells" when qMode="K"', () => {
+      layout.qHyperCube.qMode = 'K';
+
+      const selections = qBrush(brush, { byCells: true }, layout);
+      expect(selections[0].method).to.equal('selectPivotCells');
+    });
+
+    it('should have method="selectPivotCells" when qMode="P"', () => {
+      layout.qHyperCube.qMode = 'P';
+
+      const selections = qBrush(brush, { byCells: true }, layout);
+      expect(selections[0].method).to.equal('selectPivotCells');
+    });
+
     it('should have valid params when primary is not specified', () => {
       layout.qHyperCube.qNoOfLeftDims = 1;
       layout.qHyperCube.qEffectiveInterColumnSortOrder.push(2);

--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -196,7 +196,7 @@ export default function qBrush(brush, opts = {}, layout) {
 
       if (b.type === 'value' && info.dimensionIdx > -1) {
         if (byCells) {
-          if (layout && layout.qHyperCube && (layout.qHyperCube.qMode === 'P' || layout.qHyperCube.qMode === 'T')) {
+          if (layout && layout.qHyperCube && (layout.qHyperCube.qMode === 'P' || layout.qHyperCube.qMode === 'T' || layout.qHyperCube.qMode === 'K')) {
             const hyperCube = layout.qHyperCube;
             const noOfLeftDims = hyperCube.qNoOfLeftDims;
             const dimInterColSortIdx = hyperCube.qEffectiveInterColumnSortOrder.indexOf(info.dimensionIdx);


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

- Switch the selection call to selectPivotCell for ```qMode: 'K'```
