### PR TITLE
chore: fix build script for docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "version": "0.37.0",
   "description": "Documentation source",
   "scripts": {
-    "build": "yarn run spec",
+    "build": "yarn run spec && node gen",
     "spec": "jsdoc -r ../packages/picasso.js/src -p ../packages/picasso.js/package.json -X | scriptappy-from-jsdoc -c ./scriptappy.config.js",
     "version": "yarn run spec"
   },

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "picasso.js",
     "description": "A charting library streamlined for building visualizations for the Qlik Sense Analytics platform.",
-    "version": "0.36.0",
+    "version": "0.37.0",
     "license": "MIT"
   },
   "entries": {


### PR DESCRIPTION
Build script for the website package is dependent on the output of the `gen` script so I have to add it again.