### PR TITLE
fix: increase max width for slice label

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/slices.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/slices.spec.js
@@ -14,7 +14,7 @@ describe('labeling - slices', () => {
           },
           position: 'into',
           padding: 1,
-          measured: { width: 6, height: 4 },
+          measured: { width: 5, height: 4 },
           store: { insideLabelBounds: [] },
         })
       ).to.eql({
@@ -38,7 +38,7 @@ describe('labeling - slices', () => {
           },
           position: 'into',
           padding: 1,
-          measured: { width: 6, height: 4 },
+          measured: { width: 5, height: 4 },
           store: { insideLabelBounds: [] },
         })
       ).to.eql({
@@ -62,7 +62,7 @@ describe('labeling - slices', () => {
           },
           position: 'inside',
           padding: 1,
-          measured: { width: 6, height: 4 },
+          measured: { width: 5, height: 4 },
           store: { insideLabelBounds: [] },
         })
       ).to.eql({
@@ -86,7 +86,7 @@ describe('labeling - slices', () => {
           },
           position: 'inside',
           padding: 1,
-          measured: { width: 6, height: 4 },
+          measured: { width: 5, height: 4 },
           store: {
             insideLabelBounds: [
               {
@@ -132,7 +132,7 @@ describe('labeling - slices', () => {
         direction: 'rotate',
         position: 'outside',
         padding: 1,
-        measured: { width: 6, height: 4 },
+        measured: { width: 5, height: 4 },
         view: {
           x: -50,
           y: -50,
@@ -311,7 +311,7 @@ describe('labeling - slices', () => {
           },
         },
       ];
-      renderer.measureText.returns({ width: 20, height: 10 });
+      renderer.measureText.returns({ width: 19, height: 10 });
       let labels = slices({
         settings,
         chart,

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
@@ -4,6 +4,10 @@ import { rectContainsRect } from '../../../math/intersection';
 
 const LABEL_OVERLAP_THRESHOLD_X = 4;
 
+// When a label is animated, the label rect width should be bit larger than the measured text width,
+// otherwise the animated label will be ellipsed.
+const LABEL_RECT_WIDTH_PADDING = 1;
+
 function normalize(angle) {
   const PI2 = Math.PI * 2;
   return ((angle % PI2) + PI2) % PI2; // normalize
@@ -108,7 +112,7 @@ function getHorizontalInsideSliceRect({ slice, padding, measured, store }) {
   const middle = normalize((start + end) / 2);
 
   const size = {
-    width: measured.width + padding * 2,
+    width: measured.width + padding * 2 + LABEL_RECT_WIDTH_PADDING,
     height: measured.height + padding * 2,
   };
 
@@ -145,7 +149,7 @@ function getHorizontalIntoSliceRect({ slice, padding, measured }) {
   const middle = normalize((start + end) / 2);
 
   let size = {
-    width: measured.width + padding * 2,
+    width: measured.width + padding * 2 + LABEL_RECT_WIDTH_PADDING,
     height: measured.height + padding * 2,
   };
 
@@ -237,7 +241,7 @@ function getRotatedOusideSliceRect({ slice, measured, padding, view }) {
   let x = Math.sin(middle) * r;
   let y = -Math.cos(middle) * r;
 
-  let maxWidth = measured.width;
+  let maxWidth = measured.width + LABEL_RECT_WIDTH_PADDING;
   let v = middle % Math.PI;
   if (v > Math.PI / 2) {
     v = Math.PI - v;
@@ -421,7 +425,7 @@ function getHorizontalOusideSliceRect({ slice, measured, padding, view, context 
   let x = Math.sin(middle) * r;
   let y = -Math.cos(middle) * r;
 
-  let maxWidth = measured.width + 1;
+  let maxWidth = measured.width + LABEL_RECT_WIDTH_PADDING;
   if (middle < Math.PI) {
     let w = Math.abs(view.x + view.width - (x + offset.x));
     if (w < maxWidth) {

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/slices.js
@@ -421,7 +421,7 @@ function getHorizontalOusideSliceRect({ slice, measured, padding, view, context 
   let x = Math.sin(middle) * r;
   let y = -Math.cos(middle) * r;
 
-  let maxWidth = measured.width;
+  let maxWidth = measured.width + 1;
   if (middle < Math.PI) {
     let w = Math.abs(view.x + view.width - (x + offset.x));
     if (w < maxWidth) {


### PR DESCRIPTION
**Checklist**

- [x] tests fixed (unit tests)
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated (Not necessary)

### Description
This problem is related to animations.
Current maxWidth setting for slice label rect is not enough, leading to some labels becoming ellipsed during animations. Simply increase this maxWidth by one pixel solves the issue.
### Verification
  #### Example case:
- Before fix: (The video has been slowed down ~ 30 times from real time)

https://user-images.githubusercontent.com/70384379/185360897-7700496a-3d8b-4a6c-b4ca-2a83ae2b49b2.mp4

- After fix: (The video has been slowed down ~ 30 times from real time)

https://user-images.githubusercontent.com/70384379/185361157-5b25bcdb-75a3-41c2-9d3a-2db0b01a4af1.mp4

  #### Complete test matrix:
![image](https://user-images.githubusercontent.com/70384379/185605753-e2bdea51-f71c-4fc1-b2b3-3d236dda9d25.png)



