### PR TITLE
feat(brush): suppress paint on brush.end() and brush.start()

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -191,7 +191,14 @@
         "start": {
           "description": "Starts this brush context\n\nStarts this brush context and emits a 'start' event if it is not already started.",
           "kind": "function",
-          "params": [],
+          "params": [
+            {
+              "name": "args",
+              "description": "arguments to be passed to 'start' listeners",
+              "variable": true,
+              "type": "any"
+            }
+          ],
           "emits": [
             {
               "type": "#/definitions/brush/events/start"
@@ -201,7 +208,14 @@
         "end": {
           "description": "Ends this brush context\n\nEnds this brush context and emits an 'end' event if it is not already ended.",
           "kind": "function",
-          "params": [],
+          "params": [
+            {
+              "name": "args",
+              "description": "arguments to be passed to 'end' listeners",
+              "variable": true,
+              "type": "any"
+            }
+          ],
           "emits": [
             {
               "type": "#/definitions/brush/events/end"

--- a/packages/picasso.js/src/core/brush/__tests__/brush.spec.js
+++ b/packages/picasso.js/src/core/brush/__tests__/brush.spec.js
@@ -39,11 +39,11 @@ describe('brush', () => {
   });
 
   describe('events', () => {
-    it('should emit a start event when started', () => {
+    it('should emit a start event with paremeters when started', () => {
       const cb = sandbox.spy();
       b.on('start', cb);
-      b.start();
-      expect(cb.callCount).to.equal(1);
+      b.start(1, '2', false);
+      expect(cb.withArgs(1, '2', false).calledOnce).to.be.true;
     });
 
     it('should not emit a start event when alredy started', () => {
@@ -55,12 +55,12 @@ describe('brush', () => {
       expect(cb.callCount).to.equal(1);
     });
 
-    it('should emit an end event when ended', () => {
+    it('should emit an end event with parameters when ended', () => {
       const cb = sandbox.spy();
       b.on('end', cb);
       b.start();
-      b.end();
-      expect(cb.callCount).to.equal(1);
+      b.end(1, '2', false);
+      expect(cb.withArgs(1, '2', false).calledOnce).to.be.true;
       b.end();
       expect(cb.callCount).to.equal(1);
     });

--- a/packages/picasso.js/src/core/brush/__tests__/brush.spec.js
+++ b/packages/picasso.js/src/core/brush/__tests__/brush.spec.js
@@ -39,7 +39,7 @@ describe('brush', () => {
   });
 
   describe('events', () => {
-    it('should emit a start event with paremeters when started', () => {
+    it('should emit a start event with parameters when started', () => {
       const cb = sandbox.spy();
       b.on('start', cb);
       b.start(1, '2', false);

--- a/packages/picasso.js/src/core/brush/brush.js
+++ b/packages/picasso.js/src/core/brush/brush.js
@@ -479,12 +479,13 @@ export default function brush({ vc = valueCollection, rc = rangeCollection } = {
    * Starts this brush context
    *
    * Starts this brush context and emits a 'start' event if it is not already started.
+   * @param {...any} args - arguments to be passed to 'start' listeners
    * @emits brush#start
    */
-  fn.start = () => {
+  fn.start = (...args) => {
     if (!activated) {
       activated = true;
-      fn.emit('start');
+      fn.emit('start', ...args);
       links.start();
     }
   };
@@ -493,16 +494,17 @@ export default function brush({ vc = valueCollection, rc = rangeCollection } = {
    * Ends this brush context
    *
    * Ends this brush context and emits an 'end' event if it is not already ended.
+   * @param {...any} args - arguments to be passed to 'end' listeners
    * @emits brush#end
    */
-  fn.end = () => {
+  fn.end = (...args) => {
     if (!activated) {
       return;
     }
     activated = false;
     ranges = {};
     values = {};
-    fn.emit('end');
+    fn.emit('end', ...args);
     links.end();
   };
 

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -95,7 +95,8 @@ export function styler(obj, { context, data, style, filter, mode }) {
     return globalChanged;
   };
 
-  const onStart = () => {
+  const onStart = (opts = { suppressRender: false }) => {
+    const { suppressRender } = opts;
     const nodes = getNodes();
     const len = nodes.length;
     for (let i = 0; i < len; i++) {
@@ -113,10 +114,13 @@ export function styler(obj, { context, data, style, filter, mode }) {
     }
     globalActivation = true;
     activeNodes.length = 0;
-    obj.renderer.render(obj.nodes);
+    if (!suppressRender) {
+      obj.renderer.render(obj.nodes);
+    }
   };
 
-  const onEnd = () => {
+  const onEnd = (opts = { suppressRender: false }) => {
+    const { suppressRender } = opts;
     const nodes = getNodes();
     const len = nodes.length;
 
@@ -129,9 +133,11 @@ export function styler(obj, { context, data, style, filter, mode }) {
       }
     }
     activeNodes.length = 0;
-    obj.renderer.render(obj.nodes);
+    if (!suppressRender) {
+      obj.renderer.render(obj.nodes);
+    }
   };
-  const onUpdate = (/* added, removed */) => {
+  const onUpdate = () => {
     const changed = update();
     if (changed) {
       obj.renderer.render(obj.nodes);


### PR DESCRIPTION
Add possibility to suppress picasso component render when doing brush.start and brush.end

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
