### PR TITLE
fix(legend): fix calculating legend size

### DIFF
--- a/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/item-renderer.spec.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/__tests__/item-renderer.spec.js
@@ -119,6 +119,32 @@ describe('legend-item-renderer', () => {
         globalMetrics: { maxItemBounds: { width: 10, height: 20 } }
       })).to.equal(2);
     });
+
+    describe('horizontal layout', () => {
+      it('should not overflow allowed spread of two rows', () => {
+        // 25 in width + 4 spacing should fit two rows and result in 3 columns
+        // 3 columns = 25 * 3 + 2 * 4 = 83
+        // limit spread to 38 should limit the parallels to 2
+        // 2 rows = 17 * 2 + 4 = 38
+        expect(parallelize(83, 38, {
+          items: [1, 2, 3, 4, 5, 6],
+          layout: { size: 5, margin: { vertical: 4, horizontal: 6 }, orientation: 'horizontal' },
+          globalMetrics: { maxItemBounds: { width: 25, height: 17 } }
+        })).to.equal(2);
+      });
+
+      it('should not overflow allowed spread of one row', () => {
+        // 25 in width + 4 spacing should fit one row and result in 3 columns
+        // 3 columns = 25 * 3 + 2 * 4 = 83
+        // limit spread to 37 should limit the parallels to 1
+        // 1 row = 17
+        expect(parallelize(83, 37, {
+          items: [1, 2, 3, 4, 5, 6],
+          layout: { size: 5, margin: { vertical: 4, horizontal: 6 }, orientation: 'horizontal' },
+          globalMetrics: { maxItemBounds: { width: 25, height: 17 } }
+        })).to.equal(1);
+      });
+    });
   });
 
   describe('getItemsToRender', () => {

--- a/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
@@ -250,13 +250,14 @@ export function parallelize(availableExtent, availableSpread, itemized) {
   const count = itemized.items.length;
   const extentProperty = itemized.layout.orientation === 'horizontal' ? 'width' : 'height';
   const margin = extentProperty === 'width' ? 'horizontal' : 'vertical';
+  const marginSize = itemized.layout.margin[margin];
   const extentInPx = (itemized.globalMetrics.maxItemBounds[extentProperty] * count)
-    + ((count - 1) * itemized.layout.margin[margin]);
+    + ((count - 1) * marginSize);
   let numNeeded = Math.ceil(extentInPx / availableExtent);
 
   if (availableSpread != null) {
     const spreadProperty = itemized.layout.orientation === 'horizontal' ? 'height' : 'width';
-    const numAllowed = Math.floor(availableSpread / (4 + itemized.globalMetrics.maxItemBounds[spreadProperty]));
+    const numAllowed = Math.floor((availableSpread + marginSize) / (marginSize + itemized.globalMetrics.maxItemBounds[spreadProperty]));
     numNeeded = Math.min(numNeeded, numAllowed);
   }
 

--- a/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
+++ b/packages/picasso.js/src/core/chart-components/legend-cat/item-renderer.js
@@ -250,14 +250,15 @@ export function parallelize(availableExtent, availableSpread, itemized) {
   const count = itemized.items.length;
   const extentProperty = itemized.layout.orientation === 'horizontal' ? 'width' : 'height';
   const margin = extentProperty === 'width' ? 'horizontal' : 'vertical';
-  const marginSize = itemized.layout.margin[margin];
   const extentInPx = (itemized.globalMetrics.maxItemBounds[extentProperty] * count)
-    + ((count - 1) * marginSize);
+    + ((count - 1) * itemized.layout.margin[margin]);
   let numNeeded = Math.ceil(extentInPx / availableExtent);
 
   if (availableSpread != null) {
     const spreadProperty = itemized.layout.orientation === 'horizontal' ? 'height' : 'width';
-    const numAllowed = Math.floor((availableSpread + marginSize) / (marginSize + itemized.globalMetrics.maxItemBounds[spreadProperty]));
+    const spreadMargin = spreadProperty === 'width' ? 'horizontal' : 'vertical';
+    const spreadMarginSize = itemized.layout.margin[spreadMargin] || 4;
+    const numAllowed = Math.floor((availableSpread + spreadMarginSize) / (spreadMarginSize + itemized.globalMetrics.maxItemBounds[spreadProperty]));
     numNeeded = Math.min(numNeeded, numAllowed);
   }
 


### PR DESCRIPTION
This PR is to fix calculating number of rows/columns of the categorical legend.
To make it easy, let assume it is horizontal legend.
The relationship between legend height and the number of rows is:
[Legend height] = [Number of rows] * [Row height] + ( [Number of rows] - 1 ) * Margin
where Margin is the distance between rows.

If we know the legend height we can estimate the number of rows as the following:
[Number of rows] = Math.floor( ( [Legend height] + Margin ) / ( [Row height] + Margin ) )
