### PR TITLE
refactor: change class export

### DIFF
--- a/packages/picasso.js/src/core/geometry/circle.js
+++ b/packages/picasso.js/src/core/geometry/circle.js
@@ -12,7 +12,7 @@ import {
  * Construct a new GeoCircle instance
  * @private
  */
-export default class GeoCircle {
+class GeoCircle {
   constructor({ cx = 0, cy = 0, r = 0, minRadius = 0 } = {}) {
     this.set({
       cx,
@@ -99,3 +99,5 @@ export default class GeoCircle {
 export function create(...args) {
   return new GeoCircle(...args);
 }
+
+export default GeoCircle;

--- a/packages/picasso.js/src/core/geometry/geometry-collection.js
+++ b/packages/picasso.js/src/core/geometry/geometry-collection.js
@@ -4,7 +4,7 @@ import { create as factory } from './index';
  * Construct a new GeometryCollection instance
  * @private
  */
-export default class GeometryCollection {
+class GeometryCollection {
   constructor(collection = []) {
     this.set(collection);
   }
@@ -71,3 +71,5 @@ export default class GeometryCollection {
 export function create(...args) {
   return new GeometryCollection(...args);
 }
+
+export default GeometryCollection;

--- a/packages/picasso.js/src/core/geometry/geopolygon.js
+++ b/packages/picasso.js/src/core/geometry/geopolygon.js
@@ -33,12 +33,7 @@ function removeDuplicates(vertices) {
  * A geo-polygon is a polygon which is similar to a polygon in GeoJson. A typical geopolygon is an array of polygons where the first polygon is an outer polygon and the rest are inner polygons
  * @private
  */
-
-/**
- * Construct a new GeoPolygon instance
- * @private
- */
-export default class GeoPolygon {
+class GeoPolygon {
   constructor({ vertices = [[]] } = {}) {
     this.set({ vertices });
   }
@@ -141,6 +136,7 @@ export default class GeoPolygon {
 
   /**
    * Get the bounds of the polygon, as an array of points
+   * @ignore
    * @returns {Point[]}
    */
   bounds() {
@@ -158,6 +154,7 @@ export default class GeoPolygon {
 
   /**
    * Get the bounding rect of the polygon
+   * @ignore
    * @returns {Rect}
    */
   boundingRect() {
@@ -176,3 +173,5 @@ export default class GeoPolygon {
 export function create(...a) {
   return new GeoPolygon(...a);
 }
+
+export default GeoPolygon;

--- a/packages/picasso.js/src/core/geometry/line.js
+++ b/packages/picasso.js/src/core/geometry/line.js
@@ -12,7 +12,7 @@ import {
  * Construct a new GeoLine instance
  * @private
  */
-export default class GeoLine {
+class GeoLine {
   constructor({ x1 = 0, y1 = 0, x2 = 0, y2 = 0, tolerance = 0 } = {}) {
     this.set({
       x1,
@@ -104,3 +104,5 @@ export default class GeoLine {
 export function create(...args) {
   return new GeoLine(...args);
 }
+
+export default GeoLine;

--- a/packages/picasso.js/src/core/geometry/polygon.js
+++ b/packages/picasso.js/src/core/geometry/polygon.js
@@ -31,10 +31,9 @@ function removeDuplicates(vertices) {
 /**
  * Construct a new Polygon instance
  * Added ignore flag as the name collide with definition in index.js
- * @ignore
  * @private
  */
-export default class Polygon {
+class Polygon {
   constructor({ vertices = [] } = {}) {
     this.set({ vertices });
   }
@@ -188,3 +187,5 @@ export default class Polygon {
 export function create(...a) {
   return new Polygon(...a);
 }
+
+export default Polygon;

--- a/packages/picasso.js/src/core/geometry/polyline.js
+++ b/packages/picasso.js/src/core/geometry/polyline.js
@@ -16,7 +16,7 @@ function pointsAreNotEqual(p0, p1) {
  * Construct a new GeoPolyline instance
  * @private
  */
-export default class GeoPolyline {
+class GeoPolyline {
   constructor({ points = [] } = {}) {
     this.set({ points });
   }
@@ -104,3 +104,5 @@ export default class GeoPolyline {
 export function create(...a) {
   return new GeoPolyline(...a);
 }
+
+export default GeoPolyline;

--- a/packages/picasso.js/src/core/geometry/rect.js
+++ b/packages/picasso.js/src/core/geometry/rect.js
@@ -12,7 +12,7 @@ import {
  * Construct a new GeoRect instance
  * @private
  */
-export default class GeoRect {
+class GeoRect {
   constructor({ x = 0, y = 0, width = 0, height = 0, minWidth = 0, minHeight = 0 } = {}) {
     this.set({
       x,
@@ -111,3 +111,5 @@ export default class GeoRect {
 export function create(...args) {
   return new GeoRect(...args);
 }
+
+export default GeoRect;

--- a/packages/picasso.js/src/core/scene-graph/scene-node.js
+++ b/packages/picasso.js/src/core/scene-graph/scene-node.js
@@ -77,7 +77,7 @@ function colliderToShape(node, dpi) {
 /**
  * Read-only object representing a node on the scene.
  */
-export class SceneNode {
+class SceneNode {
   constructor(node) {
     this._bounds = (includeTransform = true) => {
       const { x, y, width, height } = node.boundingRect
@@ -279,3 +279,5 @@ export class SceneNode {
 export default function create(...a) {
   return new SceneNode(...a);
 }
+
+export { SceneNode };


### PR DESCRIPTION
#665 change how some classes got exported. For some reason which I do not understand currently. That results in a different JSDoc output then expected.

This PR changes it back to a syntax which does produce the correct JSDoc output.