### PR TITLE
chore: revert d3-shape version bump

### DIFF
--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -40,7 +40,7 @@
     "d3-hierarchy": "1.1.9",
     "d3-interpolate": "1.4.0",
     "d3-scale": "2.2.2",
-    "d3-shape": "1.3.7",
+    "d3-shape": "1.3.6",
     "d3-time-format": "2.3.0",
     "extend": "3.0.2",
     "hammerjs": "2.0.8",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "depTypeList": ["engines"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["d3-shape"],
+      "enabled": false
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5541,10 +5541,10 @@ d3-scale@2.2.2:
     d3-time "1"
     d3-time-format "2"
 
-d3-shape@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
-  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+d3-shape@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.6.tgz#fa16af40e5c6cde8a2c8eaa977d4ed2cf273a02c"
+  integrity sha512-vv247nPmyncoCRnCT5VYvAVPrrqTGml+GT79detw5IEuBfv2cfTnOtbPBFIIkmL0eg1EYz+ltmJ6lK384ttHcg==
   dependencies:
     d3-path "1"
 


### PR DESCRIPTION
d3-shape v1.3.7 has an unwanted side-effect because of the following change made to it:
```md
Before: Positive values are stacked above zero, while negative values are stacked below zero
Now: Positive values are stacked above zero, negative values are stacked below zero and zero values are stacked at zero.
```

This PR reverts the version bump and locks renovate to the correct version.