### PR TITLE
fix(bar-label): take overflow into finding best placement for bar label

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -192,6 +192,7 @@ describe('labeling - bars', () => {
     };
     const barRect = opts => rects[opts.position];
     beforeEach(() => {
+      placements.forEach(p => delete p.overflow);
       // barRect = sinon.stub();
     });
 
@@ -258,6 +259,66 @@ describe('labeling - bars', () => {
         direction: '',
         lblStngs: { fontSize: 2 },
         measured: { width: 900, height: 800 },
+        node: {},
+        orientation: 'v',
+        placementSettings: placements,
+        rect: {}
+      }, barRect);
+      expect(p.placement).to.equal(placements[2]);
+      expect(p.bounds).to.equal(rects.biggest);
+    });
+
+    it('should find placement with overflow and other size is fit, horizontal', () => {
+      placements[3].overflow = true;
+      let p = findBestPlacement({
+        direction: '',
+        lblStngs: { fontSize: 2 },
+        measured: { width: 10, height: 800 },
+        node: {},
+        orientation: 'h',
+        placementSettings: placements,
+        rect: {}
+      }, barRect);
+      expect(p.placement).to.equal(placements[3]);
+      expect(p.bounds).to.equal(rects.meh);
+    });
+
+    it('should find largest rect as fallback when overflow is true but both width and height are not fit , horizontal', () => {
+      placements[3].overflow = true;
+      let p = findBestPlacement({
+        direction: '',
+        lblStngs: { fontSize: 2 },
+        measured: { width: 11, height: 800 },
+        node: {},
+        orientation: 'h',
+        placementSettings: placements,
+        rect: {}
+      }, barRect);
+      expect(p.placement).to.equal(placements[2]);
+      expect(p.bounds).to.equal(rects.biggest);
+    });
+
+    it('should find largest rect as fallback when overflow is true but both width and height are not fit, vertical', () => {
+      placements[3].overflow = true;
+      let p = findBestPlacement({
+        direction: '',
+        lblStngs: { fontSize: 2 },
+        measured: { width: 20, height: 800 },
+        node: {},
+        orientation: 'v',
+        placementSettings: placements,
+        rect: {}
+      }, barRect);
+      expect(p.placement).to.equal(placements[3]);
+      expect(p.bounds).to.equal(rects.meh);
+    });
+
+    it('should find placement with overflow and other size is fit, vertical', () => {
+      placements[3].overflow = true;
+      let p = findBestPlacement({
+        direction: '',
+        lblStngs: { fontSize: 2 },
+        measured: { width: 21, height: 800 },
         node: {},
         orientation: 'v',
         placementSettings: placements,

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -32,29 +32,29 @@ function toBackground(label) {
   };
 }
 
-function isFitWidth(rect, label, rotate, ignoreCheck) {
-  return ignoreCheck || (rotate ? rect.width >= label.height : rect.width >= label.width);
+function isTextWidthInRectWidth(rect, label, rotate) {
+  return rotate ? rect.width >= label.height : rect.width >= label.width;
 }
 
-function isFitHeight(rect, label, rotate, ignoreCheck) {
-  return ignoreCheck || (rotate ? rect.height >= label.width : rect.height >= label.height);
+function isTextHeightInRectHeight(rect, label, rotate) {
+  return rotate ? rect.height >= label.width : rect.height >= label.height;
 }
 
-function isTextFitRect(orientation, rect, label, fitsHorizontally, overflow) {
+function isGoodPlacement(orientation, rect, label, fitsHorizontally, overflow) {
   let fitWidth;
   let fitHeight;
   if (orientation === 'v') {
-    fitWidth = fitsHorizontally || isFitWidth(rect, label, !fitsHorizontally, overflow);
-    fitHeight = isFitHeight(rect, label, !fitsHorizontally);
+    fitWidth = fitsHorizontally || overflow || isTextWidthInRectWidth(rect, label, true);
+    fitHeight = isTextHeightInRectHeight(rect, label, !fitsHorizontally);
   } else {
-    fitWidth = isFitWidth(rect, label);
-    fitHeight = isFitHeight(rect, label, false, overflow);
+    fitWidth = isTextWidthInRectWidth(rect, label);
+    fitHeight = overflow || isTextHeightInRectHeight(rect, label, false);
   }
   return fitWidth && fitHeight;
 }
 
 export function isTextInRect(rect, label, opts) {
-  return isFitWidth(rect, label, opts.rotate) && isFitHeight(rect, label, opts.rotate);
+  return isTextWidthInRectWidth(rect, label, opts.rotate) && isTextHeightInRectHeight(rect, label, opts.rotate);
 }
 
 export function placeSegmentInSegment(majorSegmentPosition, majorSegmentSize, minorSegmentSize, align) {
@@ -186,7 +186,7 @@ export function findBestPlacement({
     boundaries.push(testBounds);
     largest = !p || testBounds.height > largest.height ? testBounds : largest;
 
-    if (isTextFitRect(orientation, testBounds, measured, fitsHorizontally, placement.overflow)) {
+    if (isGoodPlacement(orientation, testBounds, measured, fitsHorizontally, placement.overflow)) {
       bounds = testBounds;
       break;
     }

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -167,10 +167,10 @@ export function findBestPlacement({
     largest = !p || testBounds.height > largest.height ? testBounds : largest;
 
     if (orientation === 'v' && ((fitsHorizontally && testBounds.height >= measured.height)
-      || (!fitsHorizontally && testBounds.height >= measured.width && testBounds.width >= measured.height))) {
+      || (!fitsHorizontally && testBounds.height >= measured.width && (!!placement.overflow || testBounds.width >= measured.height)))) {
       bounds = testBounds;
       break;
-    } else if (orientation === 'h' && (testBounds.height >= measured.height)
+    } else if (orientation === 'h' && (!!placement.overflow || testBounds.height >= measured.height)
       && (testBounds.width >= measured.width)) {
       bounds = testBounds;
       break;


### PR DESCRIPTION
Overflow property is used to ignore checking if a label is fit into a rectangle.
So we should take this into account of finding best placement for labels.