### PR TITLE
feat: support AND/OR mode for range selections

### DIFF
--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -231,6 +231,7 @@ describe('Brushing', () => {
     let dummyComponent;
     let consume;
     let brusherStub;
+    let dataFn;
 
     beforeEach(() => {
       nodes[0].data = data[0];
@@ -275,6 +276,9 @@ describe('Brushing', () => {
           },
         },
       };
+
+      dataFn = sinon.stub();
+      dataFn.returns(['b']);
     });
 
     it('should call containsMappedData with provided arguments', () => {
@@ -282,6 +286,13 @@ describe('Brushing', () => {
       s.update();
 
       expect(brusherStub.containsMappedData.firstCall).to.have.been.calledWithExactly(data[0], ['a'], 'moood');
+    });
+
+    it('should call containsMappedData with provided arguments when data is a function', () => {
+      const s = styler(dummyComponent, { ...consume, mode: 'moood', data: dataFn });
+      s.update();
+      expect(dataFn).to.have.been.calledWithExactly({ brush: brusherStub });
+      expect(brusherStub.containsMappedData.firstCall).to.have.been.calledWithExactly(data[0], ['b'], 'moood');
     });
 
     it('start should store all original styling values', () => {

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -50,7 +50,7 @@ export function styler(obj, { context, data, style, filter, mode }) {
     const len = nodes.length;
     let nodeData;
     let globalChanged = false;
-    const evaluatedDataProps = typeof dataProps === 'function' ? dataProps(brusher) : dataProps;
+    const evaluatedDataProps = typeof dataProps === 'function' ? dataProps({ brush: brusher }) : dataProps;
 
     for (let i = 0; i < len; i++) {
       // TODO - update only added and removed nodes

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -50,6 +50,7 @@ export function styler(obj, { context, data, style, filter, mode }) {
     const len = nodes.length;
     let nodeData;
     let globalChanged = false;
+    const evaluatedDataProps = typeof dataProps === 'function' ? dataProps(brusher) : dataProps;
 
     for (let i = 0; i < len; i++) {
       // TODO - update only added and removed nodes
@@ -65,7 +66,7 @@ export function styler(obj, { context, data, style, filter, mode }) {
         });
       }
 
-      const isActive = brusher.containsMappedData(nodeData, dataProps, mode);
+      const isActive = brusher.containsMappedData(nodeData, evaluatedDataProps, mode);
       const activeIdx = activeNodes.indexOf(nodes[i]);
       let changed = false;
       if (isActive && activeIdx === -1) {

--- a/plugins/q/src/brush/__tests__/q-brush.spec.js
+++ b/plugins/q/src/brush/__tests__/q-brush.spec.js
@@ -84,7 +84,7 @@ describe('q-brush', () => {
       expect(selections[0].method).to.equal('rangeSelectHyperCubeValues');
     });
 
-    it('should have valid params', () => {
+    it('should have valid params if opts = {} ', () => {
       const selections = qBrush(brush);
       expect(selections[0].params).to.eql([
         '/qHyperCubeDef',
@@ -119,6 +119,82 @@ describe('q-brush', () => {
         ],
         [],
         true,
+      ]);
+    });
+
+    it('should have valid params if opts = { orMode: true }', () => {
+      const selections = qBrush(brush, { orMode: true });
+      expect(selections[0].params).to.eql([
+        '/qHyperCubeDef',
+        [
+          {
+            qMeasureIx: 3,
+            qRange: {
+              qMin: 13,
+              qMax: 17,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+          {
+            qMeasureIx: 3,
+            qRange: {
+              qMin: 4,
+              qMax: 9,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+          {
+            qMeasureIx: 1,
+            qRange: {
+              qMin: -13,
+              qMax: 6,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+        ],
+        [],
+        true,
+      ]);
+    });
+
+    it('should have valid params if opts = { orMode: false }', () => {
+      const selections = qBrush(brush, { orMode: false });
+      expect(selections[0].params).to.eql([
+        '/qHyperCubeDef',
+        [
+          {
+            qMeasureIx: 3,
+            qRange: {
+              qMin: 13,
+              qMax: 17,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+          {
+            qMeasureIx: 3,
+            qRange: {
+              qMin: 4,
+              qMax: 9,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+          {
+            qMeasureIx: 1,
+            qRange: {
+              qMin: -13,
+              qMax: 6,
+              qMinInclEq: true,
+              qMaxInclEq: true,
+            },
+          },
+        ],
+        [],
+        false,
       ]);
     });
   });

--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -285,7 +285,7 @@ export default function qBrush(brush, opts = {}, layout) {
   if (methods.rangeSelectHyperCubeValues) {
     selections.push({
       method: 'rangeSelectHyperCubeValues',
-      params: [methods.rangeSelectHyperCubeValues.path, methods.rangeSelectHyperCubeValues.ranges, [], true],
+      params: [methods.rangeSelectHyperCubeValues.path, methods.rangeSelectHyperCubeValues.ranges, [], opts.orMode ?? true],
     });
   }
 

--- a/plugins/q/src/brush/q-brush.js
+++ b/plugins/q/src/brush/q-brush.js
@@ -115,6 +115,7 @@ export function extractFieldFromId(id, layout) {
  * @param {object} [opts]
  * @param {boolean} [opts.byCells=false] Whether to prefer selection by row index.
  * @param {string} [opts.primarySource] Field source to extract row indices from. If not specified, indices from first source are used.
+ * @param {boolean} [opts.orMode=true] If false, combine measure range selections.
  * @param {object} [layout] QIX data layout. Needed only when brushing on attribute expressions, to be able to calculate the measure index.
  * @return {object[]} An array of relevant selections
  */
@@ -285,7 +286,12 @@ export default function qBrush(brush, opts = {}, layout) {
   if (methods.rangeSelectHyperCubeValues) {
     selections.push({
       method: 'rangeSelectHyperCubeValues',
-      params: [methods.rangeSelectHyperCubeValues.path, methods.rangeSelectHyperCubeValues.ranges, [], opts.orMode ?? true],
+      params: [
+        methods.rangeSelectHyperCubeValues.path,
+        methods.rangeSelectHyperCubeValues.ranges,
+        [],
+        opts.orMode ?? true,
+      ],
     });
   }
 


### PR DESCRIPTION
This PR is to allow combining range selections by using OR mode or AND mode. Currently picasso.js supports only OR mode. However, AND mode is needed for example when we want to combine two range selections, each for a measure axis in a scatter plot.