### PR TITLE
refactor(polygon): rename geopolygon to polygon

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.28.0",
+    "version": "0.29.1",
     "license": "MIT"
   },
   "entries": {
@@ -2547,6 +2547,10 @@
                     },
                     "content": {
                       "type": "function"
+                    },
+                    "tabIndex": {
+                      "optional": true,
+                      "type": "number"
                     }
                   }
                 },

--- a/packages/picasso.js/src/core/geometry/__tests__/polygon.spec.js
+++ b/packages/picasso.js/src/core/geometry/__tests__/polygon.spec.js
@@ -1,7 +1,7 @@
 import { create } from '../polygon';
 import { rectToPoints, lineToPoints } from '../util';
 
-describe('GeoPolygon', () => {
+describe('Polygon', () => {
   let polygon;
   const convexPolygon = [
     { x: 0, y: 25 },

--- a/packages/picasso.js/src/core/geometry/circle.js
+++ b/packages/picasso.js/src/core/geometry/circle.js
@@ -67,7 +67,7 @@ class GeoCircle {
   }
 
   /**
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {

--- a/packages/picasso.js/src/core/geometry/geometry-collection.js
+++ b/packages/picasso.js/src/core/geometry/geometry-collection.js
@@ -52,7 +52,7 @@ class GeometryCollection {
   }
 
   /**
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {

--- a/packages/picasso.js/src/core/geometry/line.js
+++ b/packages/picasso.js/src/core/geometry/line.js
@@ -73,7 +73,7 @@ class GeoLine {
   }
 
   /**
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {

--- a/packages/picasso.js/src/core/geometry/polygon.js
+++ b/packages/picasso.js/src/core/geometry/polygon.js
@@ -31,10 +31,10 @@ function removeDuplicates(vertices) {
 }
 
 /**
- * Construct a new GeoPolygon instance
+ * Construct a new Polygon instance
  * @private
  */
-class GeoPolygon {
+class Polygon {
   constructor({ vertices = [] } = {}) {
     this.set({ vertices });
   }
@@ -117,7 +117,7 @@ class GeoPolygon {
   /**
    * Check if polygon intersects another polygon.
    * Supports convex, concave and self-intersecting polygons (filled area).
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {
@@ -180,17 +180,17 @@ class GeoPolygon {
 
 
 /**
-* Construct a new GeoPolygon instance
+* Construct a new Polygon instance
 * @param {object} input An object with a vertices property
 * @param {point[]} [input.vertices=[]] Vertices are represented as an array of points.
-* @returns {GeoPolygon} GeoPolygon instance
+* @returns {Polygon} Polygon instance
 * @private
 */
 function create(...a) {
-  return new GeoPolygon(...a);
+  return new Polygon(...a);
 }
 
 export {
   create,
-  GeoPolygon as default
+  Polygon as default
 };

--- a/packages/picasso.js/src/core/geometry/polyline.js
+++ b/packages/picasso.js/src/core/geometry/polyline.js
@@ -77,7 +77,7 @@ class GeoPolyline {
   }
 
   /**
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {

--- a/packages/picasso.js/src/core/geometry/rect.js
+++ b/packages/picasso.js/src/core/geometry/rect.js
@@ -80,7 +80,7 @@ class GeoRect {
   }
 
   /**
-   * @param {GeoPolygon} polygon
+   * @param {Polygon} polygon
    * @returns {boolean} True if there is an intersection, false otherwise
    */
   intersectsPolygon(polygon) {


### PR DESCRIPTION
This PR is to:
- rename geopolygon to polygon which is an array of vertices
This is to prepare to add geopolygon which is an array of polygons where the first polygon is an outer polygon and other polygons are inner polygons which represent holes in the outer polygon.