### PR TITLE
fix: use correct scene nodes during animation

### DIFF
--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -597,7 +597,7 @@ function componentFactory(definition, context = {}) {
   };
 
   fn.findShapes = (selector) => {
-    const shapes = rend.findShapes(selector);
+    const shapes = (currentTween?.inProgress() ? currentTween.targetScene : rend).findShapes(selector);
     for (let i = 0, num = shapes.length; i < num; i++) {
       appendComponentMeta(shapes[i]);
     }

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -22,6 +22,7 @@ function tween({ old, current }, { renderer }, config) {
   let exited = { nodes: [], ips: [] };
   let updated = { nodes: [], ips: [] };
   let stages = [];
+  let targetScene = null;
   const trackBy = config.trackBy || nodeId;
 
   const tweener = {
@@ -83,6 +84,7 @@ function tween({ old, current }, { renderer }, config) {
       }
       // console.log(stages);
       if (stages.length) {
+        targetScene = renderer.getScene(current);
         stages[0].started = Date.now();
         if (typeof window !== 'undefined') {
           ticker = window.requestAnimationFrame(tweener.tick);
@@ -121,6 +123,12 @@ function tween({ old, current }, { renderer }, config) {
         window.cancelAnimationFrame(ticker);
         ticker = false;
       }
+    },
+    inProgress() {
+      return !!ticker;
+    },
+    get targetScene() {
+      return targetScene;
     },
   };
 

--- a/packages/picasso.js/src/web/renderer/index.js
+++ b/packages/picasso.js/src/web/renderer/index.js
@@ -35,6 +35,15 @@ function create() {
     appendTo: () => {},
 
     /**
+     * Get Scene based on provided nodes, constructed in the same way as in the render function.
+     * Only the canvas and svg renderer uses scene nodes.
+     * @private
+     * @param {object[]} nodes - Nodes on which the scene will be constructed
+     * @returns {Scene}
+     */
+    getScene: () => [],
+
+    /**
      * @param {object[]} nodes - Nodes to render
      * @returns {boolean} True if the nodes were rendered, otherwise false
      */

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -77,32 +77,9 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
     return el;
   };
 
-  svg.render = (nodes) => {
-    if (!el) {
-      return false;
-    }
-
-    const transformation = typeof settings.transform === 'function' && settings.transform();
-    if (transformation) {
-      const { a, b, c, d, e, f } = transformation;
-      group.style.transform = `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;
-      return true;
-    }
-    group.style.transform = '';
-
+  svg.getScene = (nodes) => {
     const scaleX = rect.scaleRatio.x;
     const scaleY = rect.scaleRatio.y;
-
-    if (hasChangedRect) {
-      el.style.left = `${rect.computedPhysical.x}px`;
-      el.style.top = `${rect.computedPhysical.y}px`;
-      el.setAttribute('width', rect.computedPhysical.width);
-      el.setAttribute('height', rect.computedPhysical.height);
-    }
-
-    gradients.clear();
-    patterns.clear();
-    defs.children.length = 0;
 
     const sceneContainer = {
       type: 'container',
@@ -116,7 +93,7 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
       sceneContainer.transform += `scale(${scaleX}, ${scaleY})`;
     }
 
-    const newScene = sceneFn({
+    return sceneFn({
       items: [sceneContainer],
       on: {
         create: [
@@ -131,6 +108,34 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
         ],
       },
     });
+  };
+
+  svg.render = (nodes) => {
+    if (!el) {
+      return false;
+    }
+
+    const transformation = typeof settings.transform === 'function' && settings.transform();
+    if (transformation) {
+      const { a, b, c, d, e, f } = transformation;
+      group.style.transform = `matrix(${a}, ${b}, ${c}, ${d}, ${e}, ${f})`;
+      return true;
+    }
+    group.style.transform = '';
+
+    if (hasChangedRect) {
+      el.style.left = `${rect.computedPhysical.x}px`;
+      el.style.top = `${rect.computedPhysical.y}px`;
+      el.setAttribute('width', rect.computedPhysical.width);
+      el.setAttribute('height', rect.computedPhysical.height);
+    }
+
+    gradients.clear();
+    patterns.clear();
+    defs.children.length = 0;
+
+    const newScene = svg.getScene(nodes);
+
     const hasChangedScene = scene ? !newScene.equals(scene) : true;
 
     const doRender = hasChangedRect || hasChangedScene;


### PR DESCRIPTION
Makes sure the `findShapes` function (used in some component implementations) returns the "final"/"target" scene nodes from a component when an animation is in progress.

The tween now starts by building the final scene and exposing that (available from svg and canvas renderer).

**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] ~~documentation updated~~ - **N/A**
