### PR TITLE
feat(point): resolve shape with custom properties

### DIFF
--- a/packages/picasso.js/src/core/chart-components/point/__tests__/point.spec.js
+++ b/packages/picasso.js/src/core/chart-components/point/__tests__/point.spec.js
@@ -463,4 +463,133 @@ describe('point component', () => {
       },
     ]);
   });
+
+  it('should render points with custom shape', () => {
+    const config = {
+      shapeFn,
+      data: [1],
+      settings: {
+        shape: () => ({
+          type: 'custom',
+          custom: 'prop',
+        }),
+      },
+    };
+
+    componentFixture.simulateCreate(pointComponent, config);
+    renderedPoints = componentFixture.simulateRender(opts);
+
+    expect(renderedPoints).to.deep.equal([
+      {
+        custom: 'prop',
+        type: 'custom',
+        label: '',
+        x: 50,
+        y: 100,
+        fill: '#333',
+        size: 10,
+        stroke: '#ccc',
+        strokeWidth: 0,
+        strokeDasharray: '',
+        opacity: 1,
+        data: { value: 1, label: '1' },
+      },
+    ]);
+  });
+
+  it('should render points with custom shape when type prop is missing', () => {
+    const config = {
+      shapeFn,
+      data: [1],
+      settings: {
+        shape: () => ({
+          // type: 'custom',
+          custom: 'prop',
+        }),
+      },
+    };
+
+    componentFixture.simulateCreate(pointComponent, config);
+    renderedPoints = componentFixture.simulateRender(opts);
+
+    expect(renderedPoints).to.deep.equal([
+      {
+        type: 'circle',
+        label: '',
+        x: 50,
+        y: 100,
+        fill: '#333',
+        size: 10,
+        stroke: '#ccc',
+        strokeWidth: 0,
+        strokeDasharray: '',
+        opacity: 1,
+        data: { value: 1, label: '1' },
+      },
+    ]);
+  });
+
+  it('should render points with default type when shape is an object', () => {
+    const config = {
+      shapeFn,
+      data: [1],
+      settings: {
+        shape: {
+          type: 'custom',
+          custom: 'prop',
+        },
+      },
+    };
+
+    componentFixture.simulateCreate(pointComponent, config);
+    renderedPoints = componentFixture.simulateRender(opts);
+
+    expect(renderedPoints).to.deep.equal([
+      {
+        type: 'circle',
+        label: '',
+        x: 50,
+        y: 100,
+        fill: '#333',
+        size: 10,
+        stroke: '#ccc',
+        strokeWidth: 0,
+        strokeDasharray: '',
+        opacity: 1,
+        data: { value: 1, label: '1' },
+      },
+    ]);
+  });
+
+  it('should not be able to override base point properties with custom shape', () => {
+    const config = {
+      shapeFn,
+      data: [1],
+      settings: {
+        shape: () => ({
+          type: 'custom',
+          label: 'do not override',
+        }),
+      },
+    };
+
+    componentFixture.simulateCreate(pointComponent, config);
+    renderedPoints = componentFixture.simulateRender(opts);
+
+    expect(renderedPoints).to.deep.equal([
+      {
+        type: 'custom',
+        label: '',
+        x: 50,
+        y: 100,
+        fill: '#333',
+        size: 10,
+        stroke: '#ccc',
+        strokeWidth: 0,
+        strokeDasharray: '',
+        opacity: 1,
+        data: { value: 1, label: '1' },
+      },
+    ]);
+  });
 });

--- a/packages/picasso.js/src/core/chart-components/point/point.js
+++ b/packages/picasso.js/src/core/chart-components/point/point.js
@@ -113,6 +113,20 @@ function getPointSizeLimits(x, y, width, height, limits) {
   };
 }
 
+function getType(s) {
+  let type = DEFAULT_DATA_SETTINGS.shape;
+  let props = {};
+  if (typeof s.shape === 'object' && typeof s.shape.type === 'string') {
+    type = s.shape.type;
+    props = s.shape;
+  } else if (typeof s.shape === 'string') {
+    type = s.shape;
+  }
+  type = type === 'rect' ? 'square' : type;
+
+  return [type, props];
+}
+
 function createDisplayPoints(dataPoints, { width, height }, pointSize, shapeFn) {
   return dataPoints
     .filter((p) => p.show !== false && !isNaN(p.x + p.y))
@@ -123,8 +137,11 @@ function createDisplayPoints(dataPoints, { width, height }, pointSize, shapeFn) 
         s = DEFAULT_ERROR_SETTINGS.errorShape;
         size = pointSize.min + s.size * (pointSize.max - pointSize.min);
       }
+
+      const [type, typeProps] = getType(s);
       const shapeSpec = {
-        type: s.shape === 'rect' ? 'square' : s.shape,
+        ...typeProps,
+        type,
         label: p.label,
         x: p.x * width,
         y: p.y * height,


### PR DESCRIPTION
Allows `shape` property to be a function that returns an object to enable resolving of shape specific properties. Requires `type` to be on of the properties.

Example:
```js
        settings: {
          shape: () => ({
            type: 'n-polygon',
            sides: 5,
            startAngle: 90,
          }),
        }
```