### PR TITLE
feat(gradient): support custom gradient bounds

### DIFF
--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-gradient.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-gradient.spec.js
@@ -68,6 +68,30 @@ describe('canvas-gradient', () => {
       expect(fill()).to.be.equal('dummyGradient-linear');
     });
 
+    it('should create linear gradient with custom gradient bounds', () => {
+      const bounds = {
+        x: 50,
+        y: 30,
+        width: 20,
+        height: 10
+      };
+      shape = dummyRectObject('linear', bounds);
+      shape.fill = {
+        ...shape.fill,
+        x1: 1,
+        x2: 2,
+        y1: 4,
+        y2: 5
+      };
+
+      const fill = createCanvasGradient(canvascontext(), shape, shape.fill);
+
+      expect(fill.args[0]).to.be.equal(bounds.x + bounds.width * shape.fill.x1);
+      expect(fill.args[1]).to.be.equal(bounds.y + bounds.height * shape.fill.y1);
+      expect(fill.args[2]).to.be.equal(bounds.x + bounds.width * shape.fill.x2);
+      expect(fill.args[3]).to.be.equal(bounds.y + bounds.height * shape.fill.y2);
+    });
+
     it('should have been called with proper arguments', () => {
       const bounds = {
         x: 0,

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-gradient.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-gradient.js
@@ -26,6 +26,11 @@ export default function createCanvasGradient(g, node, gradient) {
     );
   } else {
     const points = degreesToPoints(degree);
+    ['x1', 'x2', 'y1', 'y2'].forEach((c) => {
+      if (c in gradient) {
+        points[c] = gradient[c];
+      }
+    });
 
     const bounds = node.boundingRect();
 

--- a/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-gradient.spec.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-gradient.spec.js
@@ -100,6 +100,39 @@ describe('svg-gradient', () => {
       expect(bucket[0].x2).be.closeTo(0, 1e-12);
     });
 
+    it('should create a linear gradient node with custom bounds', () => {
+      const state = {
+        node: {
+          fill: {
+            type: 'gradient',
+            degree: 0,
+            x1: 2,
+            x2: 3,
+            y1: 4,
+            y2: 5,
+            stops: [
+              { offset: 0, color: 'red', opacity: 0 },
+              { offset: 1, color: 'green' }
+            ]
+          }
+        }
+      };
+      p.onCreate(state);
+
+      expect(bucket[0]).to.containSubset({
+        id: 'picasso-gradient-13-2',
+        type: 'linearGradient',
+        x1: 2,
+        x2: 3,
+        y1: 4,
+        y2: 5,
+        children: [
+          { type: 'stop', offset: '0%', style: 'stop-color:red;stop-opacity:0' },
+          { type: 'stop', offset: '100%', style: 'stop-color:green;stop-opacity:1' }
+        ]
+      });
+    });
+
     it('should maintain cache', () => {
       const localBucket = [];
       const localP = gradienter(localBucket, (input) => input.key);

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-gradient.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-gradient.js
@@ -23,6 +23,11 @@ export default function gradienter(bucket, hasher = hashObject) {
           gradient.type = 'radialGradient';
         } else {
           gradient = degreesToPoints(degree);
+          ['x1', 'x2', 'y1', 'y2'].forEach((c) => {
+            if (c in item[attr]) {
+              gradient[c] = item[attr][c];
+            }
+          });
           gradient.type = 'linearGradient';
         }
 


### PR DESCRIPTION
Allow use to set custom bounds on gradient:

```js
fill() {
  return {
    type: 'gradient',
    x1: 0,
    x2: 0.5,
    y1: 0.5,
    y2: 1,
    stops: [{
      color: 'blue',
      offset: 0,
    }, {
      color: 'green',
      offset: 1,
    }]
  }; 
}
```
