### PR TITLE
fix: improve tweening when removing updating stage

### DIFF
--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -14,7 +14,7 @@ function nodeId(node, i) {
   return i;
 }
 
-let shouldRemoveUpdatingStage;
+const updatingStageMeta = { shouldBeRemoved: false, isInit: false };
 
 export default function tween({ old, current }, { renderer }, config) {
   let ticker;
@@ -79,10 +79,11 @@ export default function tween({ old, current }, { renderer }, config) {
       if (config.isMainComponent) {
         const filterFn = config.isMainComponent?.filterFn;
         const nUpdatingNodes = filterFn ? toBeUpdated.filter(filterFn).length : toBeUpdated.length;
-        if (shouldRemoveUpdatingStage === undefined) {
-          shouldRemoveUpdatingStage = nUpdatingNodes === 0;
+        if (updatingStageMeta.isInit === false) {
+          updatingStageMeta.shouldBeRemoved = nUpdatingNodes === 0;
+          updatingStageMeta.isInit = true;
         } else {
-          shouldRemoveUpdatingStage = shouldRemoveUpdatingStage && nUpdatingNodes === 0;
+          updatingStageMeta.shouldBeRemoved = updatingStageMeta.shouldBeRemoved && nUpdatingNodes === 0;
         }
       }
       // console.log(stages);
@@ -114,11 +115,11 @@ export default function tween({ old, current }, { renderer }, config) {
         // staticNodes.push(...currentStage.nodes);
         stages.shift();
         if (!stages.length) {
-          if (config.isMainComponent) {
-            shouldRemoveUpdatingStage = undefined;
+          if (updatingStageMeta.isInit === true) {
+            updatingStageMeta.isInit = false;
           }
           tweener.stop();
-        } else if (stages[0].name === 'updating' && shouldRemoveUpdatingStage) {
+        } else if (stages[0].name === 'updating' && updatingStageMeta.shouldBeRemoved) {
           stages.shift();
         }
       }

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -76,8 +76,10 @@ export default function tween({ old, current }, { renderer }, config) {
         tweens: entered.ips,
         nodes: [...updated.nodes],
       });
-      if (config.isMainComponent && toBeUpdated.length === 0) {
-        shouldRemoveUpdatingStage = true;
+      if (config.isMainComponent) {
+        const filterFn = config.isMainComponent?.filterFn;
+        const nUpdatingNodes = filterFn ? toBeUpdated.filter(filterFn).length : toBeUpdated.length;
+        shouldRemoveUpdatingStage = nUpdatingNodes === 0;
       }
       // console.log(stages);
       if (stages.length) {

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -14,7 +14,7 @@ function nodeId(node, i) {
   return i;
 }
 
-let shouldRemoveUpdatingStage = false;
+let shouldRemoveUpdatingStage;
 
 export default function tween({ old, current }, { renderer }, config) {
   let ticker;
@@ -79,7 +79,11 @@ export default function tween({ old, current }, { renderer }, config) {
       if (config.isMainComponent) {
         const filterFn = config.isMainComponent?.filterFn;
         const nUpdatingNodes = filterFn ? toBeUpdated.filter(filterFn).length : toBeUpdated.length;
-        shouldRemoveUpdatingStage = nUpdatingNodes === 0;
+        if (shouldRemoveUpdatingStage === undefined) {
+          shouldRemoveUpdatingStage = nUpdatingNodes === 0;
+        } else {
+          shouldRemoveUpdatingStage = shouldRemoveUpdatingStage && nUpdatingNodes === 0;
+        }
       }
       // console.log(stages);
       if (stages.length) {
@@ -111,7 +115,7 @@ export default function tween({ old, current }, { renderer }, config) {
         stages.shift();
         if (!stages.length) {
           if (config.isMainComponent) {
-            shouldRemoveUpdatingStage = false;
+            shouldRemoveUpdatingStage = undefined;
           }
           tweener.stop();
         } else if (stages[0].name === 'updating' && shouldRemoveUpdatingStage) {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

## Summary
When animating a chart, there is an issue when the main component has no node in updating stage: the chart looks blank for 0.4 seconds. The logics for removing updating stage in this case has been implemented before (https://github.com/qlik-oss/picasso.js/pull/722). This PR improves it even more.
- Allow filtering scene nodes of the main component. For example, the `sankey` component can have many types of scene nodes, from which we are only interested in `path` nodes.
- Allow multiple main components. For example, a combo chart can have both line and bar component. We only remove the updating stage if each of the main components has no node in updating stage.

## Verification
- Only apply removing updating stage logics to the path nodes of sankey component. 
  - Before: all scene nodes of the sankey components (paths, rect, labels) decide whether or not updating stage should be removed

     https://user-images.githubusercontent.com/70384379/200939215-2dba6d95-e577-4441-82b0-e8148c6ce7ab.mov

  - After fix: only path nodes are considered

     https://user-images.githubusercontent.com/70384379/200937933-87172f82-05a3-4db9-abb3-d45227e116c3.mov


- Multiple main components. The updating stage is removed when both or either line or bar component of a combo chart has empty updating stage.

   https://user-images.githubusercontent.com/70384379/200937177-7725fa9e-26a9-4873-be12-e9c3fd8b3545.mov

