### PR TITLE
fix: grid line value for dimension axis

### DIFF
--- a/packages/picasso.js/src/core/chart-components/grid/line.js
+++ b/packages/picasso.js/src/core/chart-components/grid/line.js
@@ -99,7 +99,7 @@ const gridLineComponent = {
             strokeWidth: typeof style.strokeWidth !== 'undefined' ? style.strokeWidth : 1,
             strokeDasharray: typeof style.strokeDasharray !== 'undefined' ? style.strokeDasharray : undefined,
             flipXY: p.flipXY || false, // This flips individual points (Y-lines)
-            value: p.value,
+            value: p.value ?? p.data?.value,
             dir,
           });
         }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

For a dimension axis (grid chart has two, for example),  value of the grid line is in `p.data`, not directly in `p`.
