### PR TITLE
fix(legend-seq): misaligned ticks

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-seq/__tests__/legend-seq.spec.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/__tests__/legend-seq.spec.js
@@ -69,18 +69,20 @@ describe('Legend Sequential', () => {
       x: 25,
       y: 15,
       dx: 0,
-      dy: 5,
+      dy: 0,
       text: 0,
-      anchor: 'start'
+      anchor: 'start',
+      baseline: 'text-before-edge'
     });
 
     expect(ticks[1]).to.include({
       x: 25,
       y: 50,
       dx: 0,
-      dy: -1,
+      dy: 0,
       text: 1,
-      anchor: 'start'
+      anchor: 'start',
+      baseline: 'text-after-edge'
     });
 
     expect(title).to.include({
@@ -149,18 +151,20 @@ describe('Legend Sequential', () => {
         x: 25,
         y: 15,
         dx: 0,
-        dy: 5,
+        dy: 0,
         text: 0,
-        anchor: 'start'
+        anchor: 'start',
+        baseline: 'text-before-edge'
       });
 
       expect(ticks[1]).to.include({
         x: 25,
         y: 50,
         dx: 0,
-        dy: -1,
+        dy: 0,
         text: 1,
-        anchor: 'start'
+        anchor: 'start',
+        baseline: 'text-after-edge'
       });
 
       const fillBoundary = componentFixture.findNodes(tickFillBoundarySelector)[0];
@@ -184,18 +188,20 @@ describe('Legend Sequential', () => {
         x: 75,
         y: 15,
         dx: 0,
-        dy: 5,
+        dy: 0,
         text: 0,
-        anchor: 'end'
+        anchor: 'end',
+        baseline: 'text-before-edge'
       });
 
       expect(ticks[1]).to.include({
         x: 75,
         y: 50,
         dx: 0,
-        dy: -1,
+        dy: 0,
         text: 1,
-        anchor: 'end'
+        anchor: 'end',
+        baseline: 'text-after-edge'
       });
 
       const fillBoundary = componentFixture.findNodes(tickFillBoundarySelector)[0];
@@ -259,7 +265,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: -1.25,
         text: 0,
-        anchor: 'start'
+        anchor: 'start',
+        baseline: 'alphabetical'
       });
 
       expect(ticks[1]).to.include({
@@ -268,7 +275,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: -1.25,
         text: 1,
-        anchor: 'end'
+        anchor: 'end',
+        baseline: 'alphabetical'
       });
 
       const fillBoundary = componentFixture.findNodes(tickFillBoundarySelector)[0];
@@ -295,7 +303,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: 4,
         text: 0,
-        anchor: 'start'
+        anchor: 'start',
+        baseline: 'alphabetical'
       });
 
       expect(ticks[1]).to.include({
@@ -304,7 +313,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: 4,
         text: 1,
-        anchor: 'end'
+        anchor: 'end',
+        baseline: 'alphabetical'
       });
 
       const fillBoundary = componentFixture.findNodes(tickFillBoundarySelector)[0];
@@ -333,7 +343,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: -1.25,
         text: 0,
-        anchor: 'start'
+        anchor: 'start',
+        baseline: 'alphabetical'
       });
 
       expect(ticks[1]).to.include({
@@ -342,7 +353,8 @@ describe('Legend Sequential', () => {
         dx: 0,
         dy: -1.25,
         text: 1,
-        anchor: 'end'
+        anchor: 'end',
+        baseline: 'alphabetical'
       });
 
       expect(title).to.include({

--- a/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/legend-seq/node-builder.js
@@ -127,10 +127,11 @@ export function createTickNodes(ctx, legendNode) {
     let y = 0;
     let dx = 0;
     let dy = 0;
+    let baseline = 'alphabetical';
 
     if (state.isVertical) {
       y = legendNode.y + (legendNode.height * tick.pos);
-      dy = tick.pos === 1 ? -(tick.textMetrics.height / 5) : tick.textMetrics.height;
+      baseline = tick.pos === 0 ? 'text-before-edge' : 'text-after-edge';
     } else {
       x = legendNode.x + (legendNode.width * tick.pos);
     }
@@ -167,7 +168,8 @@ export function createTickNodes(ctx, legendNode) {
       maxWidth: state.isVertical ? settings.tick.maxLengthPx : Math.min(settings.tick.maxLengthPx, state.legend.length() / 2),
       anchor,
       textBoundsFn: ctx.renderer.textBounds,
-      title: tick.label
+      title: tick.label,
+      baseline
     };
 
     return node;


### PR DESCRIPTION
Fixes an issue where the ticks on the sequential legend would not align properly. Removed component specific solution and instead use the baseline attribute to position the ticks.