### PR TITLE
feat: support show as a function for axis line

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-node-builder.js
@@ -214,7 +214,7 @@ export default function nodeBuilder(isDiscrete) {
     const layered = state.labels.activeMode === 'layered';
     let majorTickNodes;
 
-    if (settings.line.show) {
+    if (typeof settings.line.show === 'function' ? settings.line.show() : settings.line.show) {
       buildOpts.style = settings.line;
       buildOpts.padding = settings.paddingStart;
 


### PR DESCRIPTION
This PR is to support show as a function for axis line.
This can help controlling if an axis line should be show or not based on other things. For example when the axis line and the first grid line are almost the same position, they look like a single line with larger thickness, so axis should be not shown in this case. However, when we pan or zoom the chart, e.g. a scatter plot, then the grid line is moved away from the axis line, so the axis line should be shown in this case.
TODO:
Add unit tests.