### PR TITLE
feat: apply transform to rendered components

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -513,7 +513,7 @@ function chartFn(definition, context) {
    * @param {chart-definition} [chart] - Chart definition
    */
   instance.update = (newProps = {}) => {
-    const { partialData, excludeFromUpdate = [] } = newProps;
+    const { partialData, excludeFromUpdate = [], transforms = [] } = newProps;
     let visibleOrder;
     if (newProps.data) {
       data = newProps.data;
@@ -549,6 +549,11 @@ function chartFn(definition, context) {
           return currentComponents[idx];
         }
 
+        if (transforms.some((t) => t.key === comp.key)) {
+          currentComponents[idx].transform = transforms.filter((t) => t.key === comp.key)[0].transform;
+          return currentComponents[idx];
+        }
+
         if (idx === -1) {
           // Component is added
           return createComponent(comp, element);
@@ -577,11 +582,15 @@ function chartFn(definition, context) {
 
     const toUpdate = [];
     const toRender = [];
+    const toTransform = [];
     let toRenderOrUpdate;
     if (partialData) {
       currentComponents.forEach((comp) => {
         if (comp.updateWith && comp.visible) {
           toUpdate.push(comp);
+        }
+        if (comp.transform && comp.visible) {
+          toTransform.push(comp);
         }
       });
       toRenderOrUpdate = toUpdate;
@@ -610,6 +619,8 @@ function chartFn(definition, context) {
     toRender.forEach((comp) => comp.instance.mount());
 
     toRenderOrUpdate.forEach((comp) => comp.instance.beforeRender());
+
+    toTransform.forEach((comp) => comp.instance.transform(comp.transform));
 
     toRenderOrUpdate.forEach((comp) => {
       if (comp.updateWith && comp.visible) {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -321,7 +321,8 @@ function componentFactory(definition, context = {}) {
   });
 
   const rendString = settings.renderer || definition.renderer;
-  const rend = rendString ? renderer || registries.renderer(rendString)() : renderer || registries.renderer()();
+  const rendSettings = settings.rendererSettings;
+  const rend = renderer || registries.renderer(rendString)(rendSettings);
   brushArgs.renderer = rend;
 
   const dockConfigCallbackContext = { resources: chart.logger ? { logger: chart.logger() } : {} };
@@ -431,6 +432,12 @@ function componentFactory(definition, context = {}) {
     const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
     rend.render(nodes);
     currentNodes = nodes;
+  };
+
+  fn.transform = (transformation) => {
+    if (typeof rend.transform === 'function') {
+      rend.transform(transformation);
+    }
   };
 
   fn.hide = () => {

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
@@ -1,0 +1,64 @@
+const DEFAULT_PADDING = {
+  horizontal: 200,
+  vertical: 200,
+};
+
+/**
+ * @param {object|function} [canvasBufferSize] object containing width and height or a function which returns it
+ */
+export default function canvasBuffer({ el, canvasBufferSize }) {
+  const outputCanvas = el;
+  const bufferCanvas = el.cloneNode();
+
+  let dpi;
+  let outputSize;
+  let bufferSize;
+  let bufferOffset;
+
+  return {
+    updateSize: ({ rect, dpiRatio }) => {
+      dpi = dpiRatio;
+      outputSize = {
+        width: rect.computedPhysical.width,
+        height: rect.computedPhysical.height,
+      };
+      if (canvasBufferSize) {
+        bufferSize = typeof canvasBufferSize === 'function' ? canvasBufferSize(rect) : canvasBufferSize;
+      } else {
+        bufferSize = {
+          width: outputSize.width + DEFAULT_PADDING.horizontal * 2,
+          height: outputSize.height + DEFAULT_PADDING.vertical * 2,
+        };
+      }
+      bufferOffset = {
+        left: (bufferSize.width - outputSize.width) / 2,
+        top: (bufferSize.height - outputSize.height) / 2,
+      };
+
+      bufferCanvas.style.width = `${bufferSize.width}px`;
+      bufferCanvas.style.height = `${bufferSize.height}px`;
+      bufferCanvas.width = Math.round(bufferSize.width * dpi);
+      bufferCanvas.height = Math.round(bufferSize.height * dpi);
+    },
+    getOffset: () => bufferOffset,
+    apply: (transform) => {
+      outputCanvas.width = outputCanvas.width; // eslint-disable-line
+      const g = outputCanvas.getContext('2d');
+
+      if (typeof transform === 'object') {
+        const adjustedTransform = [
+          transform.a,
+          transform.b,
+          transform.c,
+          transform.d,
+          transform.e * dpi,
+          transform.f * dpi,
+        ];
+        g.setTransform(...adjustedTransform);
+      }
+
+      g.drawImage(bufferCanvas, -bufferOffset.left * dpi, -bufferOffset.top * dpi);
+    },
+    getContext: () => bufferCanvas.getContext('2d'),
+  };
+}

--- a/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
@@ -51,6 +51,12 @@ export default function renderer(opts = {}) {
     return true;
   };
 
+  dom.transform = (transform) => {
+    const x = transform;
+    const y = transform;
+    el.style.transform = `translate(${x}px, ${y}px)`;
+  };
+
   dom.renderArgs = [h]; // Arguments to render functions using the DOM renderer
 
   dom.clear = () => {

--- a/packages/picasso.js/src/web/renderer/index.js
+++ b/packages/picasso.js/src/web/renderer/index.js
@@ -35,6 +35,18 @@ function create() {
     render: () => false,
 
     /**
+     * Applies transfomation to the rendered area.
+     * @param {object} transform
+     * @param {number} transform.a Horizontal scaling
+     * @param {number} transform.b Horizontal skewing
+     * @param {number} transform.c Vertical skewing
+     * @param {number} transform.d Vertical scaling
+     * @param {number} transform.e Horizontal moving
+     * @param {number} transform.f Vertical scaling
+     */
+    transform: () => {},
+
+    /**
      * Get nodes renderer at area
      * @param {point|circle|rect|line|polygon|geopolygon} geometry - Get nodes that intersects with geometry
      * @returns {SceneNode[]}

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -18,12 +18,14 @@ import injectTextBoundsFn from '../../text-manipulation/inject-textbounds';
 /**
  * Create a new svg renderer
  * @typedef {function} svgRendererFactory
- * @param {function} treeFactory - Node tree factory
- * @param {string} ns - Namespace definition
- * @param {function} sceneFn - Scene factory
+ * @param {object} [opts]
+ * @param {function} [opts.treeFactory] Node tree factory
+ * @param {string} [opts.ns] Namespace definition
+ * @param {function} [opts.sceneFn] Scene factory
  * @returns {renderer} A svg renderer instance
  */
-export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory) {
+export default function renderer(opts = {}) {
+  const { treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory } = opts;
   const tree = treeFn();
   let el;
   let group;
@@ -121,6 +123,12 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     return doRender;
   };
 
+  svg.transform = (transform) => {
+    const x = transform.e;
+    const y = transform.f;
+    group.style.transform = `translate(${x}px, ${y}px)`;
+  };
+
   svg.itemsAt = (input) => (scene ? scene.getItemsFrom(input) : []);
 
   svg.findShapes = (selector) => (scene ? scene.findShapes(selector) : []);
@@ -145,9 +153,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     group = null;
   };
 
-  svg.size = (opts) => {
-    if (opts) {
-      const newRect = createRendererBox(opts);
+  svg.size = (opt) => {
+    if (opt) {
+      const newRect = createRendererBox(opt);
 
       if (JSON.stringify(rect) !== JSON.stringify(newRect)) {
         hasChangedRect = true;


### PR DESCRIPTION
This makes it possible to trigger a "light" rendering of specific components, where only a transform is applied. The reason is to provide smoother rendering performance for charts containing components with a lot of nodes. This approach might be applicable while interacting with a chart where you want to redraw the chart continuously and maintain a responsive feeling.

Here is how it is used:
```
chart.update({
  transforms[{
    key: 'component-key',
    transform: { a: 1, b: 0, c: 0, d: 1, e: 100, f: 200 },
  }]
});
```

But a component rendering using the canvas-renderer needs to provide rendererSettings in the definition (bufferSize is optional) like:
```
rendererSettings: {
  useBuffer: true,
  canvasBufferSize: {
    width: 1000,
    height: 800,
  },
},
```

Here is an example of how it can affect performance (a simple scatterplot with 2000 nodes) where chart rendering time went from 80 ms to 5 ms (the bottom one uses transfoms):
![transfoms](https://user-images.githubusercontent.com/13997395/107223717-cf057c00-6a16-11eb-920b-237b70dcac49.gif)



**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
