### PR TITLE
fix(box): evaluate show per shape

### DIFF
--- a/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
+++ b/packages/picasso.js/src/core/chart-components/box/__tests__/box-shapes.spec.js
@@ -84,4 +84,38 @@ describe('buildShapes', () => {
     const shapes = buildShapes({ resolved, keys });
     expect(shapes[0].children).to.deep.equal(['oob']);
   });
+
+  it('should not return shapes that have show === false', () => {
+    resolved = {
+      major: {
+        items: [{ major: 'first' }, { major: 'second' }],
+        settings: { major: { scale: {} } }
+      },
+      minor: {
+        items: [{
+          start: 0, end: 0.5, min: 0, max: 1, median: 0.5, med: 0.5
+        }, {
+          start: 0, end: 0.5, min: 0, max: 1, median: 0.5, med: 0.5
+        }],
+        settings: { start: 100, end: 200 }
+      },
+      box: {
+        items: [1, { show: false }]
+      },
+      line: {
+        items: [1, { show: false }]
+      },
+      median: {
+        items: [1, { show: false }]
+      },
+      whisker: {
+        items: [1, { show: false }]
+      }
+    };
+
+    keys = ['box', 'line', 'median', 'whisker'];
+    const shapes = buildShapes({ resolved, keys });
+    expect(shapes[0].children).to.eql(['box', 'verticalLine', 'verticalLine', 'horizontalLine', 'horizontalLine', 'horizontalLine']);
+    expect(shapes[1].children).to.eql([]);
+  });
 });

--- a/packages/picasso.js/src/core/chart-components/box/box-shapes.js
+++ b/packages/picasso.js/src/core/chart-components/box/box-shapes.js
@@ -179,6 +179,9 @@ export default function buildShapes({
 
     if (!isOutOfBounds) {
       for (let k = 0; k < numNonOobKeys; k++) {
+        if (minorItem[nonOobKeys[k]] && minorItem[nonOobKeys[k]].show === false) {
+          continue;
+        }
         addMarkerList[nonOobKeys[k]]();
       }
     } else if (minorItem.oob) {


### PR DESCRIPTION
The `show` method was evaluated per shape but the result was not used when determining visibility of it.

Fixes #411 