### PR TITLE
fix(labels): require label to contain at least first character

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/slices.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/slices.spec.js
@@ -160,6 +160,83 @@ describe('labeling - slices', () => {
       expect(bounds).property('width').to.equal(3);
       expect(bounds).property('height').to.equal(4);
     });
+
+    describe('should require text width to be equal to or larger than first character plus ellipsing', () => {
+      it('given position is `into` and direction `rotate`', () => {
+        expect(getSliceRect({
+          slice: {
+            offset: { x: 0, y: 0 },
+            start: Math.PI / 2,
+            end: (Math.PI / 2) + (2 * Math.asin(3 / 5)),
+            innerRadius: 0,
+            outerRadius: 15
+          },
+          position: 'into',
+          direction: 'rotate',
+          padding: 1,
+          measured: { width: 6, height: 4, minReqWidth: Infinity },
+          store: { insideLabelBounds: [] }
+        })).to.equal(null);
+      });
+
+      it('given position is `inside` and direction `rotate`', () => {
+        expect(getSliceRect({
+          slice: {
+            offset: { x: 0, y: 0 },
+            start: Math.PI / 2,
+            end: (Math.PI / 2) + (2 * Math.asin(3 / 5)),
+            innerRadius: 0,
+            outerRadius: 15
+          },
+          position: 'inside',
+          direction: 'rotate',
+          padding: 1,
+          measured: { width: 6, height: 4, minReqWidth: Infinity },
+          store: { insideLabelBounds: [] }
+        })).to.equal(null);
+      });
+
+      it('given position is `outside` and direction `rotate`', () => {
+        expect(getSliceRect({
+          slice: {
+            offset: { x: 0, y: 0 },
+            start: 0,
+            end: Math.PI,
+            innerRadius: 15,
+            outerRadius: 20
+          },
+          direction: 'rotate',
+          position: 'outside',
+          padding: 1,
+          view: {
+            x: -50, y: -50, width: 100, height: 100
+          },
+          measured: { width: 6, height: 4, minReqWidth: Infinity }
+        })).to.equal(null);
+      });
+
+      it('given position is `outside` and direction `horizontal`', () => {
+        expect(getSliceRect({
+          slice: {
+            offset: { x: 0, y: 0 },
+            start: 0,
+            end: Math.PI,
+            innerRadius: 15,
+            outerRadius: 20
+          },
+          context: {
+            q1maxY: 0, q2minY: 0, q3minY: 0, q4maxY: 0
+          },
+          direction: 'horizontal',
+          position: 'outside',
+          padding: 1,
+          view: {
+            x: -50, y: -50, width: 100, height: 100
+          },
+          measured: { width: 6, height: 4, minReqWidth: Infinity }
+        })).to.equal(null);
+      });
+    });
   });
 
   describe('slice strategy', () => {
@@ -319,7 +396,6 @@ describe('labeling - slices', () => {
           }
         }));
 
-        renderer.measureText.returns({ width: 36, height: 5 });
         return slices({
           settings,
           chart,
@@ -337,6 +413,15 @@ describe('labeling - slices', () => {
           }
         });
       }
+
+      beforeEach(() => {
+        renderer.measureText = (opts) => {
+          if (opts.text.includes('…')) {
+            return { width: 1, height: 1 };
+          }
+          return { width: 36, height: 5 };
+        };
+      });
 
       it('should not add any labels, because they are out of bounds', () => {
         const labels = createLabel([


### PR DESCRIPTION
Fixes an issue where a label would sometimes be displayed as only the ellipsis character. There is now a minimum requirement for a label to contain at least 1 character plus the ellipsis character given the full label doesn't fit.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2019-06-07 at 10 34 04](https://user-images.githubusercontent.com/16608020/59092335-980dc780-8911-11e9-86dc-bbe4950a2c5b.png)  | ![Screenshot 2019-06-07 at 10 36 30](https://user-images.githubusercontent.com/16608020/59092348-9e9c3f00-8911-11e9-82cc-23903dea88e9.png)  |
|![Screenshot 2019-06-07 at 10 35 13](https://user-images.githubusercontent.com/16608020/59092336-980dc780-8911-11e9-9dd0-afcb9776df2b.png) | ![Screenshot 2019-06-07 at 10 36 00](https://user-images.githubusercontent.com/16608020/59092346-9e9c3f00-8911-11e9-9974-79f2e607baf1.png)  |



