### PR TITLE
chore(picasso.js): upgrade @scriptappy/to-dts and include type defs in published pkg

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "build": "yarn run spec",
     "spec": "jsdoc -r ../packages/picasso.js/src -p ../packages/picasso.js/package.json -X | scriptappy-from-jsdoc -c ./scriptappy.config.js",
-    "ts": "sy to-dts --export default --exportConst pjs -o ../packages/picasso.js/types/index.d.ts",
+    "ts": "sy to-dts --export default -o ../packages/picasso.js/types/index.d.ts",
     "version": "yarn run spec && yarn run ts && git add scriptappy.json ../packages/picasso.js/types/index.d.ts"
   },
   "devDependencies": {
     "@scriptappy/cli": "0.0.1",
-    "@scriptappy/to-dts": "1.0.0-beta.3",
+    "@scriptappy/to-dts": "1.0.0-beta.4",
     "jsdoc": "3.6.7",
     "scriptappy-from-jsdoc": "0.7.0"
   }

--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "/dist",
-    "/src"
+    "/src",
+    "/types/index.d.ts"
   ],
   "main": "dist/picasso.js",
   "module": "dist/picasso.esm.js",

--- a/packages/picasso.js/types/index.d.ts
+++ b/packages/picasso.js/types/index.d.ts
@@ -1,37 +1,70 @@
 // File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.
-declare const pjs: picassojs;
+export default picassojs;
 
-export default pjs;
+/**
+ * picasso.js entry point
+ * @param cfg
+ */
+declare function picassojs(cfg?: {
+    renderer?: {
+        prio: string[];
+    };
+    logger?: {
+        level: 0 | 1 | 2 | 3 | 4;
+    };
+    style?: object;
+    palettes?: object[];
+}): typeof picassojs;
 
-declare type picassojs = {
-    (cfg?: {
-        renderer?: {
-            prio: string[];
-        };
-        logger?: {
-            level: 0 | 1 | 2 | 3 | 4;
-        };
-        style?: object;
-        palettes?: object[];
-    }): picassojs;
+declare namespace picassojs {
     /**
      * @param definition
      */
-    chart(definition: picassojs.ChartDefinition): picassojs.Chart;
-    component: picassojs.registry;
-    data: picassojs.registry;
-    formatter: picassojs.registry;
-    interaction: picassojs.registry;
-    renderer: picassojs.registry;
-    scale: picassojs.registry;
+    function chart(definition: picassojs.ChartDefinition): picassojs.Chart;
+
+    /**
+     * Component registry
+     */
+    const component: picassojs.registry;
+
+    /**
+     * Data registry
+     */
+    const data: picassojs.registry;
+
+    /**
+     * Formatter registry
+     */
+    const formatter: picassojs.registry;
+
+    /**
+     * Interaction registry
+     */
+    const interaction: picassojs.registry;
+
+    /**
+     * Renderer registry
+     */
+    const renderer: picassojs.registry;
+
+    /**
+     * Scale registry
+     */
+    const scale: picassojs.registry;
+
     /**
      * Plugin registry
      * @param plugin
      * @param options
      */
-    use(plugin: picassojs.plugin, options?: object): void;
-    version: string;
-};
+    function use(plugin: picassojs.plugin, options?: object): void;
+
+    /**
+     * picasso.js version
+     */
+    const version: string;
+
+}
 
 declare namespace picassojs {
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,12 +3209,13 @@
   resolved "https://registry.yarnpkg.com/@scriptappy/schema/-/schema-1.1.0.tgz#ad3ddffb81ed0e3ffdbfb9e86ef575f3feb0429e"
   integrity sha512-HiiW0niupVqK3qbIyWyMLIQoyjCjAzl2DqwSdWap6Cm97xN3XqW2wDKMIzsGCeSYCjaMY+dGaRK2ENSMW2mdlA==
 
-"@scriptappy/to-dts@1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@scriptappy/to-dts/-/to-dts-1.0.0-beta.3.tgz#92c4b2ed77796a2715a57485df15361a7bb7edbe"
-  integrity sha512-tv4QZ+eEPqt7vwvn1BOFHyiTSKyHwqeD38/zrY53Ojj7U/wiLaUnzKBLqwdYV2w/kTxenlfzkvgyifA8Ezd0Dg==
+"@scriptappy/to-dts@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@scriptappy/to-dts/-/to-dts-1.0.0-beta.4.tgz#0b366a62022f87a17b1abde1964656df8a121a56"
+  integrity sha512-YbaoUzQrwxePOFCqVtlbrdsmrP4u5haBp5seHEw5WdrZx/jEALeEenw63xLkLQmUfTPLZ+R8rRSZFyvFb7z8SQ==
   dependencies:
     dts-dom "^3.1.0"
+    extend "3.0.2"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.8.1"


### PR DESCRIPTION
## Overview

Upgrade `@scriptappy/to-dts` to 1.0.0-beta.4 and generate typescript definitions.

Add type definitions to list of files to include when publishing package.

**Checklist**

- [ ] ~~tests added~~ *NOT APPLICABLE*
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] ~~documentation updated~~ *NOT APPLICABLE*
