### PR TITLE
chore: update azures-pipline-image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,8 @@ pr:
   - master
 
 pool:
-  # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2017-Server2016-Readme.md
-  vmImage: 'vs2017-win2016'
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software
+  vmImage: 'windows-2022'
 
 steps:
   - bash: |


### PR DESCRIPTION
the old image was removed June 30, 2022

**Checklist**

- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
