### PR TITLE
fix: support getting to be rendered nodes for animation purpose

### DIFF
--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -866,6 +866,14 @@ function chartFn(definition, context) {
     return shapes;
   };
 
+  instance.getToBeRenderedNodes = () => {
+    const shapes = [];
+    visibleComponents.forEach((c) => {
+      shapes.push(...c.instance.getToBeRenderedNodes());
+    });
+    return shapes;
+  };
+
   /**
    * Get components overlapping a point.
    * @param {Point} p - Point with x- and y-coordinate. The coordinate is relative to the browser viewport.

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -596,6 +596,8 @@ function componentFactory(definition, context = {}) {
     return shapes;
   };
 
+  fn.getToBeRenderedNodes = () => brushArgs.nodes || [];
+
   fn.findShapes = (selector) => {
     const shapes = rend.findShapes(selector);
     for (let i = 0, num = shapes.length; i < num; i++) {


### PR DESCRIPTION
To support animation a component which depends on other component in term of positioning like a label depending on a point.