### PR TITLE
feat: progressive rendering

### DIFF
--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -144,6 +144,7 @@ export function renderer(sceneFn = sceneFactory) {
   const settings = {
     transform: undefined,
     canvasBufferSize: undefined,
+    progressive: undefined,
   };
   let scene;
   let hasChangedRect = false;
@@ -264,7 +265,9 @@ export function renderer(sceneFn = sceneFactory) {
 
     const doRender = hasChangedRect || hasChangedScene;
     if (doRender) {
-      canvasRenderer.clear();
+      if (typeof settings.progressive !== 'function' || !settings.progressive()) {
+        canvasRenderer.clear();
+      }
       renderShapes(newScene.children, g, shapeToCanvasMap, {
         patterns,
       });
@@ -277,7 +280,7 @@ export function renderer(sceneFn = sceneFactory) {
     }
 
     hasChangedRect = false;
-    scene = newScene;
+    scene = newScene; // TODO: change scene -> scenes[] to keep all scenes from progressive renderings when using itemsAt and findShapes functions
     return doRender;
   };
 


### PR DESCRIPTION
Initial implementation of "progressive rendering".
Makes it possible to render chunks of data points until all points are finally rendered. This can improve the visual experience/performance.

If a `progressive` function is passed into the `rendererSettings` of a component, the data that already exist in the component-factory will be kept and the dataPages passed in will be appended.
The data passed into the renderer, from `getRenderArgs`, however, will be sliced based on the `{ start, end }` returned from the progressive function.

TODO
- [ ] Make sure canvas-renderer keeps an array with all scenes (all data points) to make the `itemsAt` and `findShapes` functions work properly.
- [ ] Add unit tests
