### PR TITLE
feat(line): enable config of defined

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.25.1",
+    "version": "0.25.3",
     "license": "MIT"
   },
   "entries": {
@@ -2815,6 +2815,11 @@
               "optional": true,
               "defaultValue": 0,
               "type": "number"
+            },
+            "defined": {
+              "optional": true,
+              "defaultValue": "true",
+              "type": "#/definitions/datum-boolean"
             }
           }
         },
@@ -3152,6 +3157,21 @@
       "items": [
         {
           "type": "number"
+        },
+        {
+          "type": "#/definitions/datum-config"
+        },
+        {
+          "type": "#/definitions/datum-accessor"
+        }
+      ],
+      "type": "any"
+    },
+    "datum-boolean": {
+      "kind": "union",
+      "items": [
+        {
+          "type": "boolean"
         },
         {
           "type": "#/definitions/datum-config"

--- a/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
@@ -158,6 +158,35 @@ describe('line component', () => {
     }]);
   });
 
+  it('should handle custom defined null values', () => {
+    componentFixture.mocks().theme.style.returns({});
+    const config = {
+      data: [2, 3, 4, 1, 2],
+      settings: {
+        coordinates: {
+          major(a, i) { return i; },
+          minor(b) { return b.datum.value; },
+          defined(b) { return b.datum.value !== 4; }
+        },
+        layers: {}
+      }
+    };
+
+    componentFixture.simulateCreate(component, config);
+    rendered = componentFixture.simulateRender(opts);
+
+    expect(rendered).to.eql([{
+      type: 'path',
+      d: 'M0,200L200,300M600,100L800,200',
+      fill: 'none',
+      stroke: '#ccc',
+      strokeLinejoin: 'miter',
+      strokeWidth: 1,
+      opacity: 1,
+      data: { value: 2, label: '2' }
+    }]);
+  });
+
   it('should render area which defaults to minor 0', () => {
     componentFixture.mocks().theme.style.returns({
       line: {},

--- a/packages/picasso.js/src/core/chart-components/line/line.js
+++ b/packages/picasso.js/src/core/chart-components/line/line.js
@@ -108,6 +108,14 @@ const SETTINGS = {
   }
 };
 
+/**
+ * @type {datum-boolean=}
+ * @memberof component--line-settings.coordinates
+ * @name defined
+ * @default true
+ */
+
+
 function createDisplayLayer(points, {
   generator,
   item,
@@ -146,6 +154,7 @@ function createDisplayLayers(layers, {
     } = layer;
 
     const areaGenerator = area();
+    const defined = stngs.coordinates ? stngs.coordinates.defined : null;
     let lineGenerator;
     let secondaryLineGenerator;
     let minor = { size: height, p: 'y' };
@@ -160,8 +169,12 @@ function createDisplayLayers(layers, {
       [major.p](d => d.major * major.size) // eslint-disable-line no-unexpected-multiline
       [`${minor.p}1`](d => d.minor * minor.size) // eslint-disable-line no-unexpected-multiline
       [`${minor.p}0`](d => d.minor0 * minor.size) // eslint-disable-line no-unexpected-multiline
-      .defined(d => typeof d.minor === 'number' && !isNaN(d.minor))
       .curve(CURVES[layerObj.curve === 'monotone' ? `monotone${major.p}` : layerObj.curve]);
+    if (defined) {
+      areaGenerator.defined(d => typeof d.minor === 'number' && !isNaN(d.minor) && d.defined);
+    } else {
+      areaGenerator.defined(d => typeof d.minor === 'number' && !isNaN(d.minor));
+    }
     lineGenerator = areaGenerator[`line${minor.p.toUpperCase()}1`]();
     secondaryLineGenerator = areaGenerator[`line${minor.p.toUpperCase()}0`]();
 

--- a/packages/picasso.js/src/core/chart-components/property-resolver/index.js
+++ b/packages/picasso.js/src/core/chart-components/property-resolver/index.js
@@ -38,6 +38,10 @@ function isPrimitive(x) {
  */
 
 /**
+ * @typedef {boolean|datum-config|datum-accessor} datum-boolean
+ */
+
+/**
  * Normalizes property settings
  *
  * @ignore


### PR DESCRIPTION
Exposes a `defined` property for the line `coordinates` config which allows a user to specify when a coordinate is considered defined.
