### PR TITLE
fix(text-metrics): condition for using line break when computing bounds

### DIFF
--- a/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
@@ -199,15 +199,17 @@ describe('text-metrics', () => {
 
       describe('wordBreak', () => {
         describe('break-all', () => {
-          it('no other affecting properties', () => {
+          it('should not compute bounds based on line break given no maxWidth is set', () => {
             node.wordBreak = 'break-all';
+            node.maxLines = 2;
+            node.lineHeight = 10;
             bounds = textBounds(node, textMeasureMock);
             expect(bounds).to.deep.equal({
-              x: 1, y: 1.25, width: 4, height: 1.2
+              x: 1, y: 1.25, width: 4, height: 1
             });
           });
 
-          it('with maxWidth, lineHeight and maxLines', () => {
+          it('should compute bounds based on line break given all conditions are meet', () => {
             node.wordBreak = 'break-all';
             node.maxWidth = 1;
             node.lineHeight = 10;
@@ -215,6 +217,29 @@ describe('text-metrics', () => {
             bounds = textBounds(node, textMeasureMock);
             expect(bounds).to.deep.equal({
               x: 1, y: 1.25, width: 1, height: 20
+            });
+          });
+
+          it('should require text width to be more than node maxWidth', () => {
+            node.wordBreak = 'break-all';
+            node.maxWidth = node.text.length + 1;
+            node.lineHeight = 10;
+            node.maxLines = 2;
+            bounds = textBounds(node, textMeasureMock);
+            expect(bounds).to.deep.equal({
+              x: 1, y: 1.25, width: 4, height: 1
+            });
+          });
+
+          it('should compute bounds based on line break given node text contains a line break character', () => {
+            node.text = 'te\nst';
+            node.wordBreak = 'break-all';
+            node.maxWidth = Infinity;
+            node.lineHeight = 10;
+            node.maxLines = 2;
+            bounds = textBounds(node, textMeasureMock);
+            expect(bounds).to.deep.equal({
+              x: 1, y: 1.25, width: 2, height: 20
             });
           });
         });

--- a/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
+++ b/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
@@ -71,16 +71,14 @@ export function onLineBreak(measureText) {
       }
 
       const tm = measureText(item);
-      if (tm.width <= item.maxWidth && !includesLineBreak(item.text)) {
-        return;
+      if (tm.width > item.maxWidth || includesLineBreak(item.text)) {
+        const lineHeight = tm.height * Math.max((isNaN(item.lineHeight) ? DEFAULT_LINE_HEIGHT : item.lineHeight), 0);
+        const diff = lineHeight - tm.height;
+        const halfLead = diff / 2;
+        const result = wordBreakFn(item, wrappedMeasureText(item, measureText));
+
+        state.node = generateLineNodes(result, item, halfLead, tm.height); // Convert node to container
       }
-
-      const lineHeight = tm.height * Math.max((isNaN(item.lineHeight) ? DEFAULT_LINE_HEIGHT : item.lineHeight), 0);
-      const diff = lineHeight - tm.height;
-      const halfLead = diff / 2;
-      const result = wordBreakFn(item, wrappedMeasureText(item, measureText));
-
-      state.node = generateLineNodes(result, item, halfLead, tm.height); // Convert node to container
     }
   };
 }

--- a/packages/picasso.js/src/web/text-manipulation/text-metrics.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-metrics.js
@@ -6,6 +6,7 @@ import {
   ELLIPSIS_CHAR
 } from './text-const';
 import fontSizeToHeight from './font-size-to-height';
+import { includesLineBreak } from './string-tokenizer';
 
 const heightCache = {};
 const widthCache = {};
@@ -135,9 +136,11 @@ function calcTextBounds(attrs, measureFn = measureText) {
  */
 export function textBounds(node, measureFn = measureText) {
   const lineBreakFn = resolveLineBreakAlgorithm(node);
-  if (lineBreakFn) {
-    const fontSize = node['font-size'] || node.fontSize;
-    const fontFamily = node['font-family'] || node.fontFamily;
+  const fontSize = node['font-size'] || node.fontSize;
+  const fontFamily = node['font-family'] || node.fontFamily;
+  const tm = measureFn({ text: node.text, fontFamily, fontSize });
+
+  if (lineBreakFn && (tm.width > node.maxWidth || includesLineBreak(node.text))) {
     const resolvedLineBreaks = lineBreakFn(node, text => measureFn({ text, fontFamily, fontSize }));
     const nodeCopy = extend({}, node);
     let maxWidth = 0;


### PR DESCRIPTION
Fixes an issue where the condition for computing the text node bounds was not always the same as the condition for the rendering logic. Such that the bounds may be computed based on line breaking while the rendered text would not be.