### PR TITLE
fix(labels): avoid rendering ellipsis only

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,8 @@
         "chai": false,
         "expect": false,
         "sinon": false,
-        "page": false
+        "page": false,
+        "aw": false
       },
       "parserOptions": {
         "sourceType": "module",

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/rows.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/rows.spec.js
@@ -1,14 +1,24 @@
-import { rows } from '../rows';
+// import { rows } from '../rows';
+
+const mock = ({
+  ellipsText = (n) => n.text
+} = {}) => aw.mock([
+  ['**/text-manipulation/index.js', () => ({ ellipsText })]
+], ['../rows']);
 
 describe('labeling - rows', () => {
   describe('rows strategy', () => {
     let chart;
     let renderer;
+    let rows;
     beforeEach(() => {
       chart = {};
       renderer = {
         measureText: sinon.stub()
       };
+
+      const [m] = mock();
+      rows = m.rows;
     });
 
     it('should support rects', () => {
@@ -200,6 +210,77 @@ describe('labeling - rows', () => {
       }, (bounds, text) => text);
 
       expect(labels).to.eql(['label1']);
+    });
+
+    it('should precalculate ellipsed value', () => {
+      const settings = {
+        align: 0,
+        justify: 0,
+        labels: [{
+          label: () => 'etikett'
+        }]
+      };
+      const nodes = [{
+        type: 'rect',
+        bounds: {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100
+        }
+      }];
+      renderer.measureText.returns({ width: 20, height: 10 });
+      const [{ rows: r }] = mock({
+        ellipsText: () => 'et…'
+      });
+      let labels = r({
+        settings,
+        chart,
+        nodes,
+        renderer,
+        style: {}
+      }, (bounds, text) => ({ text }));
+
+      expect(labels[0]).to.eql({
+        ellipsed: 'et…',
+        text: 'etikett'
+      });
+
+      // { text: 'label1', ellipsed: 'label1' }
+    });
+
+    it('should not include labels that are ellipsed to the ellipsis only', () => {
+      const settings = {
+        align: 0,
+        justify: 0,
+        labels: [{
+          label: () => 'etikett'
+        }]
+      };
+      const nodes = [{
+        type: 'rect',
+        bounds: {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100
+        }
+      }];
+      renderer.measureText.returns({ width: 20, height: 10 });
+      const [{ rows: r }] = mock({
+        ellipsText: () => '…'
+      });
+      let labels = r({
+        settings,
+        chart,
+        nodes,
+        renderer,
+        style: {}
+      }, (bounds, text) => ({ text }));
+
+      expect(labels.length).to.eql(0);
+
+      // { text: 'label1', ellipsed: 'label1' }
     });
 
     it('should link data', () => {

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
@@ -1,5 +1,8 @@
 import extend from 'extend';
 
+import { ellipsText } from '../../../../web/text-manipulation';
+import { ELLIPSIS_CHAR } from '../../../../web/text-manipulation/text-const';
+
 const LINE_HEIGHT = 1.2;
 const CIRCLE_FACTOR = 0.9;
 
@@ -193,6 +196,14 @@ export function rows({
         textMetrics: measurements[j]
       });
       if (label) {
+        if (label.text && label.text !== ELLIPSIS_CHAR) {
+          const ellipsed = ellipsText(label, renderer.measureText);
+          if (ELLIPSIS_CHAR === ellipsed) {
+            // don't include label if it's only an ellipsis
+            continue;
+          }
+          label.ellipsed = ellipsed;
+        }
         if (typeof linkData !== 'undefined') {
           label.data = linkData;
         }

--- a/packages/picasso.js/src/core/scene-graph/display-objects/text.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/text.js
@@ -48,7 +48,8 @@ export default class Text extends DisplayObject {
       text,
       title,
       collider,
-      boundingRect
+      boundingRect,
+      ellipsed
     } = v;
 
     super.set(v);
@@ -64,6 +65,10 @@ export default class Text extends DisplayObject {
       this._textBoundsFn = () => boundingRect;
     } else if (typeof textBoundsFn === 'function') {
       this._textBoundsFn = textBoundsFn;
+    }
+
+    if (typeof ellipsed === 'string') {
+      this.ellipsed = ellipsed;
     }
 
     this.collider = extend({ type: hasData(this) ? 'bounds' : null }, collider);

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -93,7 +93,8 @@ function renderShapes(shapes, g, shapeToCanvasMap, deps) {
       reg.get(shape.type)(shape.attrs, {
         g,
         doFill: 'fill' in shape.attrs && shape.attrs.fill !== 'none',
-        doStroke: 'stroke' in shape.attrs && shape.attrs['stroke-width'] !== 0
+        doStroke: 'stroke' in shape.attrs && shape.attrs['stroke-width'] !== 0,
+        ellipsed: shape.ellipsed
       });
     }
     if (shape.children) {

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/text.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/text.js
@@ -2,8 +2,8 @@ import { ellipsText, measureText } from '../../../text-manipulation';
 import baselineHeuristic from '../../../text-manipulation/baseline-heuristic';
 import { detectTextDirection, flipTextAnchor } from '../../../../core/utils/rtl-util';
 
-export default function render(t, { g }) {
-  const text = ellipsText(t, measureText);
+export default function render(t, { g, ellipsed }) {
+  const text = ellipsed || ellipsText(t, measureText);
   g.font = `${t['font-size']} ${t['font-family']}`;
 
   const dir = detectTextDirection(t.text);

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-nodes.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-nodes.js
@@ -29,7 +29,7 @@ const maintainer = (element, item) => {
       element.setAttribute('fill', item.fillReference);
     } else if (attr === 'text') {
       element.setAttribute('style', 'white-space: pre');
-      element.textContent = ellipsText(item.attrs, measureText);
+      element.textContent = item.ellipsed || ellipsText(item.attrs, measureText);
       const dir = detectTextDirection(item.attrs.text);
       if (dir === 'rtl') {
         element.setAttribute('direction', 'rtl');


### PR DESCRIPTION
Rendering ellipsis only when text doesn't fit is weird and doesn't really add any value. This PR fixes so that ellipsed text that only contains the ellipsis character isn't rendered at all.