### PR TITLE
feat(line): add points to collected layers

### DIFF
--- a/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
@@ -32,7 +32,11 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 1, label: '1' }
+      data: {
+        value: 1,
+        label: '1',
+        points: config.data.map((p) => ({ label: `${p}`, value: p }))
+      }
     }]);
   });
 
@@ -66,7 +70,7 @@ describe('line component', () => {
       strokeWidth: 4,
       strokeDasharray: '8 4',
       opacity: 1,
-      data: { value: 1, label: '1' }
+      data: { value: 1, label: '1', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -97,7 +101,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 1, label: '1' }
+      data: { value: 1, label: '1', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -126,7 +130,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 2, label: '2' }
+      data: { value: 2, label: '2', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -154,7 +158,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 2, label: '2' }
+      data: { value: 2, label: '2', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -183,7 +187,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 2, label: '2' }
+      data: { value: 2, label: '2', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -213,7 +217,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 2, label: '2' }
+      data: { value: 2, label: '2', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -247,7 +251,7 @@ describe('line component', () => {
       strokeLinejoin: 'miter',
       strokeWidth: 1,
       opacity: 1,
-      data: { value: 'A', label: 'A' }
+      data: { value: 'A', label: 'A', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -287,7 +291,7 @@ describe('line component', () => {
       strokeLinejoin: undefined,
       strokeWidth: undefined,
       opacity: 0.3,
-      data: { value: 1, label: '1' }
+      data: { value: 1, label: '1', points: config.data.map((p) => ({ label: `${p}`, value: p })) }
     }]);
   });
 
@@ -334,7 +338,7 @@ describe('line component', () => {
         strokeLinejoin: undefined,
         strokeWidth: undefined,
         opacity: 0.3,
-        data: { value: 1, label: '1' }
+        data: { value: 1, label: '1', points: [1, 2, 3].map((p) => ({ label: `${p}`, value: p })) }
       });
     });
 
@@ -347,7 +351,7 @@ describe('line component', () => {
         strokeLinejoin: 'miter',
         strokeWidth: 1,
         opacity: 1,
-        data: { value: 1, label: '1' }
+        data: { value: 1, label: '1', points: [1, 2, 3].map((p) => ({ label: `${p}`, value: p })) }
       });
     });
 
@@ -360,7 +364,7 @@ describe('line component', () => {
         strokeLinejoin: 'miter',
         strokeWidth: 1,
         opacity: 1,
-        data: { value: 1, label: '1' }
+        data: { value: 1, label: '1', points: [1, 2, 3].map((p) => ({ label: `${p}`, value: p })) }
       });
     });
   });
@@ -394,7 +398,7 @@ describe('line component', () => {
         strokeLinejoin: 'miter',
         strokeWidth: 1,
         opacity: 1,
-        data: { value: 1, label: '1' }
+        data: { value: 1, label: '1', points: [1, 2, 1].map((p) => ({ label: `${p}`, value: p })) }
       });
     });
 
@@ -407,7 +411,7 @@ describe('line component', () => {
         strokeLinejoin: 'miter',
         strokeWidth: 1,
         opacity: 1,
-        data: { value: 3, label: '3' }
+        data: { value: 3, label: '3', points: [3, 4, 3].map((p) => ({ label: `${p}`, value: p })) }
       });
     });
   });

--- a/packages/picasso.js/src/core/chart-components/line/line.js
+++ b/packages/picasso.js/src/core/chart-components/line/line.js
@@ -186,7 +186,7 @@ function createDisplayLayers(layers, {
     // area layer
     if (layerStngs.area && areaObj.show !== false) {
       nodes.push(createDisplayLayer(filteredPoints, {
-        data: layer.firstPoint,
+        data: layer.consumableData,
         item: areaObj,
         generator: areaGenerator
       }));
@@ -195,7 +195,7 @@ function createDisplayLayers(layers, {
     // main line layer
     if (lineObj && lineObj.show !== false) {
       nodes.push(createDisplayLayer(filteredPoints, {
-        data: layer.firstPoint,
+        data: layer.consumableData,
         item: lineObj,
         generator: lineGenerator
       }, 'none'));
@@ -203,7 +203,7 @@ function createDisplayLayers(layers, {
       // secondary line layer, used only when rendering area
       if (!missingMinor0 && layerStngs.area && areaObj.show !== false) {
         nodes.push(createDisplayLayer(filteredPoints, {
-          data: layer.firstPoint,
+          data: layer.consumableData,
           item: lineObj,
           generator: secondaryLineGenerator
         }, 'none'));
@@ -256,13 +256,27 @@ function resolve({
       }
     }
     layerIds[lid] = layerIds[lid] || {
-      order: numLines++, id: lid, items: [], firstPoint: p.data
+      order: numLines++,
+      id: lid,
+      items: [],
+      dataItems: [],
+      consumableData: {}
     };
+    layerIds[lid].dataItems.push(p.data);
     layerIds[lid].items.push(p);
   }
 
-  const metaLayers = Object.keys(layerIds).map((lid) => layerIds[lid]);
-  const layersData = { items: metaLayers.map((layer) => layer.firstPoint) };
+  const metaLayers = Object.keys(layerIds).map((lid) => {
+    layerIds[lid].consumableData = {
+      points: layerIds[lid].dataItems,
+      ...layerIds[lid].dataItems[0]
+    };
+    return layerIds[lid];
+  });
+
+  const layersData = {
+    items: metaLayers.map((layer) => layer.consumableData)
+  };
   const layerStngs = stngs.layers || {};
 
   const layersResolved = resolver.resolve({
@@ -349,7 +363,7 @@ function calculateVisibleLayers(opts) {
       areaObj: areas.items[ix],
       median,
       points,
-      firstPoint: layer.firstPoint
+      consumableData: layer.consumableData
     });
   });
 


### PR DESCRIPTION
Exposes the collected points per layer which can be used for additional configurability:

```js
{
  type: "line",
  data: { /* */ },
  settings: {
    coordinates: {
      major: { scale: "x" },
      minor: { scale: "y" },
    },
    layers: {
      line: {
        strokeWidth(d) {
          const points = d.datum.points; // 'points' contains all coordinate values for this layer
          return points.length > 50 ? 2 : 4;
        },
        stroke(d) {
          const max = Math.max(...d.datum.points.map(p => p.end.value));
          return max > 100 ? 'green' : 'red';
        },
      },
    },
  },
}
```

