### PR TITLE
feat: add sortNodes function in brush config

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4219,6 +4219,11 @@
               "items": {
                 "type": "#/definitions/BrushConsumeSettings"
               }
+            },
+            "sortNodes": {
+              "description": "Optional sorting nodes function. Return sorted nodes.",
+              "optional": true,
+              "type": "function"
             }
           }
         },

--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4221,7 +4221,7 @@
               }
             },
             "sortNodes": {
-              "description": "Optional sorting nodes function. Return sorted nodes.",
+              "description": "Sorting function for nodes. Should return sorted nodes.",
               "optional": true,
               "type": "function"
             }

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -99,7 +99,7 @@ import componentCollectionFn from './component-collection';
  * @property {object} [brush] Brush settings
  * @property {BrushTriggerSettings[]} [brush.trigger] Trigger settings
  * @property {BrushConsumeSettings[]} [brush.consume] Consume settings
- * @property {function} [brush.sortNodes] Optional sorting nodes function. Return sorted nodes.
+ * @property {function} [brush.sortNodes] Sorting function for nodes. Should return sorted nodes.
  * @property {object} [layout] Layout settings
  * @property {number} [layout.displayOrder = 0]
  * @property {number} [layout.prioOrder = 0]

--- a/packages/picasso.js/src/core/chart/index.js
+++ b/packages/picasso.js/src/core/chart/index.js
@@ -99,6 +99,7 @@ import componentCollectionFn from './component-collection';
  * @property {object} [brush] Brush settings
  * @property {BrushTriggerSettings[]} [brush.trigger] Trigger settings
  * @property {BrushConsumeSettings[]} [brush.consume] Consume settings
+ * @property {function} [brush.sortNodes] Optional sorting nodes function. Return sorted nodes.
  * @property {object} [layout] Layout settings
  * @property {number} [layout.displayOrder = 0]
  * @property {number} [layout.prioOrder = 0]

--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -374,6 +374,15 @@ describe('Brushing', () => {
       expect(output[1].fill).to.equal('yellow');
     });
 
+    it('update should apply sorting', () => {
+      dummyComponent.config.sortNodes = sinon.stub();
+      styler(dummyComponent, consume);
+      brusherStub.trigger('start');
+      brusherStub.trigger('update');
+
+      expect(dummyComponent.config.sortNodes).to.have.been.calledWith(dummyComponent);
+    });
+
     it('update should apply styling values only to shape nodes', () => {
       nodes.push({
         type: 'container',

--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -245,6 +245,7 @@ describe('Brushing', () => {
         renderer: {
           render: sinon.spy(),
         },
+        config: {},
       };
 
       brusherStub = {

--- a/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/brushing.spec.js
@@ -374,13 +374,18 @@ describe('Brushing', () => {
       expect(output[1].fill).to.equal('yellow');
     });
 
-    it('update should apply sorting', () => {
-      dummyComponent.config.sortNodes = sinon.stub();
+    it('update should apply sorting nodes', () => {
+      dummyComponent.config.sortNodes = sinon.stub().returns(nodes);
       styler(dummyComponent, consume);
       brusherStub.trigger('start');
       brusherStub.trigger('update');
 
+      const output = dummyComponent.renderer.render.args[0][0];
       expect(dummyComponent.config.sortNodes).to.have.been.calledWith(dummyComponent);
+      expect(output[0].stroke).to.equal('pink'); // Inactive
+      expect(output[0].fill).to.equal('inactiveFill');
+      expect(output[1].stroke).to.equal('activeStroke'); // Active
+      expect(output[1].fill).to.equal('yellow');
     });
 
     it('update should apply styling values only to shape nodes', () => {

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -141,7 +141,17 @@ export function styler(obj, { context, data, style, filter, mode }) {
   const onUpdate = () => {
     const changed = update();
     if (changed) {
-      obj.renderer.render(obj.nodes);
+      if (obj.config.sortNode) {
+        const activeOpactiy = active?.opacity || 1;
+        const activeArray = obj.nodes.filter((node) => node.opacity === activeOpactiy);
+        const inactiveArray = obj.nodes.filter((node) => node.opacity !== activeOpactiy);
+        activeNodes.sort((node1, node2) => node2.r - node1.r);
+        inactiveArray.sort((node1, node2) => node2.r - node1.r);
+        const sortedNodes = inactiveArray.concat(activeArray);
+        obj.renderer.render(sortedNodes);
+      } else {
+        obj.renderer.render(obj.nodes);
+      }
     }
   };
 

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -142,7 +142,7 @@ export function styler(obj, { context, data, style, filter, mode }) {
     const changed = update();
     if (changed) {
       if (typeof obj.config.sortNodes === 'function') {
-        obj.config.sortNodes(obj);
+        obj.renderer.render(obj.config.sortNodes(obj));
       } else {
         obj.renderer.render(obj.nodes);
       }

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -141,14 +141,8 @@ export function styler(obj, { context, data, style, filter, mode }) {
   const onUpdate = () => {
     const changed = update();
     if (changed) {
-      if (obj.config.sortNode) {
-        const activeOpactiy = active?.opacity || 1;
-        const activeArray = obj.nodes.filter((node) => node.opacity === activeOpactiy);
-        const inactiveArray = obj.nodes.filter((node) => node.opacity !== activeOpactiy);
-        activeNodes.sort((node1, node2) => node2.r - node1.r);
-        inactiveArray.sort((node1, node2) => node2.r - node1.r);
-        const sortedNodes = inactiveArray.concat(activeArray);
-        obj.renderer.render(sortedNodes);
+      if (typeof obj.config.sortNodes === 'function') {
+        obj.config.sortNodes(obj);
       } else {
         obj.renderer.render(obj.nodes);
       }


### PR DESCRIPTION
Add a  function called `sortNodes` in brush config.

```
{
    consume: [
      {
        data,
        context: 'selection',
        mode: 'and',
        style: {
          inactive: {},
          active: {},
        },
      },
    ],
    sortNodes: (obj) => {
      return sortedNodes;
    },
  };
```
