### PR TITLE
feat: add callback to decide if labels should be tilted

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -213,7 +213,7 @@ function getComponentSize({ measure, horizontal, majorTicks, rect, measureText, 
       return { size: toLargeSize, isToLarge: true };
     }
   }
-  
+
   return { size, edgeBleed };
 }
 
@@ -262,19 +262,21 @@ export default function getSize({ isDiscrete, rect, formatter, measureText, scal
         })
       ) {
         state.labels.activeMode = 'tilted';
-        if(typeof settings.labels.shouldAutoTilt === 'function'){
+        if (typeof settings.labels.shouldAutoTilt === 'function') {
           componentSize = getComponentSize({ measure, horizontal, majorTicks, rect, measureText, settings, state });
           shouldTilt = settings.labels.shouldAutoTilt(componentSize.size);
-          if(!shouldTilt){
+          if (!shouldTilt) {
             state.labels.activeMode = 'horizontal';
           }
         }
       } else {
         state.labels.activeMode = 'horizontal';
       }
-    }    
+    }
 
-    return shouldTilt ? componentSize : getComponentSize({ measure, horizontal, majorTicks, rect, measureText, settings, state });
+    return shouldTilt
+      ? componentSize
+      : getComponentSize({ measure, horizontal, majorTicks, rect, measureText, settings, state });
   }
 
   return { size, edgeBleed };


### PR DESCRIPTION
This PR is to add a callback shouldAutoTilt to label to allow the user to approve if labels should be tilted or not. The problem is that picasso.js has internal function to decide if labels are tilted or not but in a number of scenarios this is not good enough, e.g. after tilting the labels take too much space comparing to the main area. In this case the user can override the picasso's decision.