### PR TITLE
fix: enable color interpolation for fill and stroke

### DIFF
--- a/packages/picasso.js/src/core/component/__tests__/interpolate-object.spec.js
+++ b/packages/picasso.js/src/core/component/__tests__/interpolate-object.spec.js
@@ -25,9 +25,25 @@ describe('interpolateObject', () => {
     expect(interpolateObject(source, target)(0.5)).to.deep.equal({ x: 15, y: 400 });
   });
 
-  it('should interpolate string correctly when there is number and color embedded: interpolate number but NOT color', () => {
-    source = { style: '300rem 12px Red', border: 'Green' };
-    target = { style: '600rem 20px Blue', border: 'Blue' };
-    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ style: '450rem 16px Blue', border: 'Blue' });
+  it('should interpolate string as color if the key is one of the color keys', () => {
+    source = { stroke: 'Red', fill: 'Green', backgroundColor: 'Blue' };
+    target = { stroke: 'Green', fill: 'Blue', backgroundColor: 'Red' };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({
+      stroke: 'rgb(128, 64, 0)',
+      fill: 'rgb(0, 64, 128)',
+      backgroundColor: 'rgb(128, 0, 128)',
+    });
+  });
+
+  it('should NOT interpolate string as color if the key is NOT one of the color keys', () => {
+    source = { label: 'Red', text: 'Green' };
+    target = { label: 'Blue', text: 'Blue' };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ label: 'Blue', text: 'Blue' });
+  });
+
+  it('should NOT interpolate string as color if the color is just a part of the string', () => {
+    source = { fill: '300rem 12px Red' };
+    target = { fill: '600rem 20px Blue' };
+    expect(interpolateObject(source, target)(0.5)).to.deep.equal({ fill: '450rem 16px Blue' });
   });
 });

--- a/packages/picasso.js/src/core/component/interpolate-object.js
+++ b/packages/picasso.js/src/core/component/interpolate-object.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-cond-assign */
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-nested-ternary */
 import { color } from 'd3-color';
@@ -8,6 +9,8 @@ import {
   interpolateString as string,
   interpolateNumberArray as numberArray,
 } from 'd3-interpolate';
+
+const colorKeys = ['stroke', 'fill', 'color', 'backgroundColor', 'thumbColor'];
 
 export function constant(x) {
   return () => x;
@@ -40,14 +43,17 @@ export function genericArray(a, b) {
   };
 }
 
-export function value(a, b) {
+export function value(a, b, k) {
   const t = typeof b;
+  let c;
   return b == null || t === 'boolean'
     ? constant(b)
     : (t === 'number'
         ? number
         : t === 'string'
-        ? string
+        ? (c = color(b)) && colorKeys.includes(k)
+          ? ((b = c), rgb)
+          : string
         : b instanceof color
         ? rgb
         : b instanceof Date
@@ -76,7 +82,7 @@ export default function object(a, b) {
 
   for (k in b) {
     if (k in a) {
-      i[k] = value(a[k], b[k]);
+      i[k] = value(a[k], b[k], k);
     } else {
       c[k] = b[k];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,6 +5561,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
+d3-color@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.0.1.tgz#03316e595955d1fcd39d9f3610ad41bb90194d0a"
+  integrity sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==
+
 d3-ease@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

### Description
Continuing from PR https://github.com/qlik-oss/picasso.js/pull/774.
The above PR disable all interpolations of strings as colors (i.e. "Red" should be interpreted as text but not a color code)
However, I realize that we still need to interpolate strings as colors in some cases, for example, fill. Otherwise, the fill will look black (see videos below).

### Vefication

- Before fix:
  - Pie chart:

     https://user-images.githubusercontent.com/70384379/228517070-fa89709a-8d17-4a56-af15-9c2ef3d288aa.mov

  - Scatter plot: 

     https://user-images.githubusercontent.com/70384379/228517315-29d28e16-921b-42fa-8c4f-c2b9995dc23d.mov

- After fix:
  - Pie chart:

     https://user-images.githubusercontent.com/70384379/228515398-f9e5fd39-c86f-4bc9-aa9f-a1b69dd0dd46.mov


  - Scatter plot: 

     https://user-images.githubusercontent.com/70384379/228515586-0c5202c5-5824-4b3b-a23c-22c29c981134.mov

  - Confirm that bug fixed by https://github.com/qlik-oss/picasso.js/pull/774 is still fixed (i.e. text or label containing color code is not interpreted as color)
  
     https://user-images.githubusercontent.com/70384379/228516022-3091ce0a-9630-4090-a1ab-df2e2f47e0ec.mov