### PR TITLE
feat: support styling brushed nodes based on active nodes

### DIFF
--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -148,7 +148,6 @@ export function styler(obj, { context, data, style, filter, mode }) {
           });
           globalChanged = true;
         }
-        delete nodes[i].needToUpdate;
         delete nodes[i].isActive;
       }
     }

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -148,6 +148,8 @@ export function styler(obj, { context, data, style, filter, mode }) {
           });
           globalChanged = true;
         }
+        delete nodes[i].needToUpdate;
+        delete nodes[i].isActive;
       }
     }
 

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -148,7 +148,7 @@ export function styler(obj, { context, data, style, filter, mode }) {
           });
           globalChanged = true;
         }
-        delete nodes[i].isActive;
+        delete nodes[i].needToUpdate;
       }
     }
 

--- a/packages/picasso.js/src/core/component/brushing.js
+++ b/packages/picasso.js/src/core/component/brushing.js
@@ -51,105 +51,62 @@ export function styler(obj, { context, data, style, filter, mode }) {
     let nodeData;
     let globalChanged = false;
     const evaluatedDataProps = typeof dataProps === 'function' ? dataProps({ brush: brusher }) : dataProps;
-    const lazyStyleUpdate =
-      typeof obj.config.lazyStyleUpdate === 'function' ? obj.config.lazyStyleUpdate(obj) : obj.config.lazyStyleUpdate;
 
-    if (!lazyStyleUpdate) {
-      for (let i = 0; i < len; i++) {
-        // TODO - update only added and removed nodes
-        nodeData = nodes[i].data;
-        if (!nodeData) {
-          continue;
-        }
-
-        if (!nodes[i].__style) {
-          nodes[i].__style = {};
-          styleProps.forEach((s) => {
-            nodes[i].__style[s] = nodes[i][s]; // store original value
-          });
-        }
-
-        const isActive = brusher.containsMappedData(nodeData, evaluatedDataProps, mode);
-        const activeIdx = activeNodes.indexOf(nodes[i]);
-        let changed = false;
-        if (isActive && activeIdx === -1) {
-          // activated
-          activeNodes.push(nodes[i]);
-          changed = true;
-        } else if (!isActive && activeIdx !== -1) {
-          // was active
-          activeNodes.splice(activeIdx, 1);
-          changed = true;
-        }
-        if (changed || globalActivation) {
-          const original = extend({}, nodes[i], nodes[i].__style);
-          styleProps.forEach((s) => {
-            if (isActive && s in active) {
-              nodes[i][s] = typeof active[s] === 'function' ? active[s].call(null, original) : active[s];
-            } else if (!isActive && s in inactive) {
-              nodes[i][s] = typeof inactive[s] === 'function' ? inactive[s].call(null, original) : inactive[s];
-            } else {
-              nodes[i][s] = nodes[i].__style[s];
-            }
-          });
-          globalChanged = true;
-        }
-      }
-    } else {
-      for (let i = 0; i < len; i++) {
-        // TODO - update only added and removed nodes
-        nodeData = nodes[i].data;
-        if (!nodeData) {
-          continue;
-        }
-
-        if (!nodes[i].__style) {
-          nodes[i].__style = {};
-          styleProps.forEach((s) => {
-            nodes[i].__style[s] = nodes[i][s]; // store original value
-          });
-        }
-
-        const isActive = brusher.containsMappedData(nodeData, evaluatedDataProps, mode);
-        const activeIdx = activeNodes.indexOf(nodes[i]);
-        let changed = false;
-        if (isActive && activeIdx === -1) {
-          // activated
-          activeNodes.push(nodes[i]);
-          changed = true;
-        } else if (!isActive && activeIdx !== -1) {
-          // was active
-          activeNodes.splice(activeIdx, 1);
-          changed = true;
-        }
-        nodes[i].needToUpdate = changed || globalActivation;
-        nodes[i].isActive = isActive;
+    // To calculate active nodes
+    for (let i = 0; i < len; i++) {
+      // TODO - update only added and removed nodes
+      nodeData = nodes[i].data;
+      if (!nodeData) {
+        continue;
       }
 
-      for (let i = 0; i < len; i++) {
-        // TODO - update only added and removed nodes
-        nodeData = nodes[i].data;
-        if (!nodeData) {
-          continue;
-        }
-
-        if (nodes[i].needToUpdate) {
-          const original = extend({}, nodes[i], nodes[i].__style);
-          const isActive = nodes[i].isActive;
-          styleProps.forEach((s) => {
-            if (isActive && s in active) {
-              nodes[i][s] = typeof active[s] === 'function' ? active[s].call(null, original, activeNodes) : active[s];
-            } else if (!isActive && s in inactive) {
-              nodes[i][s] =
-                typeof inactive[s] === 'function' ? inactive[s].call(null, original, activeNodes) : inactive[s];
-            } else {
-              nodes[i][s] = nodes[i].__style[s];
-            }
-          });
-          globalChanged = true;
-        }
-        delete nodes[i].needToUpdate;
+      if (!nodes[i].__style) {
+        nodes[i].__style = {};
+        styleProps.forEach((s) => {
+          nodes[i].__style[s] = nodes[i][s]; // store original value
+        });
       }
+
+      const isActive = brusher.containsMappedData(nodeData, evaluatedDataProps, mode);
+      const activeIdx = activeNodes.indexOf(nodes[i]);
+      let changed = false;
+      if (isActive && activeIdx === -1) {
+        // activated
+        activeNodes.push(nodes[i]);
+        changed = true;
+      } else if (!isActive && activeIdx !== -1) {
+        // was active
+        activeNodes.splice(activeIdx, 1);
+        changed = true;
+      }
+      nodes[i].needToUpdate = changed || globalActivation;
+      nodes[i].isActive = isActive;
+    }
+
+    // To calculate style
+    for (let i = 0; i < len; i++) {
+      // TODO - update only added and removed nodes
+      nodeData = nodes[i].data;
+      if (!nodeData) {
+        continue;
+      }
+
+      if (nodes[i].needToUpdate) {
+        const original = extend({}, nodes[i], nodes[i].__style);
+        const isActive = nodes[i].isActive;
+        styleProps.forEach((s) => {
+          if (isActive && s in active) {
+            nodes[i][s] = typeof active[s] === 'function' ? active[s].call(null, original, activeNodes) : active[s];
+          } else if (!isActive && s in inactive) {
+            nodes[i][s] =
+              typeof inactive[s] === 'function' ? inactive[s].call(null, original, activeNodes) : inactive[s];
+          } else {
+            nodes[i][s] = nodes[i].__style[s];
+          }
+        });
+        globalChanged = true;
+      }
+      delete nodes[i].needToUpdate;
     }
 
     globalActivation = false;


### PR DESCRIPTION
This PR to support styling brushed nodes (e.g. border width/color) based on active nodes. E.g. in a scatter plot, the border of active nodes should be smaller when the number of active nodes are bigger.