### PR TITLE
fix: node version dependent sorting

### DIFF
--- a/packages/picasso.js/src/core/layout/dock/docker.js
+++ b/packages/picasso.js/src/core/layout/dock/docker.js
@@ -225,6 +225,9 @@ function positionComponents({ visible, layoutRect, reducedRect, containerRect, t
   const elementOrder = referenceArray.slice().sort((a, b) => a.config.displayOrder() - b.config.displayOrder());
   visible
     .sort((a, b) => {
+      if (a.referencedDocks.length > 0 && b.referencedDocks.length > 0) {
+        return 0;
+      }
       if (b.referencedDocks.length > 0) {
         return -1;
       }


### PR DESCRIPTION
**Checklist**

- [ ] tests added (not relevant)
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated (not relevant)

## Description
From Node11, the arguments passed to the compare function of `Array.sort()` are reversed. 
(See: https://github.com/nodejs/node/issues/24294)
Therefore the code inside the compare function should be made independent of the arguments order, so that it is independent of the node version.