### PR TITLE
fix(q-brush): allow multi select pivot columns

### DIFF
--- a/plugins/q/src/brush/__tests__/q-brush.spec.js
+++ b/plugins/q/src/brush/__tests__/q-brush.spec.js
@@ -265,6 +265,21 @@ describe('q-brush', () => {
             qCol: 2,
             qRow: 7,
             qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 1,
+            qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 6,
+            qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 4,
+            qType: 'L'
           }
         ]
       ]);
@@ -324,7 +339,7 @@ describe('q-brush', () => {
       ]);
     });
 
-    it('should get left dimension, when qNoOfLeftDims = -1', () => {
+    it('should get left dimensions, when qNoOfLeftDims = -1', () => {
       layout.qHyperCube.qNoOfLeftDims = -1;
 
       const selections = qBrush(brush, { byCells: true }, layout);
@@ -344,6 +359,21 @@ describe('q-brush', () => {
           {
             qCol: 2,
             qRow: 7,
+            qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 1,
+            qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 6,
+            qType: 'L'
+          },
+          {
+            qCol: 1,
+            qRow: 4,
             qType: 'L'
           }
         ]

--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -208,7 +208,7 @@ export default function qBrush(brush, opts = {}, layout) {
               };
             }
 
-            if (b.id === primarySource || (!primarySource && methods.selectPivotCells.cells.length === 0)) {
+            if (b.id === primarySource || !primarySource) {
               const validValues = b.brush.values()
                 .map((s) => +s)
                 .filter((v) => !isNaN(v));


### PR DESCRIPTION
This PR makes it possible to brush/select more that one column for pivot cells.