### PR TITLE
fix: consider offset when generating axis lines

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-line-node.spec.js
+++ b/packages/picasso.js/src/core/chart-components/axis/__tests__/axis-line-node.spec.js
@@ -14,21 +14,18 @@ describe('Axis Line Node', () => {
     height: 0,
   };
 
-  beforeEach(() => {
-    innerRect.width = 50;
-    innerRect.height = 100;
-    innerRect.x = 0;
-    innerRect.y = 0;
-    outerRect.width = 50;
-    outerRect.height = 100;
-    outerRect.x = 0;
-    outerRect.y = 0;
-  });
-
   describe('Line', () => {
     let buildOpts, expected;
 
     beforeEach(() => {
+      innerRect.width = 50;
+      innerRect.height = 100;
+      innerRect.x = 0;
+      innerRect.y = 0;
+      outerRect.width = 50;
+      outerRect.height = 100;
+      outerRect.x = 0;
+      outerRect.y = 0;
       buildOpts = {
         style: { stroke: 'red', strokeWidth: 1 },
         align: 'bottom',
@@ -80,6 +77,52 @@ describe('Axis Line Node', () => {
       expected.y1 = buildOpts.padding;
       expected.y2 = buildOpts.padding;
       expect(buildLine(buildOpts)).to.deep.equal(expected);
+    });
+
+    describe('Within an offset container', () => {
+      it('Left align', () => {
+        buildOpts.align = 'left';
+        innerRect.y = 125;
+        outerRect.y = 100;
+        expected.x1 = innerRect.width - buildOpts.padding;
+        expected.x2 = innerRect.width - buildOpts.padding;
+        expected.y1 = 25;
+        expected.y2 = 125;
+        expect(buildLine(buildOpts)).to.deep.equal(expected);
+      });
+
+      it('Right align', () => {
+        buildOpts.align = 'right';
+        innerRect.y = 125;
+        outerRect.y = 100;
+        expected.x1 = buildOpts.padding;
+        expected.x2 = buildOpts.padding;
+        expected.y1 = 25;
+        expected.y2 = 125;
+        expect(buildLine(buildOpts)).to.deep.equal(expected);
+      });
+
+      it('Top align', () => {
+        buildOpts.align = 'top';
+        innerRect.x = 125;
+        outerRect.x = 100;
+        expected.x1 = 25;
+        expected.x2 = 75;
+        expected.y1 = innerRect.height - buildOpts.padding;
+        expected.y2 = innerRect.height - buildOpts.padding;
+        expect(buildLine(buildOpts)).to.deep.equal(expected);
+      });
+
+      it('Bottom align', () => {
+        buildOpts.align = 'bottom';
+        innerRect.x = 125;
+        outerRect.x = 100;
+        expected.x1 = 25;
+        expected.x2 = 75;
+        expected.y1 = buildOpts.padding;
+        expected.y2 = buildOpts.padding;
+        expect(buildLine(buildOpts)).to.deep.equal(expected);
+      });
     });
   });
 });

--- a/packages/picasso.js/src/core/chart-components/axis/axis-line-node.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-line-node.js
@@ -18,14 +18,14 @@ export default function buildLine(buildOpts) {
 
   if (buildOpts.align === 'top' || buildOpts.align === 'bottom') {
     struct.x1 = buildOpts.innerRect.x - buildOpts.outerRect.x;
-    struct.x2 = buildOpts.innerRect.width + buildOpts.innerRect.x;
+    struct.x2 = struct.x1 + buildOpts.innerRect.width;
     struct.y1 = struct.y2 =
       buildOpts.align === 'top' ? buildOpts.innerRect.height - buildOpts.padding : buildOpts.padding;
   } else {
     struct.x1 = struct.x2 =
       buildOpts.align === 'left' ? buildOpts.innerRect.width - buildOpts.padding : buildOpts.padding;
     struct.y1 = buildOpts.innerRect.y - buildOpts.outerRect.y;
-    struct.y2 = buildOpts.innerRect.height + buildOpts.innerRect.y;
+    struct.y2 = struct.y1 + buildOpts.innerRect.height;
   }
 
   appendStyle(struct, buildOpts);


### PR DESCRIPTION
Addresses an issue where axis lines were generated without taking "offset" into consideration. This was discovered when rendering a chart using the container component, see attached image.

<img width="867" alt="axis-line" src="https://user-images.githubusercontent.com/13997395/137134334-59059435-8cd3-4ded-b9f2-d62684f03824.png">

**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated - **N/A**
