### PR TITLE
feat: add deferred renderer

### DIFF
--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -39,6 +39,7 @@
     "d3-format": "1.4.4",
     "d3-hierarchy": "1.1.9",
     "d3-interpolate": "1.4.0",
+    "d3-path": "^2.0.0",
     "d3-scale": "2.2.2",
     "d3-shape": "1.3.6",
     "d3-time-format": "2.2.3",
@@ -47,6 +48,7 @@
     "node-event-emitter": "0.0.1",
     "path2d-polyfill": "1.1.1",
     "preact": "10.5.7",
+    "string-pixel-width": "^1.10.0",
     "test-utils": "^0.34.0"
   }
 }

--- a/packages/picasso.js/src/api/renderers.js
+++ b/packages/picasso.js/src/api/renderers.js
@@ -1,5 +1,6 @@
 import { rendererComponent as canvas } from '../web/renderer/canvas-renderer';
 import { rendererComponent as svg } from '../web/renderer/svg-renderer/svg-renderer';
 import { rendererComponent as dom } from '../web/renderer/dom-renderer';
+import { rendererComponent as deferred } from '../native/deferred-renderer';
 
-export default [svg, canvas, dom];
+export default [svg, canvas, dom, deferred];

--- a/packages/picasso.js/src/native/deferred-renderer/index.js
+++ b/packages/picasso.js/src/native/deferred-renderer/index.js
@@ -1,0 +1,7 @@
+import renderer from './renderer';
+
+export default renderer;
+
+export function rendererComponent(picasso) {
+  picasso.renderer('deferred', renderer);
+}

--- a/packages/picasso.js/src/native/deferred-renderer/renderer.js
+++ b/packages/picasso.js/src/native/deferred-renderer/renderer.js
@@ -1,0 +1,176 @@
+import sceneFactory from '../../core/scene-graph/scene';
+import createRendererBox from '../../web/renderer/renderer-box';
+import create from '../../web/renderer/index';
+
+const d3 = require('d3-path');
+const getPixelWidth = require('string-pixel-width');
+
+const renderer = (sceneFn = sceneFactory) => {
+  const rnRnderer = create();
+  let rect = createRendererBox();
+  let element;
+  let scene;
+  let _key;
+
+  function buildRect(context, _rect, obj) {
+    context.rect(_rect.x, _rect.y, _rect.width, _rect.height);
+    obj.stroke = _rect.stroke;
+    obj.strokeWidth = _rect.strokeWidth;
+    obj.opacity = _rect?.opacity;
+    obj.fill = _rect.fill;
+    obj.path = context.toString();
+  }
+
+  rnRnderer.setKey = (k) => {
+    _key = k;
+    if (element && element.setAnimationKey) {
+      element.setAnimationKey(k);
+    }
+  };
+
+  rnRnderer.appendTo = (parent) => {
+    if (!element) {
+      element = parent.createElement(rect, _key);
+    }
+  };
+
+  rnRnderer.element = () => {
+    return element;
+  };
+
+  rnRnderer.root = () => element;
+
+  rnRnderer.measureText = (opt) => {
+    let size = parseInt(opt.fontSize, 10);
+    if (isNaN(size)) {
+      size = 12;
+    }
+    const fontFamily = opt.fontFamily.split(',').map((s) => s.trim().toLowerCase());
+    const font = fontFamily.length > 1 ? fontFamily[1] : fontFamily[0];
+    const dims = opt.fontSize
+      ? { width: getPixelWidth(opt.text, { size, font }), height: size }
+      : { width: getPixelWidth(opt.text, { size: 12, font }) };
+    return dims;
+  };
+
+  rnRnderer.size = (opts) => {
+    if (opts) {
+      const newRect = createRendererBox(opts);
+      rect = newRect;
+      return newRect;
+    }
+
+    return rect;
+  };
+
+  rnRnderer.clear = () => {
+    if (element && element.clear) {
+      element.clear();
+    }
+    scene = null;
+  };
+
+  rnRnderer.destroy = () => {
+    if (element && element.destroy) {
+      element.destroy();
+    }
+    scene = null;
+  };
+
+  rnRnderer.render = (shapes) => {
+    if (!element.clear || !element.add) {
+      return;
+    }
+
+    element.clear();
+    const sceneContainer = {
+      type: 'container',
+      children: shapes,
+    };
+
+    const newScene = sceneFn({
+      items: [sceneContainer],
+    });
+
+    shapes.forEach((shape) => {
+      const obj = { type: shape.type };
+      // do individual properties because in react-native
+      // these objects are transfered over the bridge.  The bridge
+      // serializes the object into JSON, when there's 1000's of objects, every little bit helps.
+      switch (shape.type) {
+        case 'line': {
+          const context = d3.path();
+          context.moveTo(shape.x1, shape.y1);
+          context.lineTo(shape.x2, shape.y2);
+          obj.stroke = shape.stroke;
+          obj.strokeWidth = shape.strokeWidth;
+          obj.opacity = shape?.opacity;
+          obj.path = context.toString();
+          element.add(obj);
+          break;
+        }
+        case 'path': {
+          obj.fill = shape.fill;
+          obj.stroke = shape.stroke;
+          obj.strokeWidth = shape?.strokeWidth;
+          obj.path = shape.d;
+          element.add(obj);
+          break;
+        }
+        case 'circle': {
+          const context = d3.path();
+          context.arc(shape.cx, shape.cy, shape.r, 0, 2 * Math.PI);
+          obj.stroke = shape.stroke;
+          obj.strokeWidth = shape.strokeWidth;
+          obj.opacity = shape?.opacity;
+          obj.fill = shape.fill;
+          obj.path = context.toString();
+          element.add(obj);
+          break;
+        }
+        case 'text': {
+          obj.text = shape.text;
+          obj.transform = shape?.transform;
+          obj.boundingRect = shape?.boundingRect;
+          obj.fill = shape.fill;
+          obj.font = {
+            fontFamily: shape.fontFamily,
+            fontSize: parseFloat(shape.fontSize),
+            anchor: shape.anchor,
+            x: shape.x,
+            y: shape.y,
+            maxWidth: shape?.maxWidth,
+            maxHeight: shape?.maxHeight,
+          };
+          element.add(obj);
+          break;
+        }
+        case 'container': {
+          const context = d3.path();
+          const _rect = shape.children[0];
+          buildRect(context, _rect, obj);
+          element.add(obj);
+          break;
+        }
+        case 'rect': {
+          const context = d3.path();
+          buildRect(context, shape, obj);
+          element.add(obj);
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+
+    scene = newScene;
+  };
+
+  rnRnderer.itemsAt = (input) => (scene ? scene.getItemsFrom(input) : []);
+
+  rnRnderer.findShapes = (selector) => (scene ? scene.findShapes(selector) : []);
+
+  return rnRnderer;
+};
+export default renderer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5535,6 +5535,11 @@ d3-path@1:
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
 
+d3-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
+  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
+
 d3-scale@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
@@ -9492,6 +9497,11 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -13229,6 +13239,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+string-pixel-width@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/string-pixel-width/-/string-pixel-width-1.10.0.tgz#aff215aaa7a65627f937d70fcc88d83ae1bc5657"
+  integrity sha512-cOMpkH+CpxWAnrPsWUvPWhZxh25CzUukweT+6WF+Kwx6+G2ksg8flvELZusLyWiZzfFCjj1+QRRGwcPWZlwVYA==
+  dependencies:
+    lodash.deburr "^4.1.0"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This introduces a new renderer that does not require the full DOM.  This is useful for backend projects or react-native projects that would like to use Picasso to render charts int their own way.   

**How it works**
It takes all the shapes and transforms them into another object with a path property that contains an SVG path and type for custom rendering.  The SVG path is generated using d3-path.

**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
