### PR TITLE
feat(hammer-plugin): provide Hammer instance

### DIFF
--- a/plugins/hammer/src/__tests__/hammer-mock.js
+++ b/plugins/hammer/src/__tests__/hammer-mock.js
@@ -105,7 +105,6 @@ function hammerMock() {
   Hammer.Manager = Manager;
   Hammer.Tap = Tap;
   Hammer.Pan = Pan;
-  global.Hammer = Hammer;
   return Hammer;
 }
 

--- a/plugins/hammer/src/__tests__/hammer.spec.js
+++ b/plugins/hammer/src/__tests__/hammer.spec.js
@@ -8,9 +8,10 @@ describe('hammer interaction mixin', () => {
   let chart;
   let settings;
   let hammerInteraction;
+  let Hammer;
 
   beforeEach(() => {
-    hammerMock();
+    Hammer = hammerMock();
     element = createElement('div');
     mediator = {};
     chart = {};
@@ -31,7 +32,7 @@ describe('hammer interaction mixin', () => {
         },
       ],
     };
-    hammerInteraction = hammer(chart, mediator, element);
+    hammerInteraction = hammer(Hammer)(chart, mediator, element);
   });
 
   it('should add ', () => {

--- a/plugins/hammer/src/__tests__/plugin.spec.js
+++ b/plugins/hammer/src/__tests__/plugin.spec.js
@@ -1,0 +1,36 @@
+describe('plugin', () => {
+  let plugin;
+  let hammer;
+  let sandbox;
+  before(() => {
+    sandbox = sinon.createSandbox();
+    hammer = sandbox.stub();
+    [{ default: plugin }] = aw.mock([['**/hammer.js', () => hammer]], ['../index.js']);
+  });
+
+  it('should register hammer interaction when parameter is recognized as picasso', () => {
+    hammer.withArgs('H').returns('plugin');
+    const picasso = {
+      interaction: sandbox.spy(),
+    };
+    global.Hammer = 'H';
+    plugin(picasso);
+    delete global.Hammer;
+
+    expect(picasso.interaction).to.have.been.calledWithExactly('hammer', 'plugin');
+  });
+
+  it('should return plugin when parameter is not picasso', () => {
+    hammer.withArgs('HH').returns('plugin');
+    const Hammer = 'HH';
+    const p = plugin(Hammer);
+
+    const picasso = {
+      interaction: sandbox.spy(),
+    };
+
+    p(picasso);
+
+    expect(picasso.interaction).to.have.been.calledWithExactly('hammer', 'plugin');
+  });
+});

--- a/plugins/hammer/src/hammer.js
+++ b/plugins/hammer/src/hammer.js
@@ -1,5 +1,3 @@
-/* global Hammer */
-
 const translateKnownTypes = {
   click: 'Tap',
   Click: 'Tap',
@@ -21,146 +19,149 @@ function getGestureType(type) {
 }
 
 /**
- * Manages event handlers for HammerJS. Assumes Hammer is loaded and added to the global namespace
+ * Manages event handlers for HammerJS.
+ * @param {Hammer} Hammered - The Hammer instance
  */
-function hammer(chart, mediator, element) {
-  let settings;
-  let instance;
-  let mc;
-  let key;
-  let hammerGestures = [];
-  let isOn = true;
-  /**
-   * Set default settings
-   * @private
-   */
-  function setDefaultSettings(newSettings) {
-    key = newSettings.key; //eslint-disable-line
-    settings = newSettings;
-    instance = { chart, mediator, settings };
-    settings.gestures = settings.gestures || [];
-    if (settings.enable === undefined) {
-      settings.enable = true;
+function hammered(Hammered) {
+  return function hammer(chart, mediator, element) {
+    let settings;
+    let instance;
+    let mc;
+    let key;
+    let hammerGestures = [];
+    let isOn = true;
+    /**
+     * Set default settings
+     * @private
+     */
+    function setDefaultSettings(newSettings) {
+      key = newSettings.key; //eslint-disable-line
+      settings = newSettings;
+      instance = { chart, mediator, settings };
+      settings.gestures = settings.gestures || [];
+      if (settings.enable === undefined) {
+        settings.enable = true;
+      }
     }
-  }
 
-  /**
-   * @private
-   * add hammer recognizers based on settings
-   */
-  function addRecognizers() {
-    if (typeof settings.enable === 'function') {
-      settings.enable = settings.enable.bind(instance)();
-    }
-    if (!settings.enable) {
-      return; // interaction is disabled
-    }
-    settings.gestures.forEach(gesture => {
-      gesture.options = gesture.options || {};
-      // handle action enable
-      if (gesture.options.enable === undefined) {
-        gesture.options.enable = true;
+    /**
+     * @private
+     * add hammer recognizers based on settings
+     */
+    function addRecognizers() {
+      if (typeof settings.enable === 'function') {
+        settings.enable = settings.enable.bind(instance)();
       }
-      if (typeof gesture.options.enable === 'function') {
-        gesture.options.enable = gesture.options.enable.bind(instance);
+      if (!settings.enable) {
+        return; // interaction is disabled
       }
-      // setup hammer gestures
-      const type = getGestureType(gesture.type);
-      if (Hammer && Hammer[type]) {
-        gesture.options.event = gesture.options.event || gesture.type.toLowerCase();
-        mc = mc || new Hammer.Manager(element);
-        mc.add(new Hammer[type](gesture.options));
-        Object.keys(gesture.events).forEach(eventName => {
-          gesture.events[eventName] = gesture.events[eventName].bind(instance);
-          mc.on(eventName, gesture.events[eventName]);
-        });
-        hammerGestures.push(gesture);
-      }
-    });
-
-    // setup mixing hammer gestures
-    settings.gestures.forEach(gesture => {
-      const type = getGestureType(gesture.type);
-      if (Hammer && Hammer[type]) {
-        if (gesture.recognizeWith) {
-          mc.get(gesture.options.event).recognizeWith(gesture.recognizeWith.split(' ').filter(e => e !== ''));
+      settings.gestures.forEach(gesture => {
+        gesture.options = gesture.options || {};
+        // handle action enable
+        if (gesture.options.enable === undefined) {
+          gesture.options.enable = true;
         }
-        if (gesture.requireFailure) {
-          mc.get(gesture.options.event).requireFailure(gesture.requireFailure.split(' ').filter(e => e !== ''));
+        if (typeof gesture.options.enable === 'function') {
+          gesture.options.enable = gesture.options.enable.bind(instance);
         }
-      }
-    });
-  }
-  /**
-   * @private
-   * removes all added hammer recognizers and native events
-   */
-  function removeAddedEvents() {
-    // remove hammer recognizers and registered events
-    hammerGestures.forEach(gesture => {
-      Object.keys(gesture.events).forEach(eventName => {
-        mc.off(eventName, gesture.events[eventName]);
+        // setup hammer gestures
+        const type = getGestureType(gesture.type);
+        if (Hammered && Hammered[type]) {
+          gesture.options.event = gesture.options.event || gesture.type.toLowerCase();
+          mc = mc || new Hammered.Manager(element);
+          mc.add(new Hammered[type](gesture.options));
+          Object.keys(gesture.events).forEach(eventName => {
+            gesture.events[eventName] = gesture.events[eventName].bind(instance);
+            mc.on(eventName, gesture.events[eventName]);
+          });
+          hammerGestures.push(gesture);
+        }
       });
-      mc.remove(gesture.options.event);
-    });
-    hammerGestures = [];
-  }
 
-  return {
+      // setup mixing hammer gestures
+      settings.gestures.forEach(gesture => {
+        const type = getGestureType(gesture.type);
+        if (Hammered && Hammered[type]) {
+          if (gesture.recognizeWith) {
+            mc.get(gesture.options.event).recognizeWith(gesture.recognizeWith.split(' ').filter(e => e !== ''));
+          }
+          if (gesture.requireFailure) {
+            mc.get(gesture.options.event).requireFailure(gesture.requireFailure.split(' ').filter(e => e !== ''));
+          }
+        }
+      });
+    }
     /**
-     * Getter for the key.
+     * @private
+     * removes all added hammer recognizers and native events
      */
-    get key() {
-      return key;
-    },
-    /**
-     * Updates this with new settings
-     * @typedef settings
-     * @type {object}
-     * @property {string} [type] - The interaction type. Is 'hammer' for this component
-     * @property {boolean|function} [enable] - Should the interaction be enabled or not.
-     * This is only run when adding event handlers. In effect at startup, update or during on/off.
-     * It does not run during every event loop.
-     * @property {object} [events] - The keys in this object is the names of native events
-     * that should be added to the chart element and they should all point to function which
-     * will be the corresponding event handler.
-     */
-    set(newSettings) {
-      setDefaultSettings(newSettings);
-      removeAddedEvents();
-      if (isOn) {
-        addRecognizers();
-      }
-    },
-    /**
-     * Turns off interactions
-     */
-    off() {
-      isOn = false;
-      removeAddedEvents();
-    },
-    /**
-     * Turns off interactions
-     */
-    on() {
-      isOn = true;
-      if (hammerGestures.length === 0) {
-        addRecognizers();
-      }
-    },
-    /**
-     * Destroys and unbinds all event handlers
-     */
-    destroy() {
-      removeAddedEvents();
-      if (mc) {
-        mc.destroy();
-      }
-      mc = null;
-      instance = null;
-      settings = null;
-    },
+    function removeAddedEvents() {
+      // remove hammer recognizers and registered events
+      hammerGestures.forEach(gesture => {
+        Object.keys(gesture.events).forEach(eventName => {
+          mc.off(eventName, gesture.events[eventName]);
+        });
+        mc.remove(gesture.options.event);
+      });
+      hammerGestures = [];
+    }
+
+    return {
+      /**
+       * Getter for the key.
+       */
+      get key() {
+        return key;
+      },
+      /**
+       * Updates this with new settings
+       * @typedef settings
+       * @type {object}
+       * @property {string} [type] - The interaction type. Is 'hammer' for this component
+       * @property {boolean|function} [enable] - Should the interaction be enabled or not.
+       * This is only run when adding event handlers. In effect at startup, update or during on/off.
+       * It does not run during every event loop.
+       * @property {object} [events] - The keys in this object is the names of native events
+       * that should be added to the chart element and they should all point to function which
+       * will be the corresponding event handler.
+       */
+      set(newSettings) {
+        setDefaultSettings(newSettings);
+        removeAddedEvents();
+        if (isOn) {
+          addRecognizers();
+        }
+      },
+      /**
+       * Turns off interactions
+       */
+      off() {
+        isOn = false;
+        removeAddedEvents();
+      },
+      /**
+       * Turns off interactions
+       */
+      on() {
+        isOn = true;
+        if (hammerGestures.length === 0) {
+          addRecognizers();
+        }
+      },
+      /**
+       * Destroys and unbinds all event handlers
+       */
+      destroy() {
+        removeAddedEvents();
+        if (mc) {
+          mc.destroy();
+        }
+        mc = null;
+        instance = null;
+        settings = null;
+      },
+    };
   };
 }
 
-export default hammer;
+export default hammered;

--- a/plugins/hammer/src/index.js
+++ b/plugins/hammer/src/index.js
@@ -1,5 +1,13 @@
+/* global Hammer */
 import hammer from './hammer';
 
-export default function initialize(picasso) {
-  picasso.interaction('hammer', hammer);
+export default function initialize(picassoOrHammer) {
+  const isPicasso = typeof picassoOrHammer.interaction === 'function';
+  if (!isPicasso) {
+    return picasso => {
+      picasso.interaction('hammer', hammer(picassoOrHammer));
+    };
+  }
+  picassoOrHammer.interaction('hammer', hammer(Hammer));
+  return undefined;
 }


### PR DESCRIPTION
When using the Hammer plugin for picasso, it was assumed that a global Hammer instance was available. However in some cases Hammer could be imported multiple times and thus multiple versions could be conflicting with each other.

Before, the Hammer instance was assumed a global so you could just register the plugin directly:
```js
import picasso from 'picasso.js';
import hammerPlugin from 'picasso-plugin-hammer';

picasso.use(hammerPlugin);
```

It is now possible to provide the Hammer instance to the plugin itself, and then register the result:
```js
import Hammer from 'hammerjs';
import picasso from 'picasso.js';
import hammerPlugin from 'picasso-plugin-hammer';

picasso.use(hammerPlugin(Hammer));
```

While it is still possible to do it the old way, the new approach is recommended.