### PR TITLE
refactor: lower device Pixel Ratio on iPhone

### DIFF
--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -23,8 +23,13 @@ function toLineDash(p) {
   return [];
 }
 
+const isIPhone = typeof navigator === `undefined` ? false : /iPhone/.test(navigator.userAgent) && !window.MSStream;
+
 function dpiScale(g) {
-  const dpr = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+  const dpr =
+    typeof window === 'undefined'
+      ? 1
+      : (isIPhone ? Math.min(2, window.devicePixelRatio) : window.devicePixelRatio) || 1;
   const backingStorePixelRatio =
     g.webkitBackingStorePixelRatio ||
     g.mozBackingStorePixelRatio ||


### PR DESCRIPTION
Lower the device Pixel Ratio to 2 on iPhone to reduce canvas sizes. We have some issues when a sheet has many charts, it can cause crash on iPhone due to large canvas size.
When reduce the device Pixel Ratio, the text will become blurry, but the result looks acceptable. Compare to before fix, canvas size can be reduce in half size.

Before:
![IMG_0022](https://user-images.githubusercontent.com/25456307/237026146-1074f542-bbe7-45cf-8e7d-50d5b6baea0b.PNG)

After
![IMG_0018](https://user-images.githubusercontent.com/25456307/237026170-5452286e-32ff-4a97-8f91-84e71dcdc266.PNG)


Before
![IMG_0025](https://user-images.githubusercontent.com/25456307/237026407-c0b740a3-7f29-4fd4-b374-80a0ff60d8f8.PNG)

After
![IMG_0021](https://user-images.githubusercontent.com/25456307/237026459-2ff693ce-d381-404d-b822-0ebf306f5e53.PNG)

**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
