### PR TITLE
feat(line): use major prop if available

### DIFF
--- a/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
+++ b/packages/picasso.js/src/core/chart-components/line/__tests__/line.spec.js
@@ -255,6 +255,43 @@ describe('line component', () => {
     }]);
   });
 
+  it('should disconnect lines with unordered domain based on major data', () => {
+    const domain = ['A', 'B', 'C', 'D', 'E'];
+    const domainScale = (v) => domain.indexOf(v) / 4;
+    domainScale.domain = () => domain;
+    domainScale.range = () => [0, 1];
+    componentFixture.mocks().theme.style.returns({});
+    componentFixture.mocks().chart.scale.returns(domainScale);
+    const config = {
+      data: {
+        items: ['A', 'B', /* skip C */ 'D', 'E'],
+        map: (d) => ({ value: `-${d.value}-`, major: { value: d.value } })
+      },
+      settings: {
+        coordinates: {
+          major: { scale: 'x' },
+          minor(b, i) { return 3 - i; },
+          layerId: () => 0
+        },
+        layers: {}
+      }
+    };
+
+    componentFixture.simulateCreate(component, config);
+    rendered = componentFixture.simulateRender(opts);
+
+    expect(rendered).to.eql([{
+      type: 'path',
+      d: 'M0,300L50,200M150,100L200,0',
+      fill: 'none',
+      stroke: '#ccc',
+      strokeLinejoin: 'miter',
+      strokeWidth: 1,
+      opacity: 1,
+      data: { value: '-A-', major: { value: 'A' }, points: config.data.items.map((p) => ({ value: `-${p}-`, major: { value: p } })) }
+    }]);
+  });
+
   it('should render area which defaults to minor 0', () => {
     componentFixture.mocks().theme.style.returns({
       line: {},

--- a/packages/picasso.js/src/core/chart-components/line/line.js
+++ b/packages/picasso.js/src/core/chart-components/line/line.js
@@ -250,8 +250,8 @@ function resolve({
       // inject dummy if the previous point on the major domain is not the same as the prev point on the line's domain.
       // this works only if a datum's value property is the same primitive as in the domain.
       const lastItem = layerIds[lid] ? layerIds[lid].items[layerIds[lid].items.length - 1] : null;
-      const lastOrderIdx = lastItem ? domain.indexOf(lastItem.data.value) : null;
-      if (lastItem && domain.indexOf(p.data.value) - 1 !== lastOrderIdx) {
+      const lastOrderIdx = lastItem ? domain.indexOf(lastItem.data.major ? lastItem.data.major.value : lastItem.data.value) : null;
+      if (lastItem && domain.indexOf(p.data.major ? p.data.major.value : p.data.value) - 1 !== lastOrderIdx) {
         layerIds[lid].items.push({ dummy: true });
       }
     }
@@ -381,6 +381,7 @@ const lineMarkerComponent = {
   created() {
   },
   render({ data }) {
+    // console.log("DATA", data);
     const { width, height } = this.rect;
     this.stngs = this.settings.settings || {};
     const missingMinor0 = !this.stngs.coordinates || typeof this.stngs.coordinates.minor0 === 'undefined';


### PR DESCRIPTION
Use `major` prop in data if available when determining the continuity of a line's domain.