### PR TITLE
feat: transformation setting for components

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -89,9 +89,7 @@
         "renderer": {
           "description": "Renderer registry",
           "type": "#/definitions/registry",
-          "examples": [
-            "const svgFactory = picassojs.renderer('svg');\nconst svgRenderer = svgFactory();"
-          ]
+          "examples": ["const svgFactory = picassojs.renderer('svg');\nconst svgRenderer = svgFactory();"]
         },
         "scale": {
           "description": "Scale registry",
@@ -191,9 +189,7 @@
               }
             }
           ],
-          "examples": [
-            "brush.addRange('Sales', { min: 20, max: 50 });"
-          ]
+          "examples": ["brush.addRange('Sales', { min: 20, max: 50 });"]
         },
         "addRanges": {
           "kind": "function",
@@ -248,9 +244,7 @@
               "type": "#/definitions/Brush/events/update"
             }
           ],
-          "examples": [
-            "brush.addValue('countries', 'Sweden');\nbrush.addValue('/qHyperCube/qDimensionInfo/0', 3);"
-          ]
+          "examples": ["brush.addValue('countries', 'Sweden');\nbrush.addValue('/qHyperCube/qDimensionInfo/0', 3);"]
         },
         "addValues": {
           "kind": "function",
@@ -469,9 +463,7 @@
               "type": "string"
             }
           ],
-          "examples": [
-            "brush.removeKeyAlias('BadFieldName');"
-          ]
+          "examples": ["brush.removeKeyAlias('BadFieldName');"]
         },
         "removeRange": {
           "description": "Removes a numeric range from this brush context",
@@ -536,9 +528,7 @@
               "type": "any"
             }
           ],
-          "examples": [
-            "brush.removeValue('countries', 'Sweden');"
-          ]
+          "examples": ["brush.removeValue('countries', 'Sweden');"]
         },
         "removeValues": {
           "kind": "function",
@@ -685,9 +675,7 @@
               "type": "any"
             }
           ],
-          "examples": [
-            "brush.toggleValue('countries', 'Sweden');"
-          ]
+          "examples": ["brush.toggleValue('countries', 'Sweden');"]
         },
         "toggleValues": {
           "kind": "function",
@@ -1553,9 +1541,7 @@
           "type": "any"
         }
       },
-      "examples": [
-        "{\n type: 'axis',\n scale: '<name-of-scale>'\n}"
-      ],
+      "examples": ["{\n type: 'axis',\n scale: '<name-of-scale>'\n}"],
       "definitions": {
         "ContinuousSettings": {
           "description": "Continuous axis settings",
@@ -3186,9 +3172,7 @@
           }
         }
       },
-      "examples": [
-        "{\n  type: 'legend-cat',\n  scale: '<categorical-color-scale>',\n}"
-      ]
+      "examples": ["{\n  type: 'legend-cat',\n  scale: '<categorical-color-scale>',\n}"]
     },
     "ComponentLegendSeq": {
       "extends": [
@@ -4335,9 +4319,7 @@
           }
         }
       },
-      "examples": [
-        "{\n type: 'text',\n text: 'my title',\n dock: 'left',\n settings: {\n   anchor: 'left',\n }\n}"
-      ]
+      "examples": ["{\n type: 'text',\n text: 'my title',\n dock: 'left',\n settings: {\n   anchor: 'left',\n }\n}"]
     },
     "ComponentTooltip": {
       "extends": [
@@ -4435,9 +4417,7 @@
                   "type": "object"
                 }
               },
-              "examples": [
-                "({ h, data }) => data.map((datum) => h('div', {}, datum))"
-              ]
+              "examples": ["({ h, data }) => data.map((datum) => h('div', {}, datum))"]
             },
             "contentClass": {
               "description": "Set content class.",
@@ -4491,9 +4471,7 @@
                 "description": "Return data",
                 "type": "any"
               },
-              "examples": [
-                "(ctx) => ctx.node.data.value"
-              ]
+              "examples": ["(ctx) => ctx.node.data.value"]
             },
             "filter": {
               "description": "Callback function to filter incoming nodes to only a set of applicable nodes. Is called as a part of the `show` event.\n\nShould return an array of SceneNodes.",
@@ -4870,9 +4848,7 @@
                   "type": "any"
                 }
               },
-              "examples": [
-                "{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"
-              ]
+              "examples": ["{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"]
             },
             "ReduceFn": {
               "description": "Reduce callback function",
@@ -5172,9 +5148,7 @@
           "type": "#/definitions/DatumExtract"
         }
       ],
-      "examples": [
-        "(d) => Math.min(0, d.value);"
-      ]
+      "examples": ["(d) => Math.min(0, d.value);"]
     },
     "DatumBoolean": {
       "description": "Custom type that is either a boolean, DatumConfig or a datumAccessor",
@@ -5997,7 +5971,7 @@
           "type": "any"
         },
         "TransformFunction": {
-          "description": "Should return a transform object if transformation should be applied, otherwise undefined or a falsy value.\nTransforms can be applied with the canvas, svg and dom renderer.\n!Transform is applied when running chart.update with partialData set to true, see example.",
+          "description": "Should return a transform object if transformation should be applied, otherwise undefined or a falsy value.\nTransforms can be applied with the canvas, svg and dom renderer.\nTransform is applied when running chart.update, see example.\n!Important: When a transform is applied to a component, the underlaying node representations are not updated with the new positions/sizes, which\ncan cause problems for operations that relies on the positioning of the shapes/nodes (such as tooltips, selections etc). An extra chart update\nwithout a transform is therefore needed to make sure the node position information is in sync with the visual representation again.",
           "stability": "experimental",
           "kind": "function",
           "params": [],
@@ -6005,7 +5979,7 @@
             "type": "#/definitions/TransformObject"
           },
           "examples": [
-            "const pointComponentDef = {\n  type: 'point',\n  rendererSettings: {\n    tranform() {\n      if(shouldApplyTransform) {\n        return { a: 1, b: 0, c: 0, d: 1, e: x, f: y };\n      }\n    }\n  }\n  data: {\n// ............\n\nchart.update({ partialData: true });"
+            "const pointComponentDef = {\n  type: 'point',\n  rendererSettings: {\n    tranform() {\n      if(shouldApplyTransform) {\n        return {\n          horizontalScaling: 1,\n          horizontalSkewing: 0,\n          verticalSkewing: 0,\n          verticalScaling: 1,\n          horizontalMoving: x,\n          verticalMoving: y\n        };\n      }\n    }\n  }\n  data: {\n// ............\n\nchart.update({ partialData: true });"
           ]
         }
       }
@@ -6389,9 +6363,7 @@
           "returns": {
             "type": "#/definitions/Rect"
           },
-          "examples": [
-            "node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo('viewport');"
-          ]
+          "examples": ["node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo('viewport');"]
         },
         "children": {
           "description": "Get child nodes",
@@ -6483,31 +6455,25 @@
       }
     },
     "TransformObject": {
-      "description": "A format for representing a transformation.",
+      "description": "A format to represent a transformation.",
       "kind": "object",
       "entries": {
-        "a": {
-          "description": "Horizontal scaling",
+        "horizontalScaling": {
           "type": "number"
         },
-        "b": {
-          "description": "Horizontal skewing",
+        "horizontalSkewing": {
           "type": "number"
         },
-        "c": {
-          "description": "Vertical skewing",
+        "verticalSkewing": {
           "type": "number"
         },
-        "d": {
-          "description": "Vertical scaling",
+        "verticalScaling": {
           "type": "number"
         },
-        "e": {
-          "description": "Horizontal moving",
+        "horizontalMoving": {
           "type": "number"
         },
-        "f": {
-          "description": "Vertical moving",
+        "verticalMoving": {
           "type": "number"
         }
       }

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -89,7 +89,9 @@
         "renderer": {
           "description": "Renderer registry",
           "type": "#/definitions/registry",
-          "examples": ["const svgFactory = picassojs.renderer('svg');\nconst svgRenderer = svgFactory();"]
+          "examples": [
+            "const svgFactory = picassojs.renderer('svg');\nconst svgRenderer = svgFactory();"
+          ]
         },
         "scale": {
           "description": "Scale registry",
@@ -189,7 +191,9 @@
               }
             }
           ],
-          "examples": ["brush.addRange('Sales', { min: 20, max: 50 });"]
+          "examples": [
+            "brush.addRange('Sales', { min: 20, max: 50 });"
+          ]
         },
         "addRanges": {
           "kind": "function",
@@ -244,7 +248,9 @@
               "type": "#/definitions/Brush/events/update"
             }
           ],
-          "examples": ["brush.addValue('countries', 'Sweden');\nbrush.addValue('/qHyperCube/qDimensionInfo/0', 3);"]
+          "examples": [
+            "brush.addValue('countries', 'Sweden');\nbrush.addValue('/qHyperCube/qDimensionInfo/0', 3);"
+          ]
         },
         "addValues": {
           "kind": "function",
@@ -463,7 +469,9 @@
               "type": "string"
             }
           ],
-          "examples": ["brush.removeKeyAlias('BadFieldName');"]
+          "examples": [
+            "brush.removeKeyAlias('BadFieldName');"
+          ]
         },
         "removeRange": {
           "description": "Removes a numeric range from this brush context",
@@ -528,7 +536,9 @@
               "type": "any"
             }
           ],
-          "examples": ["brush.removeValue('countries', 'Sweden');"]
+          "examples": [
+            "brush.removeValue('countries', 'Sweden');"
+          ]
         },
         "removeValues": {
           "kind": "function",
@@ -675,7 +685,9 @@
               "type": "any"
             }
           ],
-          "examples": ["brush.toggleValue('countries', 'Sweden');"]
+          "examples": [
+            "brush.toggleValue('countries', 'Sweden');"
+          ]
         },
         "toggleValues": {
           "kind": "function",
@@ -1541,7 +1553,9 @@
           "type": "any"
         }
       },
-      "examples": ["{\n type: 'axis',\n scale: '<name-of-scale>'\n}"],
+      "examples": [
+        "{\n type: 'axis',\n scale: '<name-of-scale>'\n}"
+      ],
       "definitions": {
         "ContinuousSettings": {
           "description": "Continuous axis settings",
@@ -3172,7 +3186,9 @@
           }
         }
       },
-      "examples": ["{\n  type: 'legend-cat',\n  scale: '<categorical-color-scale>',\n}"]
+      "examples": [
+        "{\n  type: 'legend-cat',\n  scale: '<categorical-color-scale>',\n}"
+      ]
     },
     "ComponentLegendSeq": {
       "extends": [
@@ -4243,6 +4259,11 @@
             }
           ],
           "type": "any"
+        },
+        "rendererSettings": {
+          "description": "Settings for the renderer used to render the component",
+          "optional": true,
+          "type": "#/definitions/RendererSettings"
         }
       }
     },
@@ -4314,7 +4335,9 @@
           }
         }
       },
-      "examples": ["{\n type: 'text',\n text: 'my title',\n dock: 'left',\n settings: {\n   anchor: 'left',\n }\n}"]
+      "examples": [
+        "{\n type: 'text',\n text: 'my title',\n dock: 'left',\n settings: {\n   anchor: 'left',\n }\n}"
+      ]
     },
     "ComponentTooltip": {
       "extends": [
@@ -4412,7 +4435,9 @@
                   "type": "object"
                 }
               },
-              "examples": ["({ h, data }) => data.map((datum) => h('div', {}, datum))"]
+              "examples": [
+                "({ h, data }) => data.map((datum) => h('div', {}, datum))"
+              ]
             },
             "contentClass": {
               "description": "Set content class.",
@@ -4466,7 +4491,9 @@
                 "description": "Return data",
                 "type": "any"
               },
-              "examples": ["(ctx) => ctx.node.data.value"]
+              "examples": [
+                "(ctx) => ctx.node.data.value"
+              ]
             },
             "filter": {
               "description": "Callback function to filter incoming nodes to only a set of applicable nodes. Is called as a part of the `show` event.\n\nShould return an array of SceneNodes.",
@@ -4843,7 +4870,9 @@
                   "type": "any"
                 }
               },
-              "examples": ["{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"]
+              "examples": [
+                "{\n field: 'Sales',\n value: (val) => Math.round(val),\n label: (val) => `<${val}>`\n}"
+              ]
             },
             "ReduceFn": {
               "description": "Reduce callback function",
@@ -5143,7 +5172,9 @@
           "type": "#/definitions/DatumExtract"
         }
       ],
-      "examples": ["(d) => Math.min(0, d.value);"]
+      "examples": [
+        "(d) => Math.min(0, d.value);"
+      ]
     },
     "DatumBoolean": {
       "description": "Custom type that is either a boolean, DatumConfig or a datumAccessor",
@@ -5846,6 +5877,18 @@
             "type": "HTMLElement"
           }
         },
+        "settings": {
+          "description": "Set or Get renderer settings",
+          "kind": "function",
+          "params": [
+            {
+              "name": "settings",
+              "description": "Settings for the renderer",
+              "optional": true,
+              "type": "object"
+            }
+          ]
+        },
         "size": {
           "description": "Set or Get the size definition of the renderer container.",
           "kind": "function",
@@ -5920,6 +5963,50 @@
               }
             }
           }
+        }
+      }
+    },
+    "RendererSettings": {
+      "stability": "experimental",
+      "kind": "object",
+      "entries": {
+        "transform": {
+          "description": "Setting for applying transform without re-rendering the whole component completely.",
+          "optional": true,
+          "type": "#/definitions/RendererSettings/definitions/TransformFunction"
+        },
+        "canvasBufferSize": {
+          "description": "Specifies the size of buffer canvas (used together with transform setting).",
+          "optional": true,
+          "type": "#/definitions/RendererSettings/definitions/CanvasBufferSize"
+        }
+      },
+      "definitions": {
+        "CanvasBufferSize": {
+          "description": "An object containing width and height of the canvas buffer or a function returning an object on that format.\nGets a rect object as input parameter.",
+          "stability": "experimental",
+          "kind": "union",
+          "items": [
+            {
+              "type": "function"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "type": "any"
+        },
+        "TransformFunction": {
+          "description": "Should return a transform object if transformation should be applied, otherwise undefined or a falsy value.\nTransforms can be applied with the canvas, svg and dom renderer.\n!Transform is applied when running chart.update with partialData set to true, see example.",
+          "stability": "experimental",
+          "kind": "function",
+          "params": [],
+          "returns": {
+            "type": "#/definitions/TransformObject"
+          },
+          "examples": [
+            "const pointComponentDef = {\n  type: 'point',\n  rendererSettings: {\n    tranform() {\n      if(shouldApplyTransform) {\n        return { a: 1, b: 0, c: 0, d: 1, e: x, f: y };\n      }\n    }\n  }\n  data: {\n// ............\n\nchart.update({ partialData: true });"
+          ]
         }
       }
     },
@@ -6302,7 +6389,9 @@
           "returns": {
             "type": "#/definitions/Rect"
           },
-          "examples": ["node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo('viewport');"]
+          "examples": [
+            "node.boundsRelativeTo($('div'));\nnode.boundsRelativeTo('viewport');"
+          ]
         },
         "children": {
           "description": "Get child nodes",
@@ -6391,6 +6480,36 @@
       "returns": {
         "description": "A svg renderer instance",
         "type": "#/definitions/Renderer"
+      }
+    },
+    "TransformObject": {
+      "description": "A format for representing a transformation.",
+      "kind": "object",
+      "entries": {
+        "a": {
+          "description": "Horizontal scaling",
+          "type": "number"
+        },
+        "b": {
+          "description": "Horizontal skewing",
+          "type": "number"
+        },
+        "c": {
+          "description": "Vertical skewing",
+          "type": "number"
+        },
+        "d": {
+          "description": "Vertical scaling",
+          "type": "number"
+        },
+        "e": {
+          "description": "Horizontal moving",
+          "type": "number"
+        },
+        "f": {
+          "description": "Vertical moving",
+          "type": "number"
+        }
       }
     }
   }

--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -179,6 +179,54 @@ describe('Chart', () => {
       expect(comp2UpdatedCb).to.have.been.calledTwice;
     });
 
+    it('should update components where transform should be applied', () => {
+      const components = {
+        box: {
+          render: () => ['boxNode1'],
+        },
+        point: {
+          render: () => ['pointNode1'],
+        },
+      };
+      const comp = (key) => components[key];
+      comp.has = () => true;
+      const componentFixture = componentFactoryFixture();
+      const mockedRenderer = componentFixture.mocks().renderer;
+      mockedRenderer.render = sinon.spy();
+
+      const chartInstance = chart(
+        Object.assign(definition, {
+          settings: {
+            components: [
+              {
+                type: 'box',
+                key: 'comp1',
+              },
+              {
+                type: 'point',
+                key: 'comp2',
+                rendererSettings: {
+                  transform: () => ({ a: 0, b: 1, c: 0, d: 1, e: 100, f: 100 }),
+                },
+              },
+            ],
+          },
+        }),
+        {
+          registries: {
+            component: comp,
+            renderer: () => () => mockedRenderer,
+          },
+        }
+      );
+
+      expect(mockedRenderer.render).to.have.been.calledTwice;
+      chartInstance.update({ partialData: true });
+      const renderArgs = mockedRenderer.render.args;
+      // no nodes are passed into renderers render function when applying transform!
+      expect(renderArgs).to.eql([[['boxNode1']], [['pointNode1']], [['boxNode1']], []]);
+    });
+
     it('should maintain displayOrder of components after initial render', () => {
       const components = {
         point: {

--- a/packages/picasso.js/src/core/chart/__tests__/component-collection.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/component-collection.spec.js
@@ -12,6 +12,8 @@ function createComponent(settings) {
       getRect: () => rect,
     },
     settings,
+    key: settings.key,
+    hasKey: typeof settings.key !== 'undefined',
   };
 }
 
@@ -68,6 +70,32 @@ describe('component-collection', () => {
       const { visible, hidden } = collection.layout({ layoutSettings: hideLayoutFn, rect });
       expect(visible).to.eql([]);
       expect(hidden).to.have.length(2);
+    });
+  });
+
+  describe('update', () => {
+    it('should apply transform when transform function is available', () => {
+      const collection = componentCollectionFn({ createComponent });
+      const components = [
+        {
+          type: 'box',
+          key: 'no-transform',
+        },
+        {
+          type: 'point',
+          key: 'with-transform',
+          rendererSettings: {
+            transform: () => ({ a: 0, b: 1, c: 0, d: 1, e: 100, f: 100 }),
+          },
+        },
+      ];
+      collection.set({ components });
+      collection.update({ components, excludeFromUpdate: [] });
+      const comp1 = collection.findComponentByKey('no-transform');
+      const comp2 = collection.findComponentByKey('with-transform');
+
+      expect(comp1.applyTransform).to.be.undefined;
+      expect(comp2.applyTransform).to.be.true;
     });
   });
 });

--- a/packages/picasso.js/src/core/chart/component-collection.js
+++ b/packages/picasso.js/src/core/chart/component-collection.js
@@ -107,6 +107,17 @@ function collectionFn({ createComponent }) {
           // Component is added
           return createComp(comp);
         }
+
+        // Only apply transform, no need for an update
+        if (
+          comp.rendererSettings &&
+          typeof comp.rendererSettings.transform === 'function' &&
+          comp.rendererSettings.transform()
+        ) {
+          component.applyTransform = true;
+          return component;
+        }
+
         // Component is (potentially) updated
         component.updateWith = {
           formatters,

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -187,7 +187,7 @@ import componentCollectionFn from './component-collection';
 /**
  * Should return a transform object if transformation should be applied, otherwise undefined or a falsy value.
  * Transforms can be applied with the canvas, svg and dom renderer.
- * !Transform is applied when running chart.update with partialData set to true, see example.
+ * !Transform is applied when running chart.update, see example.
  * @typedef {function} RendererSettings~TransformFunction
  * @returns {TransformObject}
  * @experimental

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -187,7 +187,10 @@ import componentCollectionFn from './component-collection';
 /**
  * Should return a transform object if transformation should be applied, otherwise undefined or a falsy value.
  * Transforms can be applied with the canvas, svg and dom renderer.
- * !Transform is applied when running chart.update, see example.
+ * Transform is applied when running chart.update, see example.
+ * !Important: When a transform is applied to a component, the underlaying node representations are not updated with the new positions/sizes, which
+ * can cause problems for operations that relies on the positioning of the shapes/nodes (such as tooltips, selections etc). An extra chart update
+ * without a transform is therefore needed to make sure the node position information is in sync with the visual representation again.
  * @typedef {function} RendererSettings~TransformFunction
  * @returns {TransformObject}
  * @experimental
@@ -197,7 +200,14 @@ import componentCollectionFn from './component-collection';
  *   rendererSettings: {
  *     tranform() {
  *       if(shouldApplyTransform) {
- *         return { a: 1, b: 0, c: 0, d: 1, e: x, f: y };
+ *         return {
+ *           horizontalScaling: 1,
+ *           horizontalSkewing: 0,
+ *           verticalSkewing: 0,
+ *           verticalScaling: 1,
+ *           horizontalMoving: x,
+ *           verticalMoving: y
+ *         };
  *       }
  *     }
  *   }
@@ -217,12 +227,12 @@ import componentCollectionFn from './component-collection';
 /**
  * A format to represent a transformation.
  * @typedef {object} TransformObject
- * @property {number} a Horizontal scaling
- * @property {number} b Horizontal skewing
- * @property {number} c Vertical skewing
- * @property {number} d Vertical scaling
- * @property {number} e Horizontal moving
- * @property {number} f Vertical moving
+ * @property {number} horizontalScaling
+ * @property {number} horizontalSkewing
+ * @property {number} verticalSkewing
+ * @property {number} verticalScaling
+ * @property {number} horizontalMoving
+ * @property {number} verticalMoving
  */
 
 /**

--- a/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/component-factory.spec.js
@@ -116,6 +116,12 @@ describe('Component', () => {
     });
   });
 
+  it('should forward rendererSettings if renderer has settings func', () => {
+    renderer.settings = sinon.spy();
+    createInstance({ rendererSettings: { aa: 'AA', bb: {} } });
+    expect(renderer.settings).to.have.been.calledWith({ aa: 'AA', bb: {} });
+  });
+
   it('should call lifecycle methods with correct context when rendering', () => {
     createAndRenderComponent();
 
@@ -193,6 +199,23 @@ describe('Component', () => {
   it('should call lifecycle methods with correct context when updating with partial data', () => {
   });
   */
+
+  describe('update', () => {
+    it('should call renderers render func without args when applying transformation', () => {
+      renderer.render = sinon.spy();
+      definition.render = () => ['node1', 'node2'];
+      let transformation = false;
+      let transformFn = () => transformation;
+      let instance;
+
+      instance = createInstance({ rendererSettings: { transform: transformFn } });
+      instance.update();
+      expect(renderer.render).to.have.been.calledWith(['node1', 'node2']);
+      transformation = { a: 0, b: 1, c: 1 };
+      instance.update();
+      expect(renderer.render).to.have.been.calledWith();
+    });
+  });
 
   describe('findShapes', () => {
     let instance;

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -460,6 +460,17 @@ function componentFactory(definition, context = {}) {
       currentTween.stop();
     }
 
+    if (
+      settings.rendererSettings &&
+      typeof settings.rendererSettings.transform === 'function' &&
+      settings.rendererSettings.transform()
+    ) {
+      rend.render();
+      return;
+    }
+
+    const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
+
     // Reset brush stylers and triggers
     brushStylers.forEach((b) => b.cleanUp());
     brushStylers.length = 0;
@@ -476,17 +487,6 @@ function componentFactory(definition, context = {}) {
         bs.update();
       }
     });
-
-    if (
-      settings.rendererSettings &&
-      typeof settings.rendererSettings.transform === 'function' &&
-      settings.rendererSettings.transform()
-    ) {
-      rend.render();
-      return;
-    }
-
-    const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
 
     if (currentNodes && settings.animations && settings.animations.enabled) {
       currentTween = tween(

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -322,6 +322,9 @@ function componentFactory(definition, context = {}) {
 
   const rendString = settings.renderer || definition.renderer;
   const rend = rendString ? renderer || registries.renderer(rendString)() : renderer || registries.renderer()();
+  if (typeof rend.settings === 'function') {
+    rend.settings(settings.rendererSettings);
+  }
   brushArgs.renderer = rend;
 
   const dockConfigCallbackContext = { resources: chart.logger ? { logger: chart.logger() } : {} };
@@ -456,7 +459,6 @@ function componentFactory(definition, context = {}) {
     if (currentTween) {
       currentTween.stop();
     }
-    const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
 
     // Reset brush stylers and triggers
     brushStylers.forEach((b) => b.cleanUp());
@@ -474,6 +476,17 @@ function componentFactory(definition, context = {}) {
         bs.update();
       }
     });
+
+    if (
+      settings.rendererSettings &&
+      typeof settings.rendererSettings.transform === 'function' &&
+      settings.rendererSettings.transform()
+    ) {
+      rend.render();
+      return;
+    }
+
+    const nodes = (brushArgs.nodes = render.call(definitionContext, ...getRenderArgs()));
 
     if (currentNodes && settings.animations && settings.animations.enabled) {
       currentTween = tween(

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-buffer.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-buffer.spec.js
@@ -1,0 +1,64 @@
+import CanvasBuffer from '../canvas-buffer';
+
+describe('canvasBuffer', () => {
+  let targetCanvas;
+  let bufferCanvas;
+  let rect;
+  let setTransform;
+  let drawImage;
+
+  beforeEach(() => {
+    setTransform = sinon.spy();
+    drawImage = sinon.spy();
+    bufferCanvas = {
+      style: {},
+    };
+    targetCanvas = {
+      cloneNode: sinon.stub().returns(bufferCanvas),
+      getContext: sinon.stub().returns({
+        setTransform,
+        drawImage,
+      }),
+    };
+    rect = {
+      computedPhysical: {
+        height: 300,
+        width: 400,
+      },
+    };
+  });
+
+  it('should clone element', () => {
+    new CanvasBuffer(targetCanvas); // eslint-disable-line no-new
+    expect(targetCanvas.cloneNode).to.have.been.calledOnce;
+  });
+
+  describe('updateSize', () => {
+    it('should set default buffer size if not provided', () => {
+      const buffer = new CanvasBuffer(targetCanvas);
+      buffer.updateSize({ rect, dpiRatio: 2 });
+      expect(buffer.bufferCanvas.style.width).to.equal('800px');
+      expect(buffer.bufferCanvas.style.height).to.equal('700px');
+      expect(buffer.bufferCanvas.width).to.equal(1600);
+      expect(buffer.bufferCanvas.height).to.equal(1400);
+    });
+
+    it('should set provided canvasBufferSize', () => {
+      const buffer = new CanvasBuffer(targetCanvas);
+      buffer.updateSize({ rect, dpiRatio: 2, canvasBufferSize: { width: 1000, height: 600 } });
+      expect(buffer.bufferCanvas.style.width).to.equal('1000px');
+      expect(buffer.bufferCanvas.style.height).to.equal('600px');
+      expect(buffer.bufferCanvas.width).to.equal(2000);
+      expect(buffer.bufferCanvas.height).to.equal(1200);
+    });
+  });
+
+  describe('apply', () => {
+    it('should draw bufferCanvas on targetCanvas', () => {
+      const buffer = new CanvasBuffer(targetCanvas);
+      buffer.updateSize({ rect, dpiRatio: 2 });
+      buffer.apply();
+      expect(drawImage).to.have.been.calledWith(bufferCanvas, 0, 0);
+    });
+  });
+});

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
@@ -64,7 +64,14 @@ describe('canvas renderer', () => {
 
   it('should set transform and apply buffer if transform is provided', () => {
     const rendererSettings = {
-      transform: () => ({ a: 1, b: 0, c: 1, d: 0, e: 100, f: 100 }),
+      transform: () => ({
+        horizontalScaling: 1,
+        horizontalSkewing: 0,
+        verticalSkewing: 1,
+        verticalScaling: 0,
+        horizontalMoving: 100,
+        verticalMoving: 100,
+      }),
     };
     r.settings(rendererSettings);
     r.appendTo(element('div'));

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
@@ -44,6 +44,7 @@ class CanvasBuffer {
   }
 
   clear() {
+    // clear canvas
     this.bufferCanvas.width = this.bufferCanvas.width; // eslint-disable-line
   }
 

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-buffer.js
@@ -1,0 +1,55 @@
+const DEFAULT_PADDING = {
+  horizontal: 200,
+  vertical: 200,
+};
+
+/**
+ * Creates a canvas element, preferrably larger than the target canvas.
+ * This "buffer canvas" is detached from the DOM and allows rendering of shapes outside of the visible area.
+ * Especially useful when applying transforms to target canvas.
+ * @private
+ */
+class CanvasBuffer {
+  constructor(targetCanvas) {
+    this.targetCanvas = targetCanvas;
+    this.bufferCanvas = targetCanvas.cloneNode();
+  }
+
+  /**
+   * @param {object|function} [canvasBufferSize] object containing width and height or a function which returns it
+   */
+  updateSize({ rect, dpiRatio, canvasBufferSize }) {
+    let bufferSize;
+    if (canvasBufferSize) {
+      bufferSize = typeof canvasBufferSize === 'function' ? canvasBufferSize(rect) : canvasBufferSize;
+    } else {
+      bufferSize = {
+        width: rect.computedPhysical.width + DEFAULT_PADDING.horizontal * 2,
+        height: rect.computedPhysical.height + DEFAULT_PADDING.vertical * 2,
+      };
+    }
+
+    this.bufferCanvas.style.width = `${bufferSize.width}px`;
+    this.bufferCanvas.style.height = `${bufferSize.height}px`;
+    this.bufferCanvas.width = Math.round(bufferSize.width * dpiRatio);
+    this.bufferCanvas.height = Math.round(bufferSize.height * dpiRatio);
+  }
+
+  /**
+   * Draws buffer canvas on the target canvas.
+   */
+  apply() {
+    const g = this.targetCanvas.getContext('2d');
+    g.drawImage(this.bufferCanvas, 0, 0);
+  }
+
+  clear() {
+    this.bufferCanvas.width = this.bufferCanvas.width; // eslint-disable-line
+  }
+
+  getContext() {
+    return this.bufferCanvas.getContext('2d');
+  }
+}
+
+export default CanvasBuffer;

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -207,6 +207,7 @@ export function renderer(sceneFn = sceneFactory) {
     const dpiRatio = dpiScale(g);
     const transform = buffer && settings.transform();
     if (transform) {
+      // clear canvas
       el.width = el.width; // eslint-disable-line
       applyTransform({ el, dpiRatio, transform });
       buffer.apply();
@@ -260,6 +261,7 @@ export function renderer(sceneFn = sceneFactory) {
     }
 
     if (buffer) {
+      // clear canvas
       el.width = el.width; // eslint-disable-line
       buffer.apply();
     }

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -114,17 +114,18 @@ function renderShapes(shapes, g, shapeToCanvasMap, deps) {
  * Sets transform on target element.
  * @param {Element} el Target canvas element
  * @param {number} dpiRatio
+ * @param {TransformObject}
  * @private
  */
 function applyTransform({ el, dpiRatio, transform }) {
   if (typeof transform === 'object') {
     const adjustedTransform = [
-      transform.a,
-      transform.b,
-      transform.c,
-      transform.d,
-      transform.e * dpiRatio,
-      transform.f * dpiRatio,
+      transform.horizontalScaling,
+      transform.horizontalSkewing,
+      transform.verticalSkewing,
+      transform.verticalScaling,
+      transform.horizontalMoving * dpiRatio,
+      transform.verticalMoving * dpiRatio,
     ];
     const g = el.getContext('2d');
     g.setTransform(...adjustedTransform);

--- a/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
@@ -21,6 +21,17 @@ describe('dom renderer', () => {
     expect(renderer).to.be.a('function');
   });
 
+  it('should set rendererSettings correctly', () => {
+    const rendererSettings = {
+      transform: () => {},
+      irrelevantSetting: 'irrelevant!',
+    };
+    rend.settings(rendererSettings);
+    expect(rend.settings()).to.eql({
+      transform: rendererSettings.transform,
+    });
+  });
+
   describe('appendTo', () => {
     it('should append root node to element', () => {
       const el = element('div');
@@ -60,6 +71,18 @@ describe('dom renderer', () => {
 
     it('should not render before appending', () => {
       expect(rend.render()).to.equal(false);
+    });
+
+    it('should apply transform if provided', () => {
+      const rendererSettings = {
+        transform: () => ({ a: 1, b: 0, c: 1, d: 0, e: 100, f: 100 }),
+        irrelevantSetting: 'irrelevant!',
+      };
+      rend.settings(rendererSettings);
+      rend.appendTo(element('div'));
+      rend.render();
+      const el = rend.element();
+      expect(el.style.transform).to.equal('matrix(1, 0, 1, 0, 100, 100)');
     });
 
     /*

--- a/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/dom-renderer.js
@@ -8,12 +8,27 @@ export default function renderer(opts = {}) {
   let el;
   let rect = createRendererBox();
   let dNode;
+  const settings = {
+    transform: undefined,
+  };
 
   const dom = create();
 
   dom.element = () => el;
 
   dom.root = () => el;
+
+  dom.settings = (rendererSettings) => {
+    if (rendererSettings) {
+      Object.keys(settings).forEach((key) => {
+        if (rendererSettings[key] !== undefined) {
+          settings[key] = rendererSettings[key];
+        }
+      });
+    }
+
+    return settings;
+  };
 
   dom.appendTo = (element) => {
     if (!el) {
@@ -33,6 +48,14 @@ export default function renderer(opts = {}) {
     if (!el) {
       return false;
     }
+
+    const transformation = typeof settings.transform === 'function' && settings.transform();
+    if (transformation) {
+      const { a, b, c, d, e, f } = transformation;
+      el.style.transform = `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;
+      return true;
+    }
+    el.style.transform = '';
 
     el.style.left = `${rect.computedPhysical.x}px`;
     el.style.top = `${rect.computedPhysical.y}px`;

--- a/packages/picasso.js/src/web/renderer/index.js
+++ b/packages/picasso.js/src/web/renderer/index.js
@@ -23,6 +23,12 @@ function create() {
     root: () => {},
 
     /**
+     * Set or Get renderer settings
+     * @param {object} [settings] Settings for the renderer
+     */
+    settings: () => {},
+
+    /**
      * @param {HTMLElement} element - Element to attach renderer to
      * @returns {HTMLElement} Root element of the renderer
      */

--- a/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
@@ -23,6 +23,17 @@ describe('svg renderer', () => {
     expect(renderer).to.be.a('function');
   });
 
+  it('should set rendererSettings correctly', () => {
+    const rendererSettings = {
+      transform: () => {},
+      irrelevantSetting: 'irrelevant!',
+    };
+    svg.settings(rendererSettings);
+    expect(svg.settings()).to.eql({
+      transform: rendererSettings.transform,
+    });
+  });
+
   describe('appendTo', () => {
     it('should append root node to element', () => {
       const el = element('div');
@@ -61,6 +72,18 @@ describe('svg renderer', () => {
 
     it('should not render before appending', () => {
       expect(svg.render()).to.equal(false);
+    });
+
+    it('should apply transform if provided', () => {
+      const rendererSettings = {
+        transform: () => ({ a: 1, b: 0, c: 1, d: 0, e: 100, f: 100 }),
+        irrelevantSetting: 'irrelevant!',
+      };
+      svg.settings(rendererSettings);
+      svg.appendTo(element('div'));
+      svg.render();
+      const group = svg.root();
+      expect(group.style.transform).to.equal('matrix(1, 0, 1, 0, 100, 100)');
     });
 
     it('should call tree creator with proper params', () => {

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -30,6 +30,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
   let hasChangedRect = false;
   let rect = createRendererBox();
   let scene;
+  const settings = {
+    transform: undefined,
+  };
 
   const svg = create();
 
@@ -43,6 +46,18 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
   svg.element = () => el;
 
   svg.root = () => group;
+
+  svg.settings = (rendererSettings) => {
+    if (rendererSettings) {
+      Object.keys(settings).forEach((key) => {
+        if (rendererSettings[key] !== undefined) {
+          settings[key] = rendererSettings[key];
+        }
+      });
+    }
+
+    return settings;
+  };
 
   svg.appendTo = (element) => {
     if (!el) {
@@ -66,6 +81,14 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     if (!el) {
       return false;
     }
+
+    const transformation = typeof settings.transform === 'function' && settings.transform();
+    if (transformation) {
+      const { a, b, c, d, e, f } = transformation;
+      group.style.transform = `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;
+      return true;
+    }
+    group.style.transform = '';
 
     const scaleX = rect.scaleRatio.x;
     const scaleY = rect.scaleRatio.y;

--- a/packages/test-utils/mocks/canvas-context.js
+++ b/packages/test-utils/mocks/canvas-context.js
@@ -30,6 +30,7 @@ function canvascontext(contextType = '2d') {
     restore: sinon.spy(),
     scale: sinon.spy(),
     rect: sinon.spy(),
+    setTransform: sinon.spy(),
     createPattern: sinon.spy((...args) => new CanvasPattern(...args)),
     measureText: (text) => ({ width: text.length }),
   };


### PR DESCRIPTION
This makes it possible to trigger a "light" rendering of specific components, where only a transform is applied. The reason is to provide smoother rendering performance for charts containing components with a lot of nodes. This approach might be applicable while interacting with a chart where you want to redraw the chart continuously and maintain a responsive feeling.

Here is an example of how it can affect performance (a simple scatterplot with 2000 nodes) where chart rendering time went from 80 ms to 5 ms (the bottom one uses transfoms):
![transfoms](https://user-images.githubusercontent.com/13997395/117020723-feb2e000-acf6-11eb-91f8-5fe23e86f3f5.gif)

#### Example
```js
componentDef: {
  ...,
  rendererSettings: {
    transform: () => ({ a: 1, b: 0, c: 0, d: 1, e: 100, f: 100 }),
    canvasBufferSize: { width: 1000, height: 800 },
  }
};

chart.update({ partialData: true });
```

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
