### PR TITLE
fix: get correct index when columnOrder is irregular

### DIFF
--- a/plugins/q/src/data/__tests__/extractor-s.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-s.spec.js
@@ -959,7 +959,7 @@ describe('extractor-s', () => {
       }
     });
 
-    // This happens for mini chart of an axis chart that has two dims, one measure, qLeft is 1, and column order is undefined
+    // This happens for mini chart of an axis chart that has two dims, one measure, qLeft is 1, and column order is empty
     it('should return correct index when object has two dimensions and one measure, qLeft is 1, and column order is empty', () => {
       const row = ['b', 200, 100];
       localCache.fields = [{}, {}, {}, {}];

--- a/plugins/q/src/data/__tests__/extractor-s.spec.js
+++ b/plugins/q/src/data/__tests__/extractor-s.spec.js
@@ -841,14 +841,18 @@ describe('extractor-s', () => {
   });
 
   describe('getFieldAccessor', () => {
-    const localCache = {
-      fields: [{}, {}, {}],
-      wrappedFields: [
-        { attrDims: [], attrExps: [] },
-        { attrDims: [{}, { instance: {} }], attrExps: [] },
-        { attrDims: [], attrExps: [{}, { instance: {} }] },
-      ],
-    };
+    let localCache;
+
+    beforeEach(() => {
+      localCache = {
+        fields: [{}, {}, {}],
+        wrappedFields: [
+          { attrDims: [], attrExps: [] },
+          { attrDims: [{}, { instance: {} }], attrExps: [] },
+          { attrDims: [], attrExps: [{}, { instance: {} }] },
+        ],
+      };
+    });
 
     it('should return -1 when field is falsy', () => {
       const acc = getFieldAccessor(0);
@@ -933,6 +937,46 @@ describe('extractor-s', () => {
         { cache: localCache }
       );
       expect(acc(row)).to.equal('b');
+    });
+
+    // This happens when an axis chart has one dim, many measures, and irregular column order
+    it('should return correct index when object has one dimension and five measures, and column order is irregular', () => {
+      const row = ['a', 'b', 'c', 'd', 'e', 'f'];
+      const columnOrder = [0, 2, 3, 1, 4, 5];
+      const expectedReturnedValues = ['a', 'd', 'b', 'c', 'e', 'f'];
+      localCache.fields = [{}, {}, {}, {}, {}, {}];
+      for (let i = 0; i < 6; i++) {
+        const f = localCache.fields[i];
+        const acc = getFieldAccessor(
+          f,
+          {
+            qArea: { qLeft: 0 },
+          },
+          { cache: localCache },
+          columnOrder
+        );
+        expect(acc(row)).to.equal(expectedReturnedValues[i]);
+      }
+    });
+
+    // This happens for mini chart of an axis chart that has two dims, one measure, qLeft is 1, and column order is undefined
+    it('should return correct index when object has two dimensions and one measure, qLeft is 1, and column order is empty', () => {
+      const row = ['b', 200, 100];
+      localCache.fields = [{}, {}, {}, {}];
+      const columnOrder = [];
+      const expectedReturnedValues = ['b', 200, 100];
+      for (let i = 0; i <= 2; i++) {
+        const f = localCache.fields[i + 1];
+        const acc = getFieldAccessor(
+          f,
+          {
+            qArea: { qLeft: 1 },
+          },
+          { cache: localCache },
+          columnOrder
+        );
+        expect(acc(row)).to.equal(expectedReturnedValues[i]);
+      }
     });
   });
 });

--- a/plugins/q/src/data/extractor-s.js
+++ b/plugins/q/src/data/extractor-s.js
@@ -25,14 +25,14 @@ export function getFieldAccessor(field, page, deps, columnOrder) {
     }
   }
 
-  fieldIdx -= page.qArea.qLeft;
-
   if (Array.isArray(columnOrder) && columnOrder.some((el, i) => el !== i)) {
     const correctIndex = columnOrder.indexOf(fieldIdx);
     if (correctIndex !== -1) {
       fieldIdx = correctIndex;
     }
   }
+
+  fieldIdx -= page.qArea.qLeft;
 
   if (fieldIdx < 0 || fieldIdx >= page.qArea.qWidth) {
     // throw new Error('Field out of range');

--- a/plugins/q/src/data/extractor-s.js
+++ b/plugins/q/src/data/extractor-s.js
@@ -2,7 +2,7 @@
 
 import extend from 'extend';
 
-export function getFieldAccessor(field, page, deps) {
+export function getFieldAccessor(field, page, deps, columnOrder) {
   if (!field) {
     return -1;
   }
@@ -26,6 +26,14 @@ export function getFieldAccessor(field, page, deps) {
   }
 
   fieldIdx -= page.qArea.qLeft;
+
+  if (Array.isArray(columnOrder) && columnOrder.some((el, i) => el !== i)) {
+    const correctIndex = columnOrder.indexOf(fieldIdx);
+    if (correctIndex !== -1) {
+      fieldIdx = correctIndex;
+    }
+  }
+
   if (fieldIdx < 0 || fieldIdx >= page.qArea.qWidth) {
     // throw new Error('Field out of range');
     return -1;
@@ -78,10 +86,10 @@ function datumExtract(propCfg, cell, { key }) {
   return datum;
 }
 
-function cellToValue({ cache, f, mainCell, p, prop, page, rowIdx, row, sourceKey, target, targetProp }) {
+function cellToValue({ cache, f, mainCell, p, prop, page, rowIdx, row, sourceKey, target, targetProp, columnOrder }) {
   let propCell = mainCell;
   if (p.field && p.field !== f) {
-    const propCellFn = getFieldAccessor(p.field, page, { cache });
+    const propCellFn = getFieldAccessor(p.field, page, { cache }, columnOrder);
     if (propCellFn === -1) {
       return;
     }
@@ -108,7 +116,7 @@ export default function extract(config, dataset, cache, util) {
       const items = [];
 
       for (let j = 0; j < cube.qDataPages.length; j++) {
-        const fn = getFieldAccessor(f, cube.qDataPages[j], { cache });
+        const fn = getFieldAccessor(f, cube.qDataPages[j], { cache }, cube.qColumnOrder);
         if (fn === -1) {
           continue;
         }
@@ -145,6 +153,7 @@ export default function extract(config, dataset, cache, util) {
                 sourceKey,
                 target: p.fields ? ret[propsArr[l]] : ret,
                 targetProp: p.fields ? m : propsArr[l],
+                columnOrder: cube.qColumnOrder,
               });
             }
 


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

When `qColumnOrder` for chart with data in S-mode in not an empty array, the order of `qDataPages` is influenced by `qColumnOrder` and this should be taking into account when reading rows.
