### PR TITLE
fix: animations avoid interpolating color

### DIFF
--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -37,6 +37,7 @@
     "prepublishOnly": "rm -rf dist && npm run build"
   },
   "devDependencies": {
+    "d3-color": "3.0.1",
     "d3-ease": "3.0.1",
     "d3-format": "3.1.0",
     "d3-hierarchy": "3.1.2",

--- a/packages/picasso.js/src/core/component/__tests__/interpolate-object.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/interpolate-object.spec.js
@@ -1,0 +1,33 @@
+import interpolateObject from '../interpolate-object';
+
+describe('interpolateObject', () => {
+  let source;
+  let target;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should interpolate object correctly when source object does not have a property in target object', () => {
+    source = { x: 10, y: 200 };
+    target = { x: 20, y: 600, z: 1000 };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ x: 15, y: 400, z: 1000 });
+  });
+
+  it('should interpolate object correctly when target object does not have a property in source object', () => {
+    source = { x: 10, y: 200, z: 1000 };
+    target = { x: 20, y: 600 };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ x: 15, y: 400 });
+  });
+
+  it('should interpolate string correctly when there is number and color embedded: interpolate number but NOT color', () => {
+    source = { style: '300rem 12px Red', border: 'Green' };
+    target = { style: '600rem 20px Blue', border: 'Blue' };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ style: '450rem 16px Blue', border: 'Blue' });
+  });
+});

--- a/packages/picasso.js/src/core/component/interpolate-object.js
+++ b/packages/picasso.js/src/core/component/interpolate-object.js
@@ -1,0 +1,92 @@
+/* eslint-disable no-use-before-define */
+/* eslint-disable no-nested-ternary */
+import { color } from 'd3-color';
+import {
+  interpolateRgb as rgb,
+  interpolateDate as date,
+  interpolateNumber as number,
+  interpolateString as string,
+  interpolateNumberArray as numberArray,
+} from 'd3-interpolate';
+
+export function constant(x) {
+  return () => x;
+}
+
+export function isNumberArray(x) {
+  return ArrayBuffer.isView(x) && !(x instanceof DataView);
+}
+
+export function genericArray(a, b) {
+  const nb = b ? b.length : 0;
+  const na = a ? Math.min(nb, a.length) : 0;
+  const x = new Array(na);
+  const c = new Array(nb);
+  let i;
+
+  for (i = 0; i < na; ++i) {
+    x[i] = value(a[i], b[i]);
+  }
+
+  for (; i < nb; ++i) {
+    c[i] = b[i];
+  }
+
+  return function interplolate(t) {
+    for (i = 0; i < na; ++i) {
+      c[i] = x[i](t);
+    }
+    return c;
+  };
+}
+
+export function value(a, b) {
+  const t = typeof b;
+  return b == null || t === 'boolean'
+    ? constant(b)
+    : (t === 'number'
+        ? number
+        : t === 'string'
+        ? string
+        : b instanceof color
+        ? rgb
+        : b instanceof Date
+        ? date
+        : isNumberArray(b)
+        ? numberArray
+        : Array.isArray(b)
+        ? genericArray
+        : (typeof b.valueOf !== 'function' && typeof b.toString !== 'function') || isNaN(b)
+        ? object
+        : number)(a, b);
+}
+
+export default function object(a, b) {
+  const i = {};
+  const c = {};
+  let k;
+
+  if (a === null || typeof a !== 'object') {
+    a = {};
+  }
+
+  if (b === null || typeof b !== 'object') {
+    b = {};
+  }
+
+  for (k in b) {
+    if (k in a) {
+      i[k] = value(a[k], b[k]);
+    } else {
+      c[k] = b[k];
+    }
+  }
+
+  return function interplolate(t) {
+    // eslint-disable-next-line guard-for-in
+    for (k in i) {
+      c[k] = i[k](t);
+    }
+    return c;
+  };
+}

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -1,6 +1,6 @@
 import extend from 'extend';
-import { interpolateObject } from 'd3-interpolate';
 import { easeCubic, easeCubicIn, easeCubicOut } from 'd3-ease';
+import interpolateObject from './interpolate-object';
 
 /* globals window */
 


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

## Description

_**The issuse:**_ This bug is because the D3-interpolation package that we use for animations treats a string like "Red" as a color and attempts to interpolate it in the RGB form.

_**The fix:**_ Write a custom interpolate object function based on that in D3-interpolate, but modify the piece of code that attempts to interpolate string as color. This issue of interpolating any string containing color word as RBG has been raised some times (for e.g.: https://github.com/d3/d3-interpolate/issues/42) but D3 leader Mike Bostock does not want make the string interpolation, or any other types of interpolation, more customizable. To quote his words: "It feels a little too specific to me, as-is."

## Verification

- That it solves the problem.
  - Before: 

     https://user-images.githubusercontent.com/70384379/225328219-dffbc408-905d-45f5-85e7-c2f1104b41c6.mp4

  - After: 

     https://user-images.githubusercontent.com/70384379/225328459-1111d9df-580c-4daf-89ed-b00dd27c64a3.mp4

- That chart animations work properly as before.

   https://user-images.githubusercontent.com/70384379/225327601-fce85e57-9581-4ae9-9d11-71802d36af78.mp4






