### PR TITLE
feat(point): add direction setting

### DIFF
--- a/packages/picasso.js/src/core/chart-components/point/__tests__/point.spec.js
+++ b/packages/picasso.js/src/core/chart-components/point/__tests__/point.spec.js
@@ -46,6 +46,7 @@ describe('point component', () => {
         strokeDasharray: '',
         opacity: 1,
         data: { value: 1, label: '1' },
+        direction: 'vertical',
       },
     ]);
   });
@@ -81,6 +82,7 @@ describe('point component', () => {
         strokeDasharray: '',
         opacity: 1,
         data: { value: 1, label: '1' },
+        direction: 'vertical',
       },
     ]);
   });
@@ -123,6 +125,7 @@ describe('point component', () => {
         strokeDasharray: '2 5',
         opacity: 0.7,
         data: { value: 1, label: '1' },
+        direction: 'vertical',
       },
     ]);
   });
@@ -169,6 +172,7 @@ describe('point component', () => {
           value: 'a',
           label: 'a',
         },
+        direction: 'vertical',
       },
     ]);
   });
@@ -244,6 +248,7 @@ describe('point component', () => {
           },
           label: '[object Object]',
         },
+        direction: 'vertical',
       },
       {
         type: 'square',
@@ -267,6 +272,7 @@ describe('point component', () => {
           },
           label: '[object Object]',
         },
+        direction: 'vertical',
       },
     ]);
   });
@@ -349,6 +355,7 @@ describe('point component', () => {
           minRelExtent: 0.2,
           maxRelExtent: 1,
         },
+        direction: 'vertical',
       },
     };
 
@@ -460,6 +467,7 @@ describe('point component', () => {
           },
           label: '[object Object]',
         },
+        direction: 'vertical',
       },
     ]);
   });

--- a/packages/picasso.js/src/core/chart-components/point/point.js
+++ b/packages/picasso.js/src/core/chart-components/point/point.js
@@ -51,6 +51,9 @@ const DEFAULT_DATA_SETTINGS = {
   /** Whether or not to show the point
    * @type {datum-boolean=} */
   show: true,
+  /** Direction of shape
+   * @type {string=} */
+  direction: 'vertical',
 };
 
 /**
@@ -134,6 +137,7 @@ function createDisplayPoints(dataPoints, { width, height }, pointSize, shapeFn) 
         strokeWidth: s.strokeWidth,
         strokeDasharray: s.strokeDasharray,
         opacity: s.opacity,
+        direction: s.direction,
       };
       if (s === p.errorShape) {
         shapeSpec.width = s.width;


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

Add direction setting to point. For example for horizontal combo chart, triangle and line markers can be rotated.