### PR TITLE
fix(bar-label): allow fill function accessing label bound to support checking overlapping

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -542,7 +542,6 @@ describe('labeling - bars', () => {
           'bounds',
           'a',
           {
-            fill: 'blue',
             justify: 0.4,
             align: 0.8,
             fontSize: '11px',
@@ -657,7 +656,6 @@ describe('labeling - bars', () => {
         postFilter
       );
       expect(placer.firstCall).to.have.been.calledWithExactly('bounds', 'a', {
-        fill: 'blue',
         justify: 0.4,
         align: 0.7,
         fontSize: '11px',

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -307,7 +307,7 @@ export function placeInBars(
 
         if (label) {
           const textBounds = approxTextBounds(label, measured, isRotated, bounds, placement.padding);
-          fill = typeof placement.fill === 'function' ? placement.fill(arg, i, textBounds) : placement.fill;
+          fill = typeof placement.fill === 'function' ? placement.fill({ ...arg, textBounds }, i) : placement.fill;
           label.fill = fill;
           if (typeof linkData !== 'undefined') {
             label.data = linkData;
@@ -315,7 +315,7 @@ export function placeInBars(
           if (typeof placement.background === 'object') {
             label.backgroundColor =
               typeof placement.background.fill === 'function'
-                ? placement.background.fill(arg, i, textBounds)
+                ? placement.background.fill({ ...arg, textBounds }, i)
                 : placement.background.fill;
             if (typeof label.backgroundColor !== 'undefined') {
               label.backgroundBounds = approxTextBounds(

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -281,7 +281,6 @@ export function placeInBars(
 
       if (bounds && placement) {
         justify = placement.justify;
-        fill = typeof placement.fill === 'function' ? placement.fill(arg, i) : placement.fill;
         const linkData = typeof lblStngs.linkData === 'function' ? lblStngs.linkData(arg, i) : undefined;
         const overflow = typeof placement.overflow === 'function' ? placement.overflow(arg, i) : placement.overflow;
 
@@ -297,7 +296,6 @@ export function placeInBars(
 
         const isRotated = !(collectiveOrientation === 'h' || fitsHorizontally);
         label = placer(bounds, text, {
-          fill,
           justify: orientation === 'h' ? placement.align : justify,
           align: orientation === 'h' ? justify : placement.align,
           fontSize: lblStngs.fontSize,
@@ -308,13 +306,16 @@ export function placeInBars(
         });
 
         if (label) {
+          const textBounds = approxTextBounds(label, measured, isRotated, bounds, placement.padding);
+          fill = typeof placement.fill === 'function' ? placement.fill(arg, i, textBounds) : placement.fill;
+          label.fill = fill;
           if (typeof linkData !== 'undefined') {
             label.data = linkData;
           }
           if (typeof placement.background === 'object') {
             label.backgroundColor =
               typeof placement.background.fill === 'function'
-                ? placement.background.fill(arg, i)
+                ? placement.background.fill(arg, i, textBounds)
                 : placement.background.fill;
             if (typeof label.backgroundColor !== 'undefined') {
               label.backgroundBounds = approxTextBounds(
@@ -329,7 +330,7 @@ export function placeInBars(
           labels.push(label);
           postFilterContext.labels.push({
             node,
-            textBounds: approxTextBounds(label, measured, isRotated, bounds, placement.padding),
+            textBounds,
           });
         }
       }


### PR DESCRIPTION
There is a need to decide the color of a label depending on if the label is overlapping with other objects. To be able to do that, in the fill color function, we need to know the label bound to support checking overlapping between the label and other objects. 