### PR TITLE
Render transform2

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -513,7 +513,7 @@ function chartFn(definition, context) {
    * @param {chart-definition} [chart] - Chart definition
    */
   instance.update = (newProps = {}) => {
-    const { partialData, excludeFromUpdate = [] } = newProps;
+    const { partialData, excludeFromUpdate = [], transforms = [] } = newProps;
     let visibleOrder;
     if (newProps.data) {
       data = newProps.data;
@@ -549,6 +549,11 @@ function chartFn(definition, context) {
           return currentComponents[idx];
         }
 
+        if (transforms.some((t) => t.key === comp.key)) {
+          currentComponents[idx].transform = transforms.filter((t) => t.key === comp.key)[0].transform;
+          return currentComponents[idx];
+        }
+
         if (idx === -1) {
           // Component is added
           return createComponent(comp, element);
@@ -577,11 +582,15 @@ function chartFn(definition, context) {
 
     const toUpdate = [];
     const toRender = [];
+    const toTransform = [];
     let toRenderOrUpdate;
     if (partialData) {
       currentComponents.forEach((comp) => {
         if (comp.updateWith && comp.visible) {
           toUpdate.push(comp);
+        }
+        if (comp.transform && comp.visible) {
+          toTransform.push(comp);
         }
       });
       toRenderOrUpdate = toUpdate;
@@ -610,6 +619,8 @@ function chartFn(definition, context) {
     toRender.forEach((comp) => comp.instance.mount());
 
     toRenderOrUpdate.forEach((comp) => comp.instance.beforeRender());
+
+    toTransform.forEach((comp) => comp.instance.transform(comp.transform));
 
     toRenderOrUpdate.forEach((comp) => {
       if (comp.updateWith && comp.visible) {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -321,7 +321,8 @@ function componentFactory(definition, context = {}) {
   });
 
   const rendString = settings.renderer || definition.renderer;
-  const rend = rendString ? renderer || registries.renderer(rendString)() : renderer || registries.renderer()();
+  const rendSettings = settings.rendererSettings;
+  const rend = renderer || registries.renderer(rendString)(rendSettings);
   brushArgs.renderer = rend;
 
   const dockConfigCallbackContext = { resources: chart.logger ? { logger: chart.logger() } : {} };
@@ -431,6 +432,12 @@ function componentFactory(definition, context = {}) {
     const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
     rend.render(nodes);
     currentNodes = nodes;
+  };
+
+  fn.transform = (transformation) => {
+    if (typeof rend.transform === 'function') {
+      rend.transform(transformation);
+    }
   };
 
   fn.hide = () => {

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -321,7 +321,7 @@ function componentFactory(definition, context = {}) {
   });
 
   const rendString = settings.renderer || definition.renderer;
-  const rendSettings = settings.rendererSettings;
+  const rendSettings = settings.rendererSettings || {};
   const rend = renderer || registries.renderer(rendString)(rendSettings);
   brushArgs.renderer = rend;
 
@@ -434,12 +434,6 @@ function componentFactory(definition, context = {}) {
     currentNodes = nodes;
   };
 
-  fn.transform = (transformation) => {
-    if (typeof rend.transform === 'function') {
-      rend.transform(transformation);
-    }
-  };
-
   fn.hide = () => {
     fn.unmount();
     rend.size({
@@ -463,6 +457,11 @@ function componentFactory(definition, context = {}) {
     if (currentTween) {
       currentTween.stop();
     }
+    if (typeof rendSettings.transform === 'function' && rendSettings.transform()) {
+      rend.render();
+      return;
+    }
+
     const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
 
     // Reset brush stylers and triggers

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
@@ -1,0 +1,64 @@
+const DEFAULT_PADDING = {
+  horizontal: 200,
+  vertical: 200,
+};
+
+/**
+ * @param {object|function} [canvasBufferSize] object containing width and height or a function which returns it
+ */
+export default function canvasBuffer({ el, canvasBufferSize }) {
+  const outputCanvas = el;
+  const bufferCanvas = el.cloneNode();
+
+  let dpi;
+  let outputSize;
+  let bufferSize;
+  let bufferOffset;
+
+  return {
+    updateSize: ({ rect, dpiRatio }) => {
+      dpi = dpiRatio;
+      outputSize = {
+        width: rect.computedPhysical.width,
+        height: rect.computedPhysical.height,
+      };
+      if (canvasBufferSize) {
+        bufferSize = typeof canvasBufferSize === 'function' ? canvasBufferSize(rect) : canvasBufferSize;
+      } else {
+        bufferSize = {
+          width: outputSize.width + DEFAULT_PADDING.horizontal * 2,
+          height: outputSize.height + DEFAULT_PADDING.vertical * 2,
+        };
+      }
+      bufferOffset = {
+        left: (bufferSize.width - outputSize.width) / 2,
+        top: (bufferSize.height - outputSize.height) / 2,
+      };
+
+      bufferCanvas.style.width = `${bufferSize.width}px`;
+      bufferCanvas.style.height = `${bufferSize.height}px`;
+      bufferCanvas.width = Math.round(bufferSize.width * dpi);
+      bufferCanvas.height = Math.round(bufferSize.height * dpi);
+    },
+    getOffset: () => bufferOffset,
+    apply: (transform) => {
+      outputCanvas.width = outputCanvas.width; // eslint-disable-line
+      const g = outputCanvas.getContext('2d');
+
+      if (typeof transform === 'object') {
+        const adjustedTransform = [
+          transform.a,
+          transform.b,
+          transform.c,
+          transform.d,
+          transform.e * dpi,
+          transform.f * dpi,
+        ];
+        g.setTransform(...adjustedTransform);
+      }
+
+      g.drawImage(bufferCanvas, -bufferOffset.left * dpi, -bufferOffset.top * dpi);
+    },
+    getContext: () => bufferCanvas.getContext('2d'),
+  };
+}

--- a/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
@@ -3,7 +3,7 @@ import createRendererBox from '../renderer-box';
 import create from '../index';
 
 export default function renderer(opts = {}) {
-  const { createElement = document.createElement.bind(document) } = opts;
+  const { createElement = document.createElement.bind(document), transform } = opts;
 
   let el;
   let rect = createRendererBox();
@@ -34,6 +34,14 @@ export default function renderer(opts = {}) {
       return false;
     }
 
+    const transformation = typeof transform === 'function' && transform();
+    if (transformation) {
+      const { e, f } = transformation;
+      el.style.transform = `translate(${e}px, ${f}px)`;
+      return true;
+    }
+    el.style.transform = '';
+
     el.style.left = `${rect.computedPhysical.x}px`;
     el.style.top = `${rect.computedPhysical.y}px`;
     el.style.width = `${rect.computedPhysical.width}px`;
@@ -49,12 +57,6 @@ export default function renderer(opts = {}) {
     dNode = render(vNode, el, dNode);
 
     return true;
-  };
-
-  dom.transform = (transform) => {
-    const x = transform;
-    const y = transform;
-    el.style.transform = `translate(${x}px, ${y}px)`;
   };
 
   dom.renderArgs = [h]; // Arguments to render functions using the DOM renderer

--- a/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
@@ -51,6 +51,12 @@ export default function renderer(opts = {}) {
     return true;
   };
 
+  dom.transform = (transform) => {
+    const x = transform;
+    const y = transform;
+    el.style.transform = `translate(${x}px, ${y}px)`;
+  };
+
   dom.renderArgs = [h]; // Arguments to render functions using the DOM renderer
 
   dom.clear = () => {

--- a/packages/picasso.js/src/web/renderer/index.js
+++ b/packages/picasso.js/src/web/renderer/index.js
@@ -35,6 +35,18 @@ function create() {
     render: () => false,
 
     /**
+     * Applies transfomation to the rendered area.
+     * @param {object} transform
+     * @param {number} transform.a Horizontal scaling
+     * @param {number} transform.b Horizontal skewing
+     * @param {number} transform.c Vertical skewing
+     * @param {number} transform.d Vertical scaling
+     * @param {number} transform.e Horizontal moving
+     * @param {number} transform.f Vertical scaling
+     */
+    transform: () => {},
+
+    /**
      * Get nodes renderer at area
      * @param {point|circle|rect|line|polygon|geopolygon} geometry - Get nodes that intersects with geometry
      * @returns {SceneNode[]}

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -18,12 +18,14 @@ import injectTextBoundsFn from '../../text-manipulation/inject-textbounds';
 /**
  * Create a new svg renderer
  * @typedef {function} svgRendererFactory
- * @param {function} treeFactory - Node tree factory
- * @param {string} ns - Namespace definition
- * @param {function} sceneFn - Scene factory
+ * @param {object} [opts]
+ * @param {function} [opts.treeFactory] Node tree factory
+ * @param {string} [opts.ns] Namespace definition
+ * @param {function} [opts.sceneFn] Scene factory
  * @returns {renderer} A svg renderer instance
  */
-export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory) {
+export default function renderer(opts = {}) {
+  const { treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory } = opts;
   const tree = treeFn();
   let el;
   let group;
@@ -121,6 +123,12 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     return doRender;
   };
 
+  svg.transform = (transform) => {
+    const x = transform.e;
+    const y = transform.f;
+    group.style.transform = `translate(${x}px, ${y}px)`;
+  };
+
   svg.itemsAt = (input) => (scene ? scene.getItemsFrom(input) : []);
 
   svg.findShapes = (selector) => (scene ? scene.findShapes(selector) : []);
@@ -145,9 +153,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     group = null;
   };
 
-  svg.size = (opts) => {
-    if (opts) {
-      const newRect = createRendererBox(opts);
+  svg.size = (opt) => {
+    if (opt) {
+      const newRect = createRendererBox(opt);
 
       if (JSON.stringify(rect) !== JSON.stringify(newRect)) {
         hasChangedRect = true;

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -22,10 +22,11 @@ import injectTextBoundsFn from '../../text-manipulation/inject-textbounds';
  * @param {function} [opts.treeFactory] Node tree factory
  * @param {string} [opts.ns] Namespace definition
  * @param {function} [opts.sceneFn] Scene factory
+ * @param {function} [opts.transform]
  * @returns {renderer} A svg renderer instance
  */
 export default function renderer(opts = {}) {
-  const { treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory } = opts;
+  const { treeFn = treeFactory, ns = svgNs, sceneFn = sceneFactory, transform } = opts;
   const tree = treeFn();
   let el;
   let group;
@@ -68,6 +69,14 @@ export default function renderer(opts = {}) {
     if (!el) {
       return false;
     }
+
+    const transformation = typeof transform === 'function' && transform();
+    if (transformation) {
+      const { e, f } = transformation;
+      group.style.transform = `translate(${e}px, ${f}px)`;
+      return true;
+    }
+    group.style.transform = '';
 
     const scaleX = rect.scaleRatio.x;
     const scaleY = rect.scaleRatio.y;
@@ -121,12 +130,6 @@ export default function renderer(opts = {}) {
     hasChangedRect = false;
     scene = newScene;
     return doRender;
-  };
-
-  svg.transform = (transform) => {
-    const x = transform.e;
-    const y = transform.f;
-    group.style.transform = `translate(${x}px, ${y}px)`;
   };
 
   svg.itemsAt = (input) => (scene ? scene.getItemsFrom(input) : []);


### PR DESCRIPTION
Alternative solution to #556. The difference is that with this implementation, everything is controlled through `rendererSettings` the component definition (the `transform` callback function and the optional `canvasBufferSize`).
Example of how this is used:

```
componentDef: {
  ...,
  rendererSettings: {
    transform: () => ({ a: 1, b: 0, c: 0, d: 1, e: 100, f: 100 }),
    canvasBufferSize: { width: 1000, height: 800 },
  }
};

chart.update({ partialData: true });
```
 
**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
