### PR TITLE
fix(legend-cat): improve text and shape alignment

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/item-renderer.spec.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/item-renderer.spec.js
@@ -231,12 +231,12 @@ describe('legend-item-renderer', () => {
           x: 1 + 7, // x + maxSymbolSize / 2
           y: 3 + 7 // y + maxSymbolSize / 2
         }, {
-          baseline: 'hanging',
+          baseline: 'text-before-edge',
           fontSize: 11,
           anchor: 'start',
           data: 'd',
           x: 1 + 14 + 8, // x + maxSymbolSize + spacing
-          y: 3 + ((14 - 9) / 2) // y + (maxSymbolSize - labelHeight) / 2
+          y: 3 + ((14 - 9) / 2) + 11 * 0.175// y + (maxSymbolSize - labelHeight) / 2 + fontSize * 0.175
         }]
       });
     });

--- a/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
@@ -11,10 +11,10 @@ function placeTextInRect(rect, label, opts) {
   }
 
   const wiggleWidth = Math.max(0, rect.width - textMetrics.width);
-  label.baseline = 'hanging';
+  label.baseline = 'text-before-edge';
   const wiggleHeight = Math.max(0, rect.height - (textMetrics.height));
   label.x = rect.x + (opts.align * wiggleWidth);
-  label.y = rect.y + (opts.justify * wiggleHeight);
+  label.y = rect.y + (opts.justify * wiggleHeight) + parseInt(label.fontSize, 10) * 0.175; // 0.175 - basline offset
 
   return label;
 }
@@ -216,8 +216,8 @@ export function itemize({
     },
     layout: {
       margin: {
-        vertical: typeof resolved.layout.item.vertical !== 'undefined' ? resolved.layout.item.vertical : 8,
-        horizontal: typeof resolved.layout.item.horizontal !== 'undefined' ? resolved.layout.item.horizontal : 8
+        vertical: typeof resolved.layout.item.vertical !== 'undefined' ? resolved.layout.item.vertical : 4,
+        horizontal: typeof resolved.layout.item.horizontal !== 'undefined' ? resolved.layout.item.horizontal : 4
       },
       mode: resolved.layout.item.mode,
       size: resolved.layout.item.size,


### PR DESCRIPTION
Improves alignment between shape and text in categorical legend.

Before:
![Screen Shot 2019-04-29 at 10 48 56](https://user-images.githubusercontent.com/16324367/56885342-89a7d280-6a6c-11e9-8cd0-ef7722b54f7c.png)

After:
![Screen Shot 2019-04-29 at 10 46 52](https://user-images.githubusercontent.com/16324367/56885352-90364a00-6a6c-11e9-954f-c9c4d39bdc1c.png)
