### PR TITLE
fix(animations): improvements

### DIFF
--- a/packages/picasso.js/src/core/chart-components/pie/__tests__/pie.spec.js
+++ b/packages/picasso.js/src/core/chart-components/pie/__tests__/pie.spec.js
@@ -27,14 +27,9 @@ describe('pie', () => {
     componentFixture.simulateCreate(component, config);
     rendered = componentFixture.simulateRender(opts);
 
-    const d = rendered[0].d.split('A');
-    const m = d[0].replace('M', '').split(',').map(Math.round);
-    const a1 = d[1].split(',').map(Math.round);
-    const a2 = d[2].replace('Z', '').split(',').map(Math.round);
-
-    expect(m).to.eql([0, -40]);
-    expect(a1).to.eql([40, 40, 0, 1, 1, -0, 40]);
-    expect(a2).to.eql([40, 40, 0, 1, 1, 0, -40]);
+    const { startAngle, endAngle } = rendered[0].arcDatum;
+    expect(startAngle).to.eql(0);
+    expect(endAngle).to.eql(Math.PI * 2);
 
     expect(rendered[0]).to.containSubset({
       arc: 1,
@@ -133,7 +128,6 @@ describe('pie', () => {
   });
 
   describe('configured slices', () => {
-    let d;
     before(() => {
       componentFixture.mocks().theme.style.returns({
         slice: {
@@ -172,10 +166,9 @@ describe('pie', () => {
     });
 
     it('should render first slice', () => {
-      d = rendered[0].d.split(/[MALZ]/).map((arr) => (arr ? arr.split(',').map(Math.round) : []));
-      expect(d[1]).to.eql([0, -40]); // move to
-      expect(d[2]).to.eql([40, 40, 0, 0, 1, 35, 20]); // arc
-      expect(d[3]).to.eql([0, 0]); // line to
+      const { startAngle, endAngle } = rendered[0].arcDatum;
+      expect(startAngle).to.eql(0);
+      expect(endAngle).to.eql((Math.PI * 2) / 3);
 
       const t = rendered[0].transform.split(') ').map((arr) =>
         arr
@@ -188,17 +181,15 @@ describe('pie', () => {
     });
 
     it('should render second slice', () => {
-      d = rendered[1].d.split(/[MALZ]/).map((arr) => (arr ? arr.split(',').map(Math.round) : []));
-      expect(d[1]).to.eql([35, 20]); // move to
-      expect(d[2]).to.eql([40, 40, 0, 0, 1, -35, 20]); // arc
-      expect(d[3]).to.eql([0, 0]); // line to
+      const { startAngle, endAngle } = rendered[1].arcDatum;
+      expect(startAngle).to.eql((Math.PI * 2) / 3);
+      expect(endAngle).to.eql((Math.PI * 4) / 3);
     });
 
     it('should render third slice', () => {
-      d = rendered[2].d.split(/[MALZ]/).map((arr) => (arr ? arr.split(',').map(Math.round) : []));
-      expect(d[1]).to.eql([-35, 20]); // move to
-      expect(d[2]).to.eql([40, 40, 0, 0, 1, -0, -40]); // arc
-      expect(d[3]).to.eql([0, 0]); // line to
+      const { startAngle, endAngle } = rendered[2].arcDatum;
+      expect(startAngle).to.eql((Math.PI * 4) / 3);
+      expect(endAngle).to.eql(Math.PI * 2);
     });
   });
 });

--- a/packages/picasso.js/src/core/chart-components/pie/pie.js
+++ b/packages/picasso.js/src/core/chart-components/pie/pie.js
@@ -107,10 +107,11 @@ function createDisplayPies(arcData, { x, y, width, height }, slices, sum) {
     slice.type = 'path';
     const or = outerRadius * slice.outerRadius;
     const ir = innerRadius * slice.innerRadius;
+    const cr = cornerRadius * slice.cornerRadius;
     arcGen.innerRadius(ir);
     arcGen.outerRadius(or);
-    arcGen.cornerRadius(cornerRadius * slice.cornerRadius);
-    slice.d = arcGen(a);
+    arcGen.cornerRadius(cr);
+    slice.arcDatum = a;
     const centroid = arcGen.centroid(a);
     const offset = slice.offset ? offsetSlice(centroid, slice.offset, or, ir) : { x: 0, y: 0 };
     slice.transform = `translate(${offset.x}, ${offset.y}) translate(${center.x}, ${center.y})`;
@@ -121,6 +122,7 @@ function createDisplayPies(arcData, { x, y, width, height }, slices, sum) {
         end: a.endAngle,
         innerRadius: ir,
         outerRadius: or,
+        cornerRadius: cr,
         offset: { x: center.x + offset.x, y: center.y + offset.y },
       },
     };

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -58,12 +58,14 @@ function tween({ old, current }, { renderer }, config) {
         nodes: [...toBeUpdated],
       });
       // Existing nodes updating
-      stages.push({
-        easing: easeCubic,
-        duration: config.transitionPhaseDisabled ? 0 : 400,
-        tweens: updated.ips,
-        nodes: [],
-      });
+      if (!config.transitionPhaseDisabled) {
+        stages.push({
+          easing: easeCubic,
+          duration: 400,
+          tweens: updated.ips,
+          nodes: [],
+        });
+      }
       // New nodes entering
       stages.push({
         easing: easeCubicOut,

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -1,6 +1,6 @@
 import extend from 'extend';
 import { interpolateObject } from 'd3-interpolate';
-import { easeCubic } from 'd3-ease';
+import { easeCubic, easeCubicIn, easeCubicOut } from 'd3-ease';
 
 /* globals window */
 
@@ -41,15 +41,7 @@ function tween({ old, current }, { renderer }, config) {
           ids[id] = false;
         } else {
           entered.nodes.push(node);
-          entered.ips.push(
-            interpolateObject(
-              {
-                r: 0.001,
-                opacity: 0,
-              },
-              node
-            )
-          );
+          entered.ips.push(interpolateObject(extend({}, node, { r: 0.001, opacity: 0 }), node));
         }
       });
       Object.keys(ids).forEach((key) => {
@@ -60,7 +52,7 @@ function tween({ old, current }, { renderer }, config) {
       });
       // Obsolete nodes exiting
       stages.push({
-        easing: easeCubic,
+        easing: easeCubicIn,
         duration: 200,
         tweens: exited.ips,
         nodes: [...toBeUpdated],
@@ -68,13 +60,13 @@ function tween({ old, current }, { renderer }, config) {
       // Existing nodes updating
       stages.push({
         easing: easeCubic,
-        duration: 400,
+        duration: config.transitionPhaseDisabled ? 0 : 400,
         tweens: updated.ips,
         nodes: [],
       });
       // New nodes entering
       stages.push({
-        easing: easeCubic,
+        easing: easeCubicOut,
         duration: 200,
         tweens: entered.ips,
         nodes: [...updated.nodes],

--- a/packages/picasso.js/src/core/scene-graph/display-objects/__tests__/path.spec.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/__tests__/path.spec.js
@@ -12,10 +12,23 @@ describe('Path', () => {
       expect(path.collider).to.be.equal(null);
     });
 
-    it('should accept arguments', () => {
+    it('should accept arguments - case 1: svg path', () => {
       path = create({ d: 'M10 15' });
       expect(path).to.be.an.instanceof(Path);
       expect(path.attrs.d).to.be.equal('M10 15');
+    });
+
+    it('should accept arguments - case 2: pie arc datum', () => {
+      path = create({
+        arcDatum: { startAngle: (Math.PI * 4) / 3, endAngle: Math.PI * 2 },
+        padAngle: 0,
+        desc: { slice: { innerRadius: 0, cornerRadius: 0, outerRadius: 40 } },
+      });
+      expect(path).to.be.an.instanceof(Path);
+      const strokes = path.attrs.d.split(/[MALZ]/).map((arr) => (arr ? arr.split(',').map(Math.round) : []));
+      expect(strokes[1]).to.eql([-35, 20]); // move to
+      expect(strokes[2]).to.eql([40, 40, 0, 0, 1, -0, -40]); // arc
+      expect(strokes[3]).to.eql([0, 0]); // line to
     });
   });
 


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
### Summary
This PR fixes two main problems with animations:
- Animations of a pie chart's slices: (Issue: https://github.com/qlik-trial/la-vie/issues/4387)
  - Issue: currently the path that represents a slice (`slice.d`) is a string and is calculated in the pie component (src/core/chart-components/pie/pie.js). During pie chart animations, the tween slices are interpolated from this string, which is not nice (see the first video below)
  - The fix: it would be better to interpolate the actual slice (start angle, end angle, radius) instead of the slice.d string. We can achieve this by calculating `slice.d` in the display path (src/core/scene-graph/display-objects/path.js) instead of in the pie component.

- Improve the transitions:
  - Issue: currently the transition stage still happens even if there is no node to be updated (the new nodes and the old nodes have no node in common), leading to a blank period between the exiting of the old nodes and the entering of the new nodes.
  - The fix: it would be better to remove the transition stage if the main components (e.g. slices of a pie chart) are empty in the transition stage. Also the blank period can be shortened further by using relevant `d3-ease`.
### Verification
- Animations of Pie chart's slices:
  - Before fix:
  
     https://user-images.githubusercontent.com/70384379/187696043-8c418eb4-e58a-4c3e-a2b8-1475454d1b4b.mov

  - After fix: 

     https://user-images.githubusercontent.com/70384379/187696070-4d2930c2-dd65-42fc-b3f8-e19e0b036ee7.mov
- Animations of Pie chart's slices - changing corner radius, inner radius
  - Before fix: not very smooth 

     https://user-images.githubusercontent.com/70384379/187704616-f5b070b9-c9d6-494e-81a5-7d1346060504.mov

  - After fix: 

     https://user-images.githubusercontent.com/70384379/187704678-220fd67f-ab2e-4323-b992-2b70bd5a886e.mov
  
- Improve the transitions:
  - Before fix:  

     https://user-images.githubusercontent.com/70384379/187699458-be95526a-887e-4744-b2cf-858df678f68e.mov

  - After fix: 

     https://user-images.githubusercontent.com/70384379/187699491-e5427a5a-739f-4d34-b5d1-dc6f0b5911dd.mov




   
