### PR TITLE
fix(text-metrics): computed line height

### DIFF
--- a/packages/picasso.js/src/web/text-manipulation/__tests__/font-size-to-height.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/font-size-to-height.spec.js
@@ -1,4 +1,4 @@
-import fontSizeToHeight from '../font-size-to-height';
+import { fontSizeToHeight } from '../font-size-to-height';
 
 describe('font-size to height', () => {
   it('should use 24px a base for determing height', () => {

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/line-break-resolver.spec.js
@@ -9,7 +9,7 @@ describe('Line Break Resolver', () => {
     let fn;
 
     beforeEach(() => {
-      node = { type: 'text' };
+      node = { type: 'text', fontSize: '1px' };
       state = { node };
       measureTextSpy = sinon.spy();
       fn = onLineBreak(measureTextMock);

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/text-metrics.spec.js
@@ -110,7 +110,7 @@ describe('text-metrics', () => {
 
   describe('textBounds', () => {
     const textMeasureMock = ({ text, fontSize, fontFamily }) => ({
-      width: text.length * (fontSize || 1),
+      width: text.length * (parseFloat(fontSize) || 1),
       height: fontFamily || 1
     });
     let node;
@@ -198,6 +198,10 @@ describe('text-metrics', () => {
       });
 
       describe('wordBreak', () => {
+        beforeEach(() => {
+          node.fontSize = '1px';
+        });
+
         describe('break-all', () => {
           it('should not compute bounds based on line break given no maxWidth is set', () => {
             node.wordBreak = 'break-all';

--- a/packages/picasso.js/src/web/text-manipulation/__tests__/word-break.spec.js
+++ b/packages/picasso.js/src/web/text-manipulation/__tests__/word-break.spec.js
@@ -7,7 +7,8 @@ describe('Word Break', () => {
     beforeEach(() => {
       node = {
         type: 'text',
-        text: '123456789'
+        text: '123456789',
+        fontSize: '1px'
       };
     });
 
@@ -187,7 +188,8 @@ describe('Word Break', () => {
     beforeEach(() => {
       node = {
         type: 'text',
-        text: 'aaa sss fff ddd'
+        text: 'aaa sss fff ddd',
+        fontSize: '1px'
       };
     });
 

--- a/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
+++ b/packages/picasso.js/src/web/text-manipulation/font-size-to-height.js
@@ -1,7 +1,8 @@
 const BASE = 24;
 const PAD = 4;
 const BUMP = 1e-12;
-const DEFAULT_HEIGHT = 16;
+const DEFAULT_FONT_HEIGHT = 16;
+const DEFAULT_LINE_HEIGHT = 1.2;
 const TEXT_REGEX = /^\s*\d+(\.\d+)?px\s*$/i;
 
 function isValidFontSize(val) {
@@ -13,7 +14,7 @@ function isValidFontSize(val) {
   return false;
 }
 
-export default function fontSizeToHeight(fontSize) {
+export function fontSizeToHeight(fontSize) {
   if (isValidFontSize(fontSize)) {
     const size = parseFloat(fontSize);
     const m = PAD * Math.ceil((size + BUMP) / BASE);
@@ -21,5 +22,14 @@ export default function fontSizeToHeight(fontSize) {
     return size + m;
   }
 
-  return DEFAULT_HEIGHT;
+  return DEFAULT_FONT_HEIGHT;
+}
+
+export function fontSizeToLineHeight(node) {
+  const fontSize = node['font-size'] || node.fontSize;
+  if (isValidFontSize(fontSize)) {
+    return parseFloat(fontSize) * Math.max(isNaN(node.lineHeight) ? DEFAULT_LINE_HEIGHT : node.lineHeight, 0);
+  }
+
+  return DEFAULT_FONT_HEIGHT * DEFAULT_LINE_HEIGHT;
 }

--- a/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
+++ b/packages/picasso.js/src/web/text-manipulation/line-break-resolver.js
@@ -1,7 +1,8 @@
 import extend from 'extend';
 import { breakAll, breakWord } from './word-break';
-import { DEFAULT_LINE_HEIGHT, ELLIPSIS_CHAR } from './text-const';
+import { ELLIPSIS_CHAR } from './text-const';
 import { includesLineBreak } from './string-tokenizer';
+import { fontSizeToLineHeight } from './font-size-to-height';
 
 function generateLineNodes(result, item, halfLead, height) {
   const container = { type: 'container', children: [] };
@@ -72,8 +73,7 @@ export function onLineBreak(measureText) {
 
       const tm = measureText(item);
       if (tm.width > item.maxWidth || includesLineBreak(item.text)) {
-        const lineHeight = tm.height * Math.max((isNaN(item.lineHeight) ? DEFAULT_LINE_HEIGHT : item.lineHeight), 0);
-        const diff = lineHeight - tm.height;
+        const diff = fontSizeToLineHeight(item) - tm.height;
         const halfLead = diff / 2;
         const result = wordBreakFn(item, wrappedMeasureText(item, measureText));
 

--- a/packages/picasso.js/src/web/text-manipulation/text-const.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-const.js
@@ -1,9 +1,7 @@
-const DEFAULT_LINE_HEIGHT = 1.2;
 const HYPHENS_CHAR = '\u2010';
 const ELLIPSIS_CHAR = '…';
 
 export {
-  DEFAULT_LINE_HEIGHT,
   HYPHENS_CHAR,
   ELLIPSIS_CHAR
 };

--- a/packages/picasso.js/src/web/text-manipulation/text-metrics.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-metrics.js
@@ -2,10 +2,12 @@ import extend from 'extend';
 import { resolveLineBreakAlgorithm } from './line-break-resolver';
 import baselineHeuristic from './baseline-heuristic';
 import {
-  DEFAULT_LINE_HEIGHT,
   ELLIPSIS_CHAR
 } from './text-const';
-import fontSizeToHeight from './font-size-to-height';
+import {
+  fontSizeToHeight,
+  fontSizeToLineHeight
+} from './font-size-to-height';
 import { includesLineBreak } from './string-tokenizer';
 
 const heightCache = {};
@@ -156,10 +158,7 @@ export function textBounds(node, measureFn = measureText) {
     }
     nodeCopy.text = widestLine;
     const bounds = calcTextBounds(nodeCopy, measureFn);
-    const lineHeight = bounds.height * Math.max(isNaN(node.lineHeight) ? DEFAULT_LINE_HEIGHT : node.lineHeight, 0);
-    const diff = lineHeight - bounds.height;
-
-    bounds.height = (bounds.height + diff) * resolvedLineBreaks.lines.length;
+    bounds.height = fontSizeToLineHeight(node) * resolvedLineBreaks.lines.length;
 
     return bounds;
   }

--- a/packages/picasso.js/src/web/text-manipulation/word-break.js
+++ b/packages/picasso.js/src/web/text-manipulation/word-break.js
@@ -3,22 +3,21 @@ import stringTokenizer, {
   BREAK_ALLOWED
 } from './string-tokenizer';
 import {
-  DEFAULT_LINE_HEIGHT,
   HYPHENS_CHAR
 } from './text-const';
+import { fontSizeToLineHeight } from './font-size-to-height';
 
-function resolveMaxAllowedLines(node, measuredLineHeight) {
+function resolveMaxAllowedLines(node) {
   const maxHeight = node.maxHeight;
-  let maxLines = Math.max(node.maxLines, 1) || Infinity;
+  const maxLines = Math.max(node.maxLines, 1) || Infinity;
 
   if (isNaN(maxHeight)) {
     return maxLines;
   }
 
-  const lineHeight = node.lineHeight || DEFAULT_LINE_HEIGHT;
-  const calcLineHeight = measuredLineHeight * lineHeight;
+  const computedLineHeight = fontSizeToLineHeight(node);
 
-  return Math.max(1, Math.min(Math.floor(maxHeight / calcLineHeight), maxLines));
+  return Math.max(1, Math.min(Math.floor(maxHeight / computedLineHeight), maxLines));
 }
 
 function initState(node, measureText) {
@@ -26,7 +25,7 @@ function initState(node, measureText) {
     lines: [],
     line: '',
     width: 0,
-    maxLines: resolveMaxAllowedLines(node, measureText(node.text).height),
+    maxLines: resolveMaxAllowedLines(node),
     maxWidth: node.maxWidth,
     hyphens: {
       enabled: node.hyphens === 'auto',


### PR DESCRIPTION
Changes so that line height is computed based on the font-size instead of a computed text height. The result of this will be less space between each line than before and it will more closely resemble how line-height is handle in CSS.