### PR TITLE
feat(line): disconnect lines

### DIFF
--- a/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
@@ -217,6 +217,40 @@ describe('line component', () => {
     }]);
   });
 
+  it('should disconnect lines with unordered domain', () => {
+    const domain = ['A', 'B', 'C', 'D', 'E'];
+    const domainScale = (v) => domain.indexOf(v) / 4;
+    domainScale.domain = () => domain;
+    domainScale.range = () => [0, 1];
+    componentFixture.mocks().theme.style.returns({});
+    componentFixture.mocks().chart.scale.returns(domainScale);
+    const config = {
+      data: ['A', 'B', /* skip C */ 'D', 'E'],
+      settings: {
+        coordinates: {
+          major: { scale: 'x' },
+          minor(b, i) { return 3 - i; },
+          layerId: () => 0
+        },
+        layers: {}
+      }
+    };
+
+    componentFixture.simulateCreate(component, config);
+    rendered = componentFixture.simulateRender(opts);
+
+    expect(rendered).to.eql([{
+      type: 'path',
+      d: 'M0,300L50,200M150,100L200,0',
+      fill: 'none',
+      stroke: '#ccc',
+      strokeLinejoin: 'miter',
+      strokeWidth: 1,
+      opacity: 1,
+      data: { value: 'A', label: 'A' }
+    }]);
+  });
+
   it('should render area which defaults to minor 0', () => {
     componentFixture.mocks().theme.style.returns({
       line: {},


### PR DESCRIPTION
There are two cases when a line should be interrupted:

#### 1: When the minor value is undefined

Domain|Value
---|---
A|2
B|3
C|undefined
D|4
E|5

This case is easily handled today with `lineGenerator.defined`.

#### 2: When a line is moving over a domain that may not coincide with the domain on the major scale.

Domain|Value
---|---
A|2
B|3
D|4
E|5

Notice that the domain value **B** is missing. When the line is constructed all points on the line are defined so there will be no gaps.

There may however be cases when the domain on the major scale is different from the domain on the line and the line should reflect this by interrupting the line.

This PR implements the second case so that the two datasets above are rendered the same:

![Screenshot 2019-09-17 at 11 55 38](https://user-images.githubusercontent.com/16324367/65031746-1bdc4480-d942-11e9-8f89-faf3f0aa4610.png)
