### PR TITLE
fix: should take excludeFromUpdate into account for update

### DIFF
--- a/packages/picasso.js/src/core/chart/component-collection.js
+++ b/packages/picasso.js/src/core/chart/component-collection.js
@@ -98,6 +98,7 @@ function collectionFn({ createComponent }) {
         // Component should not be updated
         if (excludeFromUpdate.indexOf(comp.key) > -1) {
           // TODO: decide if to skip children
+          delete component.updateWith;
           return component;
         }
 


### PR DESCRIPTION
Currently there is a limitation on using chart.layoutComponents and chart.update together.
For example we want to layout all components and then render light components in one chart.update and then render heavy components in a series of chart.update with progressive mechanism.
The current problem is that :
1. First, we run chart.layoutComponents (without using excludeFromUpdate) to layout all components, all components have updateWith property which is used to render the components in next chart.update.
2. Second, we run chart.update with excludeFromUpdate with intension that we want to render few components and exclude other components from updating. However, with updateWith calculated from chart.layoutComponents, excludeFromUpdate is not used to exclude a component from update. Therefore all components are updated, this is not what we want.
This PR is to fix this problem by using excludeFromUpdate to check if a component is in excludeFromUpdate list, it should not be updated by removing updateWith property from it.