### PR TITLE
fix: avoid problem during tree data extraction

### DIFF
--- a/plugins/q/src/data/__tests__/extractor-t.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-t.spec.js
@@ -929,13 +929,13 @@ describe('q-data-extractor-t', () => {
         deps
       );
 
+      // Restore
+      treePages[0].qNodes[0].qAttrDims = tempQAttrDims;
+
       expect(m).to.eql([
         { value: NaN, label: '', source: { key: 'cube', field: 'qDimensionInfo/0/qAttrDimInfo/1' } },
         { value: 7, label: 'Bake', source: { key: 'cube', field: 'qDimensionInfo/0/qAttrDimInfo/1' } },
       ]);
-
-      // Restore
-      treePages[0].qNodes[0].qAttrDims = tempQAttrDims;
     });
 
     it('should be fine with nodes missing qAttrExps', () => {
@@ -953,6 +953,9 @@ describe('q-data-extractor-t', () => {
         deps
       );
 
+      // Restore
+      treePages[0].qNodes[0].qNodes[0].qAttrExps = tempQAttrExps;
+
       expect(m).to.eql([
         { value: NaN, label: '', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
         { value: 2, label: 'two', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
@@ -960,9 +963,6 @@ describe('q-data-extractor-t', () => {
         { value: 7, label: 'seven', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
         { value: 9, label: 'nine', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
       ]);
-
-      // Restore
-      treePages[0].qNodes[0].qNodes[0].qAttrExps = tempQAttrExps;
     });
   });
 

--- a/plugins/q/src/data/__tests__/extractor-t.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-t.spec.js
@@ -914,6 +914,56 @@ describe('q-data-extractor-t', () => {
         },
       ]);
     });
+
+    it('should be fine with nodes missing qAttrDims', () => {
+      const tempQAttrDims = treePages[0].qNodes[0].qAttrDims;
+      delete treePages[0].qNodes[0].qAttrDims;
+      const m = extract(
+        {
+          field: 'firstDimSecondAttrDim',
+          value: (d) => d?.qElemNo || NaN,
+          label: (d) => d?.qText || '',
+        },
+        dataset,
+        {},
+        deps
+      );
+
+      expect(m).to.eql([
+        { value: NaN, label: '', source: { key: 'cube', field: 'qDimensionInfo/0/qAttrDimInfo/1' } },
+        { value: 7, label: 'Bake', source: { key: 'cube', field: 'qDimensionInfo/0/qAttrDimInfo/1' } },
+      ]);
+
+      // Restore
+      treePages[0].qNodes[0].qAttrDims = tempQAttrDims;
+    });
+
+    it('should be fine with nodes missing qAttrExps', () => {
+      const tempQAttrExps = treePages[0].qNodes[0].qNodes[0].qAttrExps;
+      delete treePages[0].qNodes[0].qNodes[0].qAttrExps;
+
+      const m = extract(
+        {
+          field: 'qDimensionInfo/1/qAttrExprInfo/0',
+          value: (d) => d?.qNum || NaN,
+          label: (d) => d?.qText || '',
+        },
+        dataset,
+        {},
+        deps
+      );
+
+      expect(m).to.eql([
+        { value: NaN, label: '', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
+        { value: 2, label: 'two', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
+        { value: 5, label: 'five', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
+        { value: 7, label: 'seven', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
+        { value: 9, label: 'nine', source: { key: 'cube', field: 'qDimensionInfo/1/qAttrExprInfo/0' } },
+      ]);
+
+      // Restore
+      treePages[0].qNodes[0].qNodes[0].qAttrExps = tempQAttrExps;
+    });
   });
 
   describe('with pseudo', () => {

--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -108,9 +108,9 @@ function getFieldAccessor(sourceDepthObject, targetDepthObject) {
   let attrFn;
 
   if (targetDepthObject.attrDimIdx >= 0) {
-    attrFn = (data) => data.qAttrDims.qValues[targetDepthObject.attrDimIdx];
+    attrFn = (data) => data?.qAttrDims?.qValues[targetDepthObject.attrDimIdx];
   } else if (targetDepthObject.attrIdx >= 0) {
-    attrFn = (data) => data.qAttrExps.qValues[targetDepthObject.attrIdx];
+    attrFn = (data) => data?.qAttrExps?.qValues[targetDepthObject.attrIdx];
   }
 
   return {


### PR DESCRIPTION
Additional checks to avoid problem during data extraction for tree data nodes that are missing qAttrDims or qAttrExps.
