### PR TITLE
feat: add orientation setting for bar strategy

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -2638,6 +2638,12 @@
                   ],
                   "type": "any"
                 },
+                "orientation": {
+                  "description": "Orientation of text: 'auto', 'horizontal' or 'vertical'",
+                  "optional": true,
+                  "defaultValue": "'auto'",
+                  "type": "string"
+                },
                 "fontFamily": {
                   "optional": true,
                   "defaultValue": "'Arial'",

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -7,6 +7,7 @@ import {
   placeInBars,
   findBestPlacement,
   bars,
+  getOrientation,
 } from '../bars';
 
 function place(position, direction) {
@@ -898,6 +899,23 @@ describe('labeling - bars', () => {
       });
 
       expect(labels).to.be.empty;
+    });
+  });
+
+  describe('orientation', () => {
+    it('should support setting "horizontal"', () => {
+      const orientation = getOrientation({ orientation: 'horizontal', defaultOrientation: 'v' });
+      expect(orientation).to.equal('h');
+    });
+
+    it('should support setting "vertical"', () => {
+      const orientation = getOrientation({ orientation: 'vertical', defaultOrientation: 'h' });
+      expect(orientation).to.equal('v');
+    });
+
+    it('should fallback to default orientation for setting "auto"', () => {
+      expect(getOrientation({ orientation: 'auto', defaultOrientation: 'h' })).to.equal('h');
+      expect(getOrientation({ orientation: 'auto', defaultOrientation: 'v' })).to.equal('v');
     });
   });
 });

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -406,7 +406,7 @@ export function precalculate({ nodes, rect, chart, labelSettings, placementSetti
 }
 
 export function getOrientation({ orientation = 'auto', defaultOrientation = 'h' }) {
-  switch (orientation?.toLocaleLowerCase()) {
+  switch (orientation.toLocaleLowerCase()) {
     case 'vertical':
       return 'v';
     case 'horizontal':

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -405,6 +405,17 @@ export function precalculate({ nodes, rect, chart, labelSettings, placementSetti
   };
 }
 
+export function getOrientation({ orientation = 'auto', defaultOrientation = 'h' }) {
+  switch (orientation.toLocaleLowerCase()) {
+    case 'vertical':
+      return 'v';
+    case 'horizontal':
+      return 'h';
+    default:
+      return defaultOrientation;
+  }
+}
+
 /**
  * @typedef {object} ComponentLabels~BarsLabelStrategy
  * @property {string} type='bar' Name of strategy
@@ -414,6 +425,7 @@ export function precalculate({ nodes, rect, chart, labelSettings, placementSetti
  * Bars strategy settings
  * @typedef {object} ComponentLabels~BarsLabelStrategy.settings
  * @property {string|function} [direction='up'] - The direction in which the bars are growing: 'up', 'down', 'right' or 'left'.
+ * @property {string} [orientation='auto'] - Orientation of text: 'auto', 'horizontal' or 'vertical'
  * @property {string} [fontFamily='Arial']
  * @property {number} [fontSize=12]
  * @property {Array<object>} labels
@@ -469,8 +481,13 @@ export function bars({ settings, chart, nodes, rect, renderer, style }, placer =
     placementSettings,
   });
 
-  const coord = hasHorizontalDirection ? 'y' : 'x';
-  const side = hasHorizontalDirection ? 'height' : 'width';
+  const orientation = getOrientation({
+    orientation: settings.orientation,
+    defaultOrientation: hasHorizontalDirection ? 'h' : 'v',
+  });
+
+  const coord = orientation === 'h' ? 'y' : 'x';
+  const side = orientation === 'h' ? 'height' : 'width';
   targetNodes.sort(
     (a, b) =>
       a.node.localBounds[coord] + a.node.localBounds[side] - (b.node.localBounds[coord] + b.node.localBounds[side])
@@ -482,6 +499,6 @@ export function bars({ settings, chart, nodes, rect, renderer, style }, placer =
     stngs: settings,
     rect,
     fitsHorizontally,
-    collectiveOrientation: hasHorizontalDirection ? 'h' : 'v',
+    collectiveOrientation: orientation,
   });
 }

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -406,7 +406,7 @@ export function precalculate({ nodes, rect, chart, labelSettings, placementSetti
 }
 
 export function getOrientation({ orientation = 'auto', defaultOrientation = 'h' }) {
-  switch (orientation.toLocaleLowerCase()) {
+  switch (orientation?.toLocaleLowerCase()) {
     case 'vertical':
       return 'v';
     case 'horizontal':


### PR DESCRIPTION
Add setting `orientation` to bar strategy for labels. It specifies the orientation of the displayed text. For example, forces horizontal text for a label displayed above a point.

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated
