### PR TITLE
chore(docs): build spec on publish

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "yarn run spec",
     "spec": "jsdoc -r ../packages/picasso.js/src -p ../packages/picasso.js/package.json -X | scriptappy-from-jsdoc -c ./scriptappy.config.js",
-    "version": "yarn run build"
+    "version": "yarn run spec"
   },
   "devDependencies": {
     "glob": "7.1.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,9 @@
   "version": "0.36.0",
   "description": "Documentation source",
   "scripts": {
-    "build": "yarn run spec && node gen",
-    "spec": "jsdoc -r ../packages/picasso.js/src -p ../packages/picasso.js/package.json -X | scriptappy-from-jsdoc -c ./scriptappy.config.js"
+    "build": "yarn run spec",
+    "spec": "jsdoc -r ../packages/picasso.js/src -p ../packages/picasso.js/package.json -X | scriptappy-from-jsdoc -c ./scriptappy.config.js",
+    "version": "yarn run build"
   },
   "devDependencies": {
     "glob": "7.1.6",


### PR DESCRIPTION
When a release is created today the api spec has a version that is out-of-sync with the released version. This is an attempt to fix that by building the spec as a part of the `lerna version` lifecycle.

Also removed the call to the `gen` script as that is no longer needed.