### PR TITLE
fix: brush based on the amount of components

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.24.0",
+    "version": "0.25.0",
     "license": "MIT"
   },
   "entries": {

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "license": "MIT"
   },
   "entries": {

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -747,12 +747,9 @@ function chartFn(definition, context) {
   instance.brushFromShapes = (shapes, config = { components: [] }) => {
     for (let i = 0; i < config.components.length; i++) {
       const iKey = config.components[i].key;
-      visibleComponents.forEach((c) => {
-        const isMatchingKeys = iKey === c.key;
-        if (isMatchingKeys) {
+      visibleComponents.filter(c => iKey === c.key).forEach((c) => {
           const compShapes = shapes.filter(shape => shape.key === c.key);
           c.instance.brushFromShapes(compShapes, config.components[i]);
-        }
       });
     }
   };

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -745,20 +745,16 @@ function chartFn(definition, context) {
    * chartInstance.brushFromShapes(shapes, config);
    */
   instance.brushFromShapes = (shapes, config = { components: [] }) => {
-    const configKeys = config.components.map(conf => conf.key);
-    visibleComponents.forEach((c) => {
-      const configIndex = configKeys.indexOf(c.key);
-      if (configIndex !== -1) {
-        const compShapes = [];
-        for (let i = 0, num = shapes.length; i < num; i++) {
-          const shape = shapes[i];
-          if (shape.key === c.key) {
-            compShapes.push(shape);
-          }
+    for (let i = 0; i < config.components.length; i++) {
+      const iKey = config.components[i].key;
+      visibleComponents.forEach((c) => {
+        const isMatchingKeys = iKey === c.key;
+        if (isMatchingKeys) {
+          const compShapes = shapes.filter(shape => shape.key === c.key);
+          c.instance.brushFromShapes(compShapes, config.components[i]);
         }
-        c.instance.brushFromShapes(compShapes, config.components[configIndex]);
-      }
-    });
+      });
+    }
   };
 
   /**

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -748,8 +748,8 @@ function chartFn(definition, context) {
     for (let i = 0; i < config.components.length; i++) {
       const iKey = config.components[i].key;
       visibleComponents.filter(c => iKey === c.key).forEach((c) => {
-          const compShapes = shapes.filter(shape => shape.key === c.key);
-          c.instance.brushFromShapes(compShapes, config.components[i]);
+        let compShapes = shapes.filter(shape => shape.key === c.key);
+        c.instance.brushFromShapes(compShapes, config.components[i]);
       });
     }
   };


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

- brush from shapes based on the amount of components sent in. Basically allows multiple components sharing the same key, but different contexts to be brushed on.
