### PR TITLE
fix(legend-cat): add enabled/disabled state to navigation buttons

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.23.2",
+    "version": "0.24.0",
     "license": "MIT"
   },
   "entries": {
@@ -2549,6 +2549,12 @@
                       "type": "function"
                     }
                   }
+                },
+                "disabled": {
+                  "description": "Whether the button should be disabled or not",
+                  "optional": true,
+                  "defaultValue": false,
+                  "type": "boolean"
                 }
               }
             }

--- a/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/legend-resolver.js
@@ -100,7 +100,10 @@ const DEFAULT_SETTINGS = {
       /**
        * @type {function} */
       content: undefined
-    }
+    },
+    /** Whether the button should be disabled or not
+     * @type {boolean=} */
+    disabled: false
   }
 };
 

--- a/packages/picasso.js/src/core/chart-components/legend-cat/navigation-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/navigation-renderer.js
@@ -51,7 +51,7 @@ function btn(h, {
     style.background = 'none';
   }
   const attrsMerged = attrs;
-  if (!isActive || nav.disabled) {
+  if (!isActive || (nav && nav.disabled)) {
     attrsMerged.disabled = 'disabled';
   }
 

--- a/packages/picasso.js/src/core/chart-components/legend-cat/navigation-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/navigation-renderer.js
@@ -51,7 +51,7 @@ function btn(h, {
     style.background = 'none';
   }
   const attrsMerged = attrs;
-  if (!isActive) {
+  if (!isActive || nav.disabled) {
     attrsMerged.disabled = 'disabled';
   }
 


### PR DESCRIPTION
This PR is to allow disabling navigation buttons of a categorical color legend.
