### PR TITLE
fix: allow accessing the layout of a Qlik chart inside settings

### DIFF
--- a/studio/src/components/QDataArea/QDataArea.jsx
+++ b/studio/src/components/QDataArea/QDataArea.jsx
@@ -311,17 +311,10 @@ const QDataArea = ({ loadedData = {}, setLoadedData, qDataSettings = {}, onQData
 
   React.useEffect(() => {
     if (objectLayout) {
-      const qData = [
-        {
-          type: 'q',
-          key: 'qHyperCube',
-          data: objectLayout.box ? objectLayout.generated.box.qHyperCube : objectLayout.qHyperCube,
-        },
-      ];
       if (!codeDebouncer.current) {
         codeDebouncer.current = debouncer(onQDataChange, 200);
       }
-      codeDebouncer.current(qData);
+      codeDebouncer.current(objectLayout);
     }
   }, [objectLayout, onQDataChange]);
 


### PR DESCRIPTION
This PR is support accessing the layout of a Qlik chart inside settings so settings can adapt to the chart layout (e.g. number of dimensions, measures, or max/min value of a measure).