### PR TITLE
fix(transformation): update renderer settings after a component has changed

### DIFF
--- a/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/chart.spec.js
@@ -270,7 +270,9 @@ describe('Chart', () => {
       );
 
       expect(mockedRenderer.render).to.have.been.calledTwice;
+      mockedRenderer.settings = sinon.spy();
       chartInstance.update({ partialData: true });
+      expect(mockedRenderer.settings).to.have.been.calledOnce;
       const renderArgs = mockedRenderer.render.args;
       // no nodes are passed into renderers render function when applying transform!
       expect(renderArgs).to.eql([[['boxNode1']], [['pointNode1']], [['boxNode1']], []]);

--- a/packages/picasso.js/src/core/chart/__tests__/component-collection.spec.js
+++ b/packages/picasso.js/src/core/chart/__tests__/component-collection.spec.js
@@ -2,6 +2,12 @@ import componentCollectionFn from '../component-collection';
 
 function createComponent(settings) {
   let rect;
+  const rend = {
+    settings() {
+      this.myRendererSettings = 'new settings';
+    },
+    myRendererSettings: 'old settings',
+  };
   return {
     instance: {
       type: settings.type,
@@ -10,6 +16,7 @@ function createComponent(settings) {
         rect = r;
       },
       getRect: () => rect,
+      renderer: () => rend,
     },
     settings,
     key: settings.key,
@@ -96,6 +103,7 @@ describe('component-collection', () => {
 
       expect(comp1.applyTransform).to.be.undefined;
       expect(comp2.applyTransform).to.be.true;
+      expect(comp2.instance.renderer().myRendererSettings).to.equal('new settings');
     });
   });
 });

--- a/packages/picasso.js/src/core/chart/component-collection.js
+++ b/packages/picasso.js/src/core/chart/component-collection.js
@@ -113,6 +113,7 @@ function collectionFn({ createComponent }) {
           comp.rendererSettings.transform()
         ) {
           component.applyTransform = true;
+          component.instance.renderer().settings(comp.rendererSettings);
           return component;
         }
 

--- a/packages/picasso.js/test/helpers/component-factory-fixture.js
+++ b/packages/picasso.js/test/helpers/component-factory-fixture.js
@@ -92,6 +92,7 @@ export default function componentFactoryFixture() {
       clear: () => {},
       destroy: () => {},
       setKey: (key) => rendererElement.setAttribute('data-key', key),
+      settings: () => {},
     };
 
     mediatorMock = {


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [not relevant] documentation updated

## Summary
Currently the renderer settings (for example, for canvas renderer: https://github.com/veinfors/picasso.js/blob/bb628a6b981c62109c68982273882986dbb00a67/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js#L169) are only updated when a component is created. It means when a component changes (due to for example a range selection), the renderer settings, especially the transform function, is oudated. This PR is to fix that issue.

## Verification 
Before fix:

https://user-images.githubusercontent.com/70384379/141995711-b05766df-4d19-4443-93cc-def085bcf26a.mov


After fix:

https://user-images.githubusercontent.com/70384379/141995541-34064bd5-3f0c-487a-ac78-1a52537fc5b0.mov



