### PR TITLE
fix: more info for label bg rect, to support chart animations

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -27,6 +27,8 @@ function toBackground(label) {
     ry: 2,
     fill: label.backgroundColor,
     ...label.backgroundBounds,
+    data: label.data,
+    rotation: label.transform && label.transform.match(/rotate/gi) ? 'rotated' : 'horizontal',
   };
 }
 


### PR DESCRIPTION

**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

## Description
Bullet chart has background rect for labels, due to the fact that a bullet can have multiple colors.
To animate these rects, we need to give IDs for them: https://github.com/qlik-trial/la-vie/blob/master/chart-modules/animations/src/labels/track-by.js#L7
This PR is to provide the info needed to ID these rects.