### PR TITLE
fix: support SI abbreviation only when format is auto or type is 'U'

### DIFF
--- a/plugins/q/src/data/__tests__/field.spec.js
+++ b/plugins/q/src/data/__tests__/field.spec.js
@@ -11,8 +11,7 @@ describe('q-field', () => {
         qTags: ['a', 'b'],
         qFallbackTitle: 'TITLE',
         qNumFormat: {
-          qType: 'M',
-          qFmt: '$#-###A',
+          qType: 'U',
         },
       },
       type,
@@ -20,8 +19,7 @@ describe('q-field', () => {
       cube: { qMode: mode || 'S' },
       fieldExtractor: fe,
       localeInfo: {
-        qThousandSep: '-',
-        qNumericalAbbreviation: '3:x',
+        qDecimalSep: '-',
       },
     };
   }
@@ -114,7 +112,7 @@ describe('q-field', () => {
     it('should take localeInfo into account when formatting', () => {
       let f = mField();
       const form = f.formatter();
-      expect(form(3000000)).to.eql('$3-000x');
+      expect(form(3.123)).to.eql('3-12');
     });
 
     it('should have a default reducer of "avg" for a measure', () => {

--- a/plugins/q/src/formatter/__tests__/formatter.spec.js
+++ b/plugins/q/src/formatter/__tests__/formatter.spec.js
@@ -39,14 +39,14 @@ const qLocaleInfo = {
 describe('qs-formatter', () => {
   it('should create a numeric formatter by default', () => {
     const f = createFromMetaInfo();
-    expect(f.pattern()).to.equal('#.##A');
+    expect(f.pattern()).to.equal('#.##');
   });
   it('should create an abbreviation formatter when qIsAutoFormat=true', () => {
     const f = createFromMetaInfo({
       qIsAutoFormat: true,
       qNumFormat: {},
     });
-    expect(f.pattern()).to.equal('#.##A');
+    expect(f.pattern()).to.equal('#.##');
   });
   it('should create an abbreviation formatter when qNumFormat.qType=U', () => {
     const f = createFromMetaInfo({
@@ -55,7 +55,7 @@ describe('qs-formatter', () => {
         qType: 'U',
       },
     });
-    expect(f.pattern()).to.equal('#.##A');
+    expect(f.pattern()).to.equal('#.##');
   });
 
   it('should not create an abbreviation formatter when qType="M"', () => {
@@ -78,7 +78,7 @@ describe('qs-formatter', () => {
         qDecimalSep: 'dec',
       }
     );
-    expect(f.pattern()).to.equal('#dec##A');
+    expect(f.pattern()).to.equal('#dec##');
   });
 
   it('should create locale specific date pattern', () => {

--- a/plugins/q/src/formatter/__tests__/numberFormat.spec.js
+++ b/plugins/q/src/formatter/__tests__/numberFormat.spec.js
@@ -264,47 +264,6 @@ describe('numberFormat', () => {
           expect(f(123456789)).to.equal('1-2345-6789');
         });
 
-        it('should support SI abbreviations', () => {
-          f = formatter('#,###.0A', ',');
-
-          expect(f(0)).to.equal('0.0');
-          expect(f(1)).to.equal('1.0');
-          expect(f(100)).to.equal('100.0');
-          expect(f(1000)).to.equal('1.0k');
-          expect(f(100000)).to.equal('100.0k');
-          expect(f(10000000)).to.equal('10.0M');
-
-          f = formatter('#.###A');
-
-          expect(f(1234567, '#.###A')).to.equal('1.235M');
-
-          f = formatter('#.#A');
-
-          expect(f(0.0001)).to.equal('0.1m');
-        });
-
-        it('should support custom abbreviations', () => {
-          let localeInfo = {
-            qNumericalAbbreviation: '-6:u;-3:x;2:h;6:test',
-          };
-          f = formatter('#,###.0A', ',', '', '', localeInfo);
-
-          expect(f(0)).to.equal('0.0');
-          expect(f(1)).to.equal('1.0');
-          expect(f(10000000)).to.equal('10.0test');
-          expect(f(100)).to.equal('1.0h');
-          expect(f(100000)).to.equal('1,000.0h');
-
-          f = formatter('#.###A', ',', '', '', localeInfo);
-          expect(f(1234567, '#.###A')).to.equal('1.235test');
-
-          f = formatter('#.#A', ',', '', '', localeInfo);
-          expect(f(0.0001, '#.#A')).to.equal('0.1x');
-          expect(f(0.00001, '#.#A')).to.equal('10u');
-          expect(f(0.0000001, '#.#A')).to.equal('0.1u');
-          expect(f(1005)).to.equal('10.1h');
-        });
-
         it('should support percentage', () => {
           f = formatter('0.0%');
 
@@ -491,7 +450,6 @@ describe('numberFormat', () => {
             expect(f.format('#.###,###', 123456789.987, '.', ',')).to.equal('123.456.789,987');
             expect(f.format('#.00', 0.1234)).to.equal('0.12');
             expect(f.format('#,###.00', 10000000, ',', '.')).to.equal('10,000,000.00');
-            expect(f.format('#,###.0A', 1000, ',')).to.equal('1.0k');
             expect(f.format('0.0%', 0.275)).to.equal('27.5%');
             expect(f.format('foo0.0bar', 1.234)).to.equal('foo1.2bar');
             expect(f.format('0.0;(0.0)', 1.234)).to.equal('1.2');
@@ -561,7 +519,6 @@ describe('numberFormat', () => {
             expect(f.format('#.###,###', 123456789.987, '.', ',')).to.equal('123.456.789,987');
             expect(f.format('#.00', 0.1234)).to.equal('0.12');
             expect(f.format('#,###.00', 10000000, ',', '.')).to.equal('10,000,000.00');
-            expect(f.format('#,###.0A', 1000, ',')).to.equal('1.0k');
             expect(f.format('0.0%', 0.275)).to.equal('27.5%');
             expect(f.format('foo0.0bar', 1.234)).to.equal('foo1.2bar');
             expect(f.format('0.0;(0.0)', 1.234)).to.equal('1.2');

--- a/plugins/q/src/formatter/index.js
+++ b/plugins/q/src/formatter/index.js
@@ -23,7 +23,7 @@ export function createFromMetaInfo(meta, localeInfo) {
   }
 
   if (isAuto || type === 'U') {
-    pattern = `#${decimal}##A`;
+    pattern = `#${decimal}##`;
     type = 'U';
   }
 

--- a/plugins/q/src/formatter/parts/qs-number-formatter.js
+++ b/plugins/q/src/formatter/parts/qs-number-formatter.js
@@ -514,7 +514,6 @@ class NumberFormatter {
       }
 
       value = value.replace(prep.numericRegex, (m) => {
-        console.log(m);
         if (m === t) {
           return prep.groupTemp;
         }

--- a/plugins/q/src/formatter/parts/qs-number-formatter.js
+++ b/plugins/q/src/formatter/parts/qs-number-formatter.js
@@ -145,16 +145,7 @@ function getAbbreviations(localeInfo, listSeparator) {
   return abbreviations;
 }
 
-function isSIAbbreviation(pattern, t, d) {
-  if (pattern.indexOf('A') === -1) {
-    return false;
-  }
-  const validFormatCodeCharacters = [t, d, '#', '0', '$', ' ']; // The last character is a non-breaking space, not a normal space
-  const formatCode = pattern.substring(0, pattern.indexOf('A'));
-  return [...formatCode].every((c) => validFormatCodeCharacters.includes(c));
-}
-
-function preparePattern(o, t, d) {
+function preparePattern(o, t, d, abbreviate) {
   let parts,
     lastPart,
     pattern = o.pattern,
@@ -166,9 +157,7 @@ function preparePattern(o, t, d) {
     temp,
     regex;
 
-  if (isSIAbbreviation(pattern, t, d)) {
-    // abbreviate SI
-    pattern = pattern.replace('A', '');
+  if (abbreviate) {
     o.abbreviate = true;
   }
 
@@ -284,9 +273,6 @@ class NumberFormatter {
    * format(10.123, "0.00##") // 10.123; // at least 2 decimals, never more than 4
    * format(123456789, "#,###") // 123,456,789;
    * format(123456789, "####-####", "-") // 1-2345-6789;
-   * format(10000, "#A") // 10k,  A -> SI abbreviation
-   * format(1234567, "#.###A") // 1.235M;
-   * format(0.0001, "#.#A") // 0.1m;
    *
    * format(0.257, "0.0%") // 25.7%; // will multiply by 100
    * format(9876, "$#,###") // $9,876;
@@ -366,14 +352,15 @@ class NumberFormatter {
       prep.zero.isFunctional = true;
     }
 
+    const abbreviate = this.type === 'U';
     if (!prep.positive.isFunctional) {
-      preparePattern(prep.positive, t, d);
+      preparePattern(prep.positive, t, d, abbreviate);
     }
     if (prep.negative && !prep.negative.isFunctional) {
-      preparePattern(prep.negative, t, d);
+      preparePattern(prep.negative, t, d, abbreviate);
     }
     if (prep.zero && !prep.zero.isFunctional) {
-      preparePattern(prep.zero, t, d);
+      preparePattern(prep.zero, t, d, abbreviate);
     }
   }
 
@@ -527,6 +514,7 @@ class NumberFormatter {
       }
 
       value = value.replace(prep.numericRegex, (m) => {
+        console.log(m);
         if (m === t) {
           return prep.groupTemp;
         }

--- a/plugins/q/src/formatter/parts/qs-number-formatter.js
+++ b/plugins/q/src/formatter/parts/qs-number-formatter.js
@@ -145,11 +145,11 @@ function getAbbreviations(localeInfo, listSeparator) {
   return abbreviations;
 }
 
-function isSIAbbreviation(pattern) {
+function isSIAbbreviation(pattern, t, d) {
   if (pattern.indexOf('A') === -1) {
     return false;
   }
-  const validFormatCodeCharacters = ['#', '0', ' ']; // The last character is a non-breaking space, not a normal space
+  const validFormatCodeCharacters = [t, d, '#', '0', '$', ' ']; // The last character is a non-breaking space, not a normal space
   const formatCode = pattern.substring(0, pattern.indexOf('A'));
   return [...formatCode].every((c) => validFormatCodeCharacters.includes(c));
 }
@@ -166,7 +166,7 @@ function preparePattern(o, t, d) {
     temp,
     regex;
 
-  if (isSIAbbreviation(pattern)) {
+  if (isSIAbbreviation(pattern, t, d)) {
     // abbreviate SI
     pattern = pattern.replace('A', '');
     o.abbreviate = true;

--- a/plugins/q/src/formatter/parts/qs-number-formatter.js
+++ b/plugins/q/src/formatter/parts/qs-number-formatter.js
@@ -145,6 +145,15 @@ function getAbbreviations(localeInfo, listSeparator) {
   return abbreviations;
 }
 
+function isSIAbbreviation(pattern) {
+  if (pattern.indexOf('A') === -1) {
+    return false;
+  }
+  const validFormatCodeCharacters = ['#', '0', ' ']; // The last character is a non-breaking space, not a normal space
+  const formatCode = pattern.substring(0, pattern.indexOf('A'));
+  return [...formatCode].every((c) => validFormatCodeCharacters.includes(c));
+}
+
 function preparePattern(o, t, d) {
   let parts,
     lastPart,
@@ -157,7 +166,7 @@ function preparePattern(o, t, d) {
     temp,
     regex;
 
-  if (pattern.indexOf('A') >= 0) {
+  if (isSIAbbreviation(pattern)) {
     // abbreviate SI
     pattern = pattern.replace('A', '');
     o.abbreviate = true;


### PR DESCRIPTION
## Description (update below)
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

To fix https://jira.qlikdev.com/browse/QB-6534

Currently, any 'A' character in the format expression will force the number to adopt SI abbreviation. This seems to be an overkill. 

To give customers more freedom to use character 'A', we can restrict the SI abbreviation syntax: only when 'A' is right after format code, which uses either '#', '0', or non-breaking space. This restricted syntax is in accordance with what has been planned for the SI abbreviation syntax, see in the same file at:
https://github.com/qlik-oss/picasso.js/blob/02620ff4f8e3c89e14539bc2387c0524599322a8/plugins/q/src/formatter/parts/qs-number-formatter.js#L278