### PR TITLE
fix: same key issue when extract data

### DIFF
--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -267,7 +267,7 @@ function getHierarchyForSMode(dataset) {
     let isNew = false;
     for (let c = 0; c < dimensions.length; c++) {
       const cell = row[dimensions[c]];
-      const key = `${id}__${cell.qText}__${cell.qElemNumber}`;
+      const key = `${id}__${cell.qElemNumber ?? cell.qElemNo}`;
       if (!keys[key]) {
         keys[key] = {
           __id: key,

--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -267,7 +267,7 @@ function getHierarchyForSMode(dataset) {
     let isNew = false;
     for (let c = 0; c < dimensions.length; c++) {
       const cell = row[dimensions[c]];
-      const key = `${id}__${cell.qText}`;
+      const key = `${id}__${cell.qText}__${cell.qNum}`;
       if (!keys[key]) {
         keys[key] = {
           __id: key,

--- a/plugins/q/src/data/extractor-t.js
+++ b/plugins/q/src/data/extractor-t.js
@@ -267,7 +267,7 @@ function getHierarchyForSMode(dataset) {
     let isNew = false;
     for (let c = 0; c < dimensions.length; c++) {
       const cell = row[dimensions[c]];
-      const key = `${id}__${cell.qText}__${cell.qNum}`;
+      const key = `${id}__${cell.qText}__${cell.qElemNumber}`;
       if (!keys[key]) {
         keys[key] = {
           __id: key,


### PR DESCRIPTION
Fix data not showing in two dimensional grouped bar chart when data has same qText.

The issue

![Screenshot 2022-08-08 at 15 44 15](https://user-images.githubusercontent.com/25456307/183432845-6589f54d-1238-4852-8aef-d99fd26d8e80.png)

After fixing showing in nebula

![Screenshot 2022-08-08 at 15 45 58](https://user-images.githubusercontent.com/25456307/183432986-ef112d82-9401-4ac1-b51b-549f191cac7e.png)


**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
