### PR TITLE
chore: set "babel-eslint" as parser

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "env": {
     "node": true
   },
+  "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module",
     "ecmaFeatures": {


### PR DESCRIPTION
This is mainly to enable the use of optional chaining in picasso.js like:
`obj.val?.prop` instead of writing `obj.val && obj.val.prop`