### PR TITLE
feat: add style overrides in definition

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -293,6 +293,9 @@ function chartFn(definition, context) {
     if (_settings.palettes) {
       theme.setPalettes(_settings.palettes);
     }
+    if (_settings.style) {
+      theme.setStyle(_settings.style);
+    }
     dataCollection = dataCollections(_settings.collections, { dataset }, { logger });
 
     const deps = {

--- a/packages/picasso.js/src/core/theme/__tests__/theme.spec.js
+++ b/packages/picasso.js/src/core/theme/__tests__/theme.spec.js
@@ -31,4 +31,17 @@ describe('Theme', () => {
     }, []);
     expect(t.style({ title: '$label' })).to.eql({ title: { fontFamily: 'Sans nonsense' } });
   });
+
+  it('should inherit when setting style', () => {
+    const t = themeFn({
+      $font: 'Sans nonsense',
+      $label: {
+        fontFamily: '$font'
+      }
+    }, []);
+    t.setStyle({
+      $font: 'Sans x'
+    });
+    expect(t.style({ title: '$label' })).to.eql({ title: { fontFamily: 'Sans x' } });
+  });
 });

--- a/packages/picasso.js/src/core/theme/index.js
+++ b/packages/picasso.js/src/core/theme/index.js
@@ -1,7 +1,9 @@
+import extend from 'extend';
 import styleResolver from '../style/resolver';
 
 function themeFn(style = {}, palettes = []) {
   let pals = {};
+  let internalStyle = style;
   const setPalettes = (p) => {
     p.forEach((palette) => {
       const pal = Array.isArray(palette.colors[0]) ? palette.colors : [palette.colors];
@@ -44,9 +46,17 @@ function themeFn(style = {}, palettes = []) {
 
     /**
      * Resolve style references
-     * @param {style-object} s - Object containing
+     * @param {style-object} s - Object containing style
      */
-    style: s => styleResolver(s, style)
+    style: s => styleResolver(s, internalStyle),
+
+    /**
+     * Set custom style
+     * @param {style-object} s - Object containing style
+     */
+    setStyle: (s) => {
+      internalStyle = extend({}, style, s);
+    }
   };
 
   setPalettes(palettes);


### PR DESCRIPTION
Enables style overrides on chart update:

```js
chart.update({
  style: {
    '$font-color': 'red'
  }
})
```
