### PR TITLE
docs: add data extraction type

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -1489,9 +1489,12 @@
         },
         "data": {
           "description": "Data configuration",
-          "type": "#/definitions/DataExtractConfig"
+          "type": "#/definitions/DataExtraction"
         }
-      }
+      },
+      "examples": [
+        "{\n    key: 'my-collection',\n    data: {\n      extract: [{\n        source: 'Products',\n        field: 'Product',\n        value: d => d.name,\n        label: d => `<${d.name}>`\n        props: {\n          year: { field: 'Year' }\n          num: { field: 'Sales' }\n        }\n      }],\n      filter: d => d.label !== 'Sneakers', // extract everything except Sneakers\n      sort: (a, b) => a.label > b.label ? -1 : 1, // sort descending\n    }\n}"
+      ]
     },
     "Component": {
       "description": "Component instance",
@@ -4211,6 +4214,20 @@
           ],
           "type": "any",
           "stability": "experimental"
+        },
+        "data": {
+          "description": "Extracted data that should be available to the component",
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "type": "#/definitions/DataExtraction"
+            },
+            {
+              "type": "#/definitions/DataFieldExtraction"
+            }
+          ],
+          "type": "any"
         }
       }
     },
@@ -4590,8 +4607,13 @@
       ]
     },
     "DataExtractConfig": {
+      "description": "Data extraction definition. Define how and what kind of data should be extracted from a `DataSource`.",
       "kind": "object",
       "entries": {
+        "source": {
+          "description": "Which data source to extract from",
+          "type": "string"
+        },
         "field": {
           "description": "The field to extract data from",
           "type": "string"
@@ -4629,11 +4651,23 @@
         "props": {
           "description": "Additional properties to add to the extracted item",
           "optional": true,
-          "type": "object"
+          "type": "object",
+          "generics": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "#/definitions/DataPropsExtraction"
+            }
+          ]
         }
       },
+      "examples": [
+        "{\n    source: 'Products',\n    field: 'Product',\n    value: d => d.name,\n    label: d => `<${d.name}>`\n    props: {\n      year: { field: 'Year' }\n      num: { field: 'Sales' }\n    }\n  }"
+      ],
       "definitions": {
         "FilterFn": {
+          "description": "Filter callback function",
           "kind": "function",
           "params": [
             {
@@ -4647,6 +4681,7 @@
           }
         },
         "LabelFn": {
+          "description": "Label callback function",
           "kind": "function",
           "params": [
             {
@@ -4660,6 +4695,7 @@
           }
         },
         "ReduceFn": {
+          "description": "Reduce callback function",
           "kind": "function",
           "params": [
             {
@@ -4676,6 +4712,7 @@
           }
         },
         "ReduceLabelFn": {
+          "description": "ReduceLabel callback function",
           "kind": "function",
           "params": [
             {
@@ -4697,6 +4734,7 @@
           }
         },
         "TrackByFn": {
+          "description": "TrackBy callback function",
           "kind": "function",
           "params": [
             {
@@ -4710,6 +4748,7 @@
           }
         },
         "ValueFn": {
+          "description": "Value callback function",
           "kind": "function",
           "params": [
             {
@@ -4724,6 +4763,157 @@
         }
       }
     },
+    "DataExtraction": {
+      "description": "Used to extract data from a `DataSource`",
+      "kind": "object",
+      "entries": {
+        "extract": {
+          "description": "Extract definition",
+          "type": "#/definitions/DataExtractConfig"
+        },
+        "stack": {
+          "description": "If provided, defines how the data should be stacked",
+          "optional": true,
+          "kind": "object",
+          "entries": {
+            "stackKey": {
+              "description": "Callback function. Should return the key to stack by",
+              "type": "#/definitions/DataExtraction/definitions/StackKeyCallback"
+            },
+            "value": {
+              "description": "Callback function. Should return the data value to stack with",
+              "type": "#/definitions/DataExtraction/definitions/StackValueCallback"
+            }
+          }
+        },
+        "filter": {
+          "description": "Callback function to filter the extracted data items",
+          "optional": true,
+          "type": "#/definitions/DataExtraction/definitions/FilterCallback"
+        },
+        "sort": {
+          "description": "Callback function to sort the extracted data items",
+          "optional": true,
+          "type": "#/definitions/DataExtraction/definitions/SortCallback"
+        }
+      },
+      "examples": [
+        "{\n  extract: [{\n    source: 'Products',\n    field: 'Product',\n    value: d => d.name,\n    label: d => `<${d.name}>`\n    props: {\n      year: { field: 'Year' }\n      num: { field: 'Sales' }\n    }\n  }],\n  filter: d => d.label !== 'Sneakers', // extract everything except Sneakers\n  sort: (a, b) => a.label > b.label ? -1 : 1, // sort descending\n}"
+      ],
+      "definitions": {
+        "FilterCallback": {
+          "description": "Callback function to filter the extracted data items",
+          "kind": "function",
+          "params": [
+            {
+              "name": "datum",
+              "description": "The extracted datum",
+              "type": "#/definitions/DatumExtract"
+            }
+          ],
+          "returns": {
+            "description": "Return true if the datum should be included in the final data set",
+            "type": "boolean"
+          }
+        },
+        "SortCallback": {
+          "description": "Callback function to sort the extracted data items",
+          "kind": "function",
+          "params": [
+            {
+              "name": "a",
+              "description": "The extracted datum",
+              "type": "#/definitions/DatumExtract"
+            },
+            {
+              "name": "b",
+              "description": "The extracted datum",
+              "type": "#/definitions/DatumExtract"
+            }
+          ],
+          "returns": {
+            "description": "If less than 0, sort a before b. If greater than 0, sort b before a",
+            "type": "number"
+          }
+        },
+        "StackKeyCallback": {
+          "description": "Callback function. Should return the key to stack by",
+          "kind": "function",
+          "params": [
+            {
+              "name": "datum",
+              "description": "The extracted datum",
+              "type": "#/definitions/DatumExtract"
+            }
+          ],
+          "returns": {
+            "description": "The data value to stack by",
+            "type": "any"
+          }
+        },
+        "StackValueCallback": {
+          "description": "Callback function. Should return the data value to stack with",
+          "kind": "function",
+          "params": [
+            {
+              "name": "datum",
+              "description": "The extracted datum",
+              "type": "#/definitions/DatumExtract"
+            }
+          ],
+          "returns": {
+            "description": "The data value to stack with",
+            "type": "any"
+          }
+        }
+      }
+    },
+    "DataFieldExtraction": {
+      "kind": "object",
+      "entries": {
+        "source": {
+          "description": "Which data source to extract from",
+          "type": "string"
+        },
+        "field": {
+          "description": "The field to extract data from",
+          "type": "string"
+        },
+        "value": {
+          "description": "The field value accessor",
+          "optional": true,
+          "type": "#/definitions/DataExtractConfig/definitions/ValueFn"
+        },
+        "label": {
+          "description": "The field label accessor",
+          "optional": true,
+          "type": "#/definitions/DataExtractConfig/definitions/LabelFn"
+        }
+      },
+      "examples": [
+        "{\n source: 'Products',\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `${val} sek`,\n}"
+      ]
+    },
+    "DataPropsExtraction": {
+      "kind": "object",
+      "entries": {
+        "field": {
+          "description": "The field to extract data from",
+          "type": "string"
+        },
+        "value": {
+          "description": "The field value accessor",
+          "optional": true,
+          "type": "#/definitions/DataExtractConfig/definitions/ValueFn"
+        },
+        "label": {
+          "description": "The field label accessor",
+          "optional": true,
+          "type": "#/definitions/DataExtractConfig/definitions/LabelFn"
+        }
+      },
+      "examples": ["{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `${val} sek`,\n}"]
+    },
     "Dataset": {
       "kind": "interface",
       "params": [],
@@ -4734,7 +4924,16 @@
           "params": [
             {
               "name": "config",
-              "type": "#/definitions/DataExtractConfig"
+              "kind": "union",
+              "items": [
+                {
+                  "type": "#/definitions/DataExtractConfig"
+                },
+                {
+                  "type": "#/definitions/DataFieldExtraction"
+                }
+              ],
+              "type": "any"
             }
           ],
           "returns": {
@@ -5728,7 +5927,16 @@
         "data": {
           "description": "Data configuration",
           "optional": true,
-          "type": "#/definitions/DataExtractConfig"
+          "kind": "union",
+          "items": [
+            {
+              "type": "#/definitions/DataExtraction"
+            },
+            {
+              "type": "#/definitions/DataFieldExtraction"
+            }
+          ],
+          "type": "any"
         }
       }
     },

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4606,170 +4606,13 @@
         }
       ]
     },
-    "DataExtractConfig": {
-      "description": "Data extraction definition. Define how and what kind of data should be extracted from a `DataSource`.",
-      "kind": "object",
-      "entries": {
-        "source": {
-          "description": "Which data source to extract from",
-          "type": "string"
-        },
-        "field": {
-          "description": "The field to extract data from",
-          "type": "string"
-        },
-        "value": {
-          "description": "The field value accessor",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/ValueFn"
-        },
-        "label": {
-          "description": "The field label accessor",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/LabelFn"
-        },
-        "trackBy": {
-          "description": "Track by value accessor",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/TrackByFn"
-        },
-        "reduce": {
-          "description": "Reducer function",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/ReduceFn"
-        },
-        "reduceLabel": {
-          "description": "Label reducer function",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/ReduceLabelFn"
-        },
-        "filter": {
-          "description": "Filter function",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/FilterFn"
-        },
-        "props": {
-          "description": "Additional properties to add to the extracted item",
-          "optional": true,
-          "type": "object",
-          "generics": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "#/definitions/DataPropsExtraction"
-            }
-          ]
-        }
-      },
-      "examples": [
-        "{\n    source: 'Products',\n    field: 'Product',\n    value: d => d.name,\n    label: d => `<${d.name}>`\n    props: {\n      year: { field: 'Year' }\n      num: { field: 'Sales' }\n    }\n  }"
-      ],
-      "definitions": {
-        "FilterFn": {
-          "description": "Filter callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "cell",
-              "description": "The field cell",
-              "type": "any"
-            }
-          ],
-          "returns": {
-            "type": "boolean"
-          }
-        },
-        "LabelFn": {
-          "description": "Label callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "cell",
-              "description": "The field cell",
-              "type": "any"
-            }
-          ],
-          "returns": {
-            "type": "string"
-          }
-        },
-        "ReduceFn": {
-          "description": "Reduce callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "values",
-              "description": "The collected values to reduce",
-              "kind": "array",
-              "items": {
-                "type": "any"
-              }
-            }
-          ],
-          "returns": {
-            "type": "any"
-          }
-        },
-        "ReduceLabelFn": {
-          "description": "ReduceLabel callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "labels",
-              "description": "The collected labels to reduce",
-              "kind": "array",
-              "items": {
-                "type": "any"
-              }
-            },
-            {
-              "name": "value",
-              "description": "Reduced value",
-              "type": "any"
-            }
-          ],
-          "returns": {
-            "type": "string"
-          }
-        },
-        "TrackByFn": {
-          "description": "TrackBy callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "cell",
-              "description": "The field cell",
-              "type": "any"
-            }
-          ],
-          "returns": {
-            "type": "any"
-          }
-        },
-        "ValueFn": {
-          "description": "Value callback function",
-          "kind": "function",
-          "params": [
-            {
-              "name": "cell",
-              "description": "The field cell",
-              "type": "any"
-            }
-          ],
-          "returns": {
-            "type": "any"
-          }
-        }
-      }
-    },
     "DataExtraction": {
       "description": "Used to extract data from a `DataSource`",
       "kind": "object",
       "entries": {
         "extract": {
           "description": "Extract definition",
-          "type": "#/definitions/DataExtractConfig"
+          "type": "#/definitions/DataExtraction/definitions/Extract"
         },
         "stack": {
           "description": "If provided, defines how the data should be stacked",
@@ -4801,6 +4644,183 @@
         "{\n  extract: [{\n    source: 'Products',\n    field: 'Product',\n    value: d => d.name,\n    label: d => `<${d.name}>`\n    props: {\n      year: { field: 'Year' }\n      num: { field: 'Sales' }\n    }\n  }],\n  filter: d => d.label !== 'Sneakers', // extract everything except Sneakers\n  sort: (a, b) => a.label > b.label ? -1 : 1, // sort descending\n}"
       ],
       "definitions": {
+        "Extract": {
+          "description": "Data extraction definition. Define how and what kind of data should be extracted from a `DataSource`.",
+          "kind": "object",
+          "entries": {
+            "source": {
+              "description": "Which data source to extract from",
+              "type": "string"
+            },
+            "field": {
+              "description": "The field to extract data from",
+              "type": "string"
+            },
+            "value": {
+              "description": "The field value accessor",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/ValueFn"
+            },
+            "label": {
+              "description": "The field label accessor",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/LabelFn"
+            },
+            "trackBy": {
+              "description": "Track by value accessor",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/TrackByFn"
+            },
+            "reduce": {
+              "description": "Reducer function",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/ReduceFn"
+            },
+            "reduceLabel": {
+              "description": "Label reducer function",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/ReduceLabelFn"
+            },
+            "filter": {
+              "description": "Filter function",
+              "optional": true,
+              "type": "#/definitions/DataExtraction/definitions/Extract/definitions/FilterFn"
+            },
+            "props": {
+              "description": "Additional properties to add to the extracted item",
+              "optional": true,
+              "type": "object",
+              "generics": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "#/definitions/DataExtraction/definitions/Extract/definitions/Props"
+                }
+              ]
+            }
+          },
+          "examples": [
+            "{\n    source: 'Products',\n    field: 'Product',\n    value: (val) => val,\n    label: (val) => `<${val}>`\n    props: {\n      year: { field: 'Year' }\n      num: { field: 'Sales' }\n    }\n  }"
+          ],
+          "definitions": {
+            "FilterFn": {
+              "description": "Filter callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "cell",
+                  "description": "The field cell",
+                  "type": "any"
+                }
+              ],
+              "returns": {
+                "type": "boolean"
+              }
+            },
+            "LabelFn": {
+              "description": "Label callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "cell",
+                  "description": "The field cell",
+                  "type": "any"
+                }
+              ],
+              "returns": {
+                "type": "string"
+              }
+            },
+            "Props": {
+              "kind": "object",
+              "entries": {
+                "field": {
+                  "description": "The field to extract data from",
+                  "type": "string"
+                },
+                "value": {
+                  "description": "The field value accessor",
+                  "optional": true,
+                  "type": "#/definitions/DataExtraction/definitions/Extract/definitions/ValueFn"
+                },
+                "label": {
+                  "description": "The field label accessor",
+                  "optional": true,
+                  "type": "#/definitions/DataExtraction/definitions/Extract/definitions/LabelFn"
+                }
+              },
+              "examples": ["{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"]
+            },
+            "ReduceFn": {
+              "description": "Reduce callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "values",
+                  "description": "The collected values to reduce",
+                  "kind": "array",
+                  "items": {
+                    "type": "any"
+                  }
+                }
+              ],
+              "returns": {
+                "type": "any"
+              }
+            },
+            "ReduceLabelFn": {
+              "description": "ReduceLabel callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "labels",
+                  "description": "The collected labels to reduce",
+                  "kind": "array",
+                  "items": {
+                    "type": "any"
+                  }
+                },
+                {
+                  "name": "value",
+                  "description": "Reduced value",
+                  "type": "any"
+                }
+              ],
+              "returns": {
+                "type": "string"
+              }
+            },
+            "TrackByFn": {
+              "description": "TrackBy callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "cell",
+                  "description": "The field cell",
+                  "type": "any"
+                }
+              ],
+              "returns": {
+                "type": "any"
+              }
+            },
+            "ValueFn": {
+              "description": "Value callback function",
+              "kind": "function",
+              "params": [
+                {
+                  "name": "cell",
+                  "description": "The field cell",
+                  "type": "any"
+                }
+              ],
+              "returns": {
+                "type": "any"
+              }
+            }
+          }
+        },
         "FilterCallback": {
           "description": "Callback function to filter the extracted data items",
           "kind": "function",
@@ -4882,37 +4902,17 @@
         "value": {
           "description": "The field value accessor",
           "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/ValueFn"
+          "type": "#/definitions/DataExtraction/definitions/Extract/definitions/ValueFn"
         },
         "label": {
           "description": "The field label accessor",
           "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/LabelFn"
+          "type": "#/definitions/DataExtraction/definitions/Extract/definitions/LabelFn"
         }
       },
       "examples": [
-        "{\n source: 'Products',\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `${val} sek`,\n}"
+        "{\n source: 'Products',\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"
       ]
-    },
-    "DataPropsExtraction": {
-      "kind": "object",
-      "entries": {
-        "field": {
-          "description": "The field to extract data from",
-          "type": "string"
-        },
-        "value": {
-          "description": "The field value accessor",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/ValueFn"
-        },
-        "label": {
-          "description": "The field label accessor",
-          "optional": true,
-          "type": "#/definitions/DataExtractConfig/definitions/LabelFn"
-        }
-      },
-      "examples": ["{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `${val} sek`,\n}"]
     },
     "Dataset": {
       "kind": "interface",
@@ -4927,7 +4927,7 @@
               "kind": "union",
               "items": [
                 {
-                  "type": "#/definitions/DataExtractConfig"
+                  "type": "#/definitions/DataExtraction/definitions/Extract"
                 },
                 {
                   "type": "#/definitions/DataFieldExtraction"
@@ -5339,6 +5339,20 @@
           "description": "Format string",
           "optional": true,
           "type": "string"
+        },
+        "data": {
+          "description": "The data to create formatter from",
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "type": "#/definitions/DataExtraction"
+            },
+            {
+              "type": "#/definitions/DataFieldExtraction"
+            }
+          ],
+          "type": "any"
         }
       }
     },

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -108,6 +108,7 @@ import componentCollectionFn from './component-collection';
  * @property {string} [formatter] Named formatter. Fallback to create formatter from scale. Will be provided to the component if it ask for it.
  * @property {ComponentSettings[]} [components] Optional list of child components
  * @property {DockLayoutSettings|customLayoutFunction} [strategy] Layout strategy used for child components.
+ * @property {DataExtraction|DataFieldExtraction} [data] Extracted data that should be available to the component
  */
 
 // mark strategy as experimental

--- a/packages/picasso.js/src/core/chart/scales/index.js
+++ b/packages/picasso.js/src/core/chart/scales/index.js
@@ -11,7 +11,7 @@ import extractData from '../../data/extractor';
  * Definition for creating a scale. Additional properties, specific for a type of scale, can be addded as key/value pairs
  * @typedef {object} ScaleDefinition
  * @property {string} [type] Type of scale
- * @property {DataExtractConfig} [data] Data configuration
+ * @property {DataExtraction|DataFieldExtraction} [data] Data configuration
  */
 
 /**

--- a/packages/picasso.js/src/core/data/collections.js
+++ b/packages/picasso.js/src/core/data/collections.js
@@ -4,7 +4,25 @@ import extract from './extractor';
 /**
  * @interface CollectionSettings
  * @property {string} key Unique key for the collection
- * @property {DataExtractConfig} data Data configuration
+ * @property {DataExtraction} data Data configuration
+ * @example
+ * {
+    key: 'my-collection',
+    data: {
+      extract: [{
+        source: 'Products',
+        field: 'Product',
+        value: d => d.name,
+        label: d => `<${d.name}>`
+        props: {
+          year: { field: 'Year' }
+          num: { field: 'Sales' }
+        }
+      }],
+      filter: d => d.label !== 'Sneakers', // extract everything except Sneakers
+      sort: (a, b) => a.label > b.label ? -1 : 1, // sort descending
+    }
+ * }
  */
 
 function create(config, d, opts, extractor = extract) {

--- a/packages/picasso.js/src/core/data/dataset.js
+++ b/packages/picasso.js/src/core/data/dataset.js
@@ -187,7 +187,7 @@ function ds({ key, data, config } = {}) {
 
     /**
      * Extract data items from this dataset
-     * @param {DataExtractConfig} config
+     * @param {DataExtractConfig|DataFieldExtraction} config
      * @returns {Array<DatumExtract>}
      */
     extract: (cfg) => extract(cfg, dataset, cache),
@@ -217,7 +217,96 @@ ds.util = {
 export { ds as default };
 
 /**
+ * Callback function. Should return the key to stack by
+ * @callback
+ * @typedef {function} DataExtraction~StackKeyCallback
+ * @param {DatumExtract} datum The extracted datum
+ * @returns {any} The data value to stack by
+ */
+
+/**
+ * Callback function. Should return the data value to stack with
+ * @callback
+ * @typedef {function} DataExtraction~StackValueCallback
+ * @param {DatumExtract} datum The extracted datum
+ * @returns {any} The data value to stack with
+ */
+
+/**
+ * Callback function to filter the extracted data items
+ * @callback
+ * @typedef {function} DataExtraction~FilterCallback
+ * @param {DatumExtract} datum The extracted datum
+ * @returns {boolean} Return true if the datum should be included in the final data set
+ */
+
+/**
+ * Callback function to sort the extracted data items
+ * @callback
+ * @typedef {function} DataExtraction~SortCallback
+ * @param {DatumExtract} a The extracted datum
+ * @param {DatumExtract} b The extracted datum
+ * @returns {number} If less than 0, sort a before b. If greater than 0, sort b before a
+ */
+
+/**
+ * Used to extract data from a `DataSource`
+ * @typedef {object} DataExtraction
+ * @property {DataExtractConfig} extract Extract definition
+ * @property {object} [stack] If provided, defines how the data should be stacked
+ * @property {DataExtraction~StackKeyCallback} stack.stackKey Callback function. Should return the key to stack by
+ * @property {DataExtraction~StackValueCallback} stack.value Callback function. Should return the data value to stack with
+ * @property {DataExtraction~FilterCallback} [filter] Callback function to filter the extracted data items
+ * @property {DataExtraction~SortCallback} [sort] Callback function to sort the extracted data items
+ * @example
+{
+  extract: [{
+    source: 'Products',
+    field: 'Product',
+    value: d => d.name,
+    label: d => `<${d.name}>`
+    props: {
+      year: { field: 'Year' }
+      num: { field: 'Sales' }
+    }
+  }],
+  filter: d => d.label !== 'Sneakers', // extract everything except Sneakers
+  sort: (a, b) => a.label > b.label ? -1 : 1, // sort descending
+}
+ */
+
+/**
+ * @typedef {object} DataFieldExtraction
+ * @property {string} source - Which data source to extract from
+ * @property {string} field - The field to extract data from
+ * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
+ * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
+ * @example
+ * {
+ *  source: 'Products',
+ *  field: 'Sales',
+ *  value: (val) => Math.round(val),
+ *  label: (val) => `${val} sek`,
+ * }
+ */
+
+/**
+ * @typedef {object} DataPropsExtraction
+ * @property {string} field - The field to extract data from
+ * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
+ * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
+ * @example
+ * {
+ *  field: 'Sales',
+ *  value: (val) => Math.round(val),
+ *  label: (val) => `${val} sek`,
+ * }
+ */
+
+/**
+ * Data extraction definition. Define how and what kind of data should be extracted from a `DataSource`.
  * @typedef {object} DataExtractConfig
+ * @property {string} source - Which data source to extract from
  * @property {string} field - The field to extract data from
  * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
  * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
@@ -225,40 +314,57 @@ export { ds as default };
  * @property {DataExtractConfig~ReduceFn} [reduce] - Reducer function
  * @property {DataExtractConfig~ReduceLabelFn} [reduceLabel] - Label reducer function
  * @property {DataExtractConfig~FilterFn} [filter] - Filter function
- * @property {object} [props] - Additional properties to add to the extracted item
+ * @property {object.<string, DataPropsExtraction>} [props] - Additional properties to add to the extracted item
+ * @example
+ * {
+    source: 'Products',
+    field: 'Product',
+    value: d => d.name,
+    label: d => `<${d.name}>`
+    props: {
+      year: { field: 'Year' }
+      num: { field: 'Sales' }
+    }
+  }
  */
 
 /**
+ * Value callback function
  * @callback DataExtractConfig~ValueFn
  * @param {any} cell The field cell
  * @returns {any}
  */
 
 /**
+ * Label callback function
  * @callback DataExtractConfig~LabelFn
  * @param {any} cell The field cell
  * @returns {string}
  */
 
 /**
+ * Filter callback function
  * @callback DataExtractConfig~FilterFn
  * @param {any} cell The field cell
  * @returns {boolean}
  */
 
 /**
+ * TrackBy callback function
  * @callback DataExtractConfig~TrackByFn
  * @param {any} cell The field cell
  * @returns {any}
  */
 
 /**
+ * Reduce callback function
  * @callback DataExtractConfig~ReduceFn
  * @param {any[]} values The collected values to reduce
  * @returns {any}
  */
 
 /**
+ * ReduceLabel callback function
  * @callback DataExtractConfig~ReduceLabelFn
  * @param {any[]} labels The collected labels to reduce
  * @param {any} value Reduced value

--- a/packages/picasso.js/src/core/data/dataset.js
+++ b/packages/picasso.js/src/core/data/dataset.js
@@ -187,7 +187,7 @@ function ds({ key, data, config } = {}) {
 
     /**
      * Extract data items from this dataset
-     * @param {DataExtractConfig|DataFieldExtraction} config
+     * @param {DataExtraction~Extract|DataFieldExtraction} config
      * @returns {Array<DatumExtract>}
      */
     extract: (cfg) => extract(cfg, dataset, cache),
@@ -252,7 +252,7 @@ export { ds as default };
 /**
  * Used to extract data from a `DataSource`
  * @typedef {object} DataExtraction
- * @property {DataExtractConfig} extract Extract definition
+ * @property {DataExtraction~Extract} extract Extract definition
  * @property {object} [stack] If provided, defines how the data should be stacked
  * @property {DataExtraction~StackKeyCallback} stack.stackKey Callback function. Should return the key to stack by
  * @property {DataExtraction~StackValueCallback} stack.value Callback function. Should return the data value to stack with
@@ -279,48 +279,35 @@ export { ds as default };
  * @typedef {object} DataFieldExtraction
  * @property {string} source - Which data source to extract from
  * @property {string} field - The field to extract data from
- * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
- * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
+ * @property {DataExtraction~Extract~ValueFn} [value] - The field value accessor
+ * @property {DataExtraction~Extract~LabelFn} [label] - The field label accessor
  * @example
  * {
  *  source: 'Products',
  *  field: 'Sales',
  *  value: (val) => Math.round(val),
- *  label: (val) => `${val} sek`,
- * }
- */
-
-/**
- * @typedef {object} DataPropsExtraction
- * @property {string} field - The field to extract data from
- * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
- * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
- * @example
- * {
- *  field: 'Sales',
- *  value: (val) => Math.round(val),
- *  label: (val) => `${val} sek`,
+ *  label: (val) => `<${val}>`
  * }
  */
 
 /**
  * Data extraction definition. Define how and what kind of data should be extracted from a `DataSource`.
- * @typedef {object} DataExtractConfig
+ * @typedef {object} DataExtraction~Extract
  * @property {string} source - Which data source to extract from
  * @property {string} field - The field to extract data from
- * @property {DataExtractConfig~ValueFn} [value] - The field value accessor
- * @property {DataExtractConfig~LabelFn} [label] - The field label accessor
- * @property {DataExtractConfig~TrackByFn} [trackBy] - Track by value accessor
- * @property {DataExtractConfig~ReduceFn} [reduce] - Reducer function
- * @property {DataExtractConfig~ReduceLabelFn} [reduceLabel] - Label reducer function
- * @property {DataExtractConfig~FilterFn} [filter] - Filter function
- * @property {object.<string, DataPropsExtraction>} [props] - Additional properties to add to the extracted item
+ * @property {DataExtraction~Extract~ValueFn} [value] - The field value accessor
+ * @property {DataExtraction~Extract~LabelFn} [label] - The field label accessor
+ * @property {DataExtraction~Extract~TrackByFn} [trackBy] - Track by value accessor
+ * @property {DataExtraction~Extract~ReduceFn} [reduce] - Reducer function
+ * @property {DataExtraction~Extract~ReduceLabelFn} [reduceLabel] - Label reducer function
+ * @property {DataExtraction~Extract~FilterFn} [filter] - Filter function
+ * @property {object.<string, DataExtraction~Extract~Props>} [props] - Additional properties to add to the extracted item
  * @example
  * {
     source: 'Products',
     field: 'Product',
-    value: d => d.name,
-    label: d => `<${d.name}>`
+    value: (val) => val,
+    label: (val) => `<${val}>`
     props: {
       year: { field: 'Year' }
       num: { field: 'Sales' }
@@ -329,43 +316,56 @@ export { ds as default };
  */
 
 /**
+ * @typedef {object} DataExtraction~Extract~Props
+ * @property {string} field - The field to extract data from
+ * @property {DataExtraction~Extract~ValueFn} [value] - The field value accessor
+ * @property {DataExtraction~Extract~LabelFn} [label] - The field label accessor
+ * @example
+ * {
+ *  field: 'Sales',
+ *  value: (val) => Math.round(val),
+ *  label: (val) => `<${val}>`
+ * }
+ */
+
+/**
  * Value callback function
- * @callback DataExtractConfig~ValueFn
+ * @callback DataExtraction~Extract~ValueFn
  * @param {any} cell The field cell
  * @returns {any}
  */
 
 /**
  * Label callback function
- * @callback DataExtractConfig~LabelFn
+ * @callback DataExtraction~Extract~LabelFn
  * @param {any} cell The field cell
  * @returns {string}
  */
 
 /**
  * Filter callback function
- * @callback DataExtractConfig~FilterFn
+ * @callback DataExtraction~Extract~FilterFn
  * @param {any} cell The field cell
  * @returns {boolean}
  */
 
 /**
  * TrackBy callback function
- * @callback DataExtractConfig~TrackByFn
+ * @callback DataExtraction~Extract~TrackByFn
  * @param {any} cell The field cell
  * @returns {any}
  */
 
 /**
  * Reduce callback function
- * @callback DataExtractConfig~ReduceFn
+ * @callback DataExtraction~Extract~ReduceFn
  * @param {any[]} values The collected values to reduce
  * @returns {any}
  */
 
 /**
  * ReduceLabel callback function
- * @callback DataExtractConfig~ReduceLabelFn
+ * @callback DataExtraction~Extract~ReduceLabelFn
  * @param {any[]} labels The collected labels to reduce
  * @param {any} value Reduced value
  * @returns {string}

--- a/packages/picasso.js/src/core/formatter/index.js
+++ b/packages/picasso.js/src/core/formatter/index.js
@@ -12,6 +12,7 @@ import { numberFormat as d3NumberFormatter, timeFormat as d3TimeFormatter } from
  * @property {string} [formatter] Name of the formatter
  * @property {string} [type] Type of formatter
  * @property {string} [format] Format string
+ * @property {DataExtraction|DataFieldExtraction} [data] The data to create formatter from
  */
 
 const formatterRegistry = registry();


### PR DESCRIPTION
This PR adds two new definitions for extracting data `DataExtraction` and `DataFieldExtraction`. The previously documented definition was not really reflecting reality.