### PR TITLE
fix: show the tooltip inside the object when its takes up the whole screen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/picassojs
-      - browser-tools/install-chrome
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          # TODO Remove when following issue is fixed: https://github.com/CircleCI-Public/browser-tools-orb/issues/90
+          chrome-version: 116.0.5845.96
       - browser-tools/install-chromedriver
       - run: yarn run test:integration:ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.4.3
 
 aliases:
   - &restore_yarn_cache

--- a/packages/picasso.js/src/web/components/tooltip/__tests__/placement.spec.js
+++ b/packages/picasso.js/src/web/components/tooltip/__tests__/placement.spec.js
@@ -427,6 +427,67 @@ describe('placement', () => {
       });
     });
 
+    it('dock - inside dock', () => {
+      // Unable to fit in the existing dock positions, as the current target is too big
+      // should choose inside to dock
+      global.window.innerWidth = 1451;
+      global.window.innerHeight = 1160;
+      componentMock.rect.width = 1410;
+      componentMock.rect.height = 978;
+      context.state = {
+        activeNodes: [
+          {
+            bounds: {
+              x: 2,
+              y: 1,
+              width: 1406,
+              height: 975,
+            },
+            key: 'aKey',
+          },
+        ],
+        pointer: {
+          x: 271,
+          y: 167,
+          dx: 271,
+          dy: 167,
+          targetBounds: { x: 0, y: 0, width: 1451, height: 1160 },
+        },
+        targetElement: {
+          getBoundingClientRect: () => ({
+            x: 0,
+            y: 0,
+            width: 1451,
+            height: 1160,
+          }),
+        },
+      };
+      context.props.placement = {
+        type: 'bounds',
+        offset: 8,
+        dock: 'inside',
+      };
+      size = {
+        width: 368.03,
+        height: 408,
+      };
+      const r = placement(size, context);
+
+      expect(r).to.deep.equal({
+        computedArrowStyle: {
+          borderWidth: '0px',
+          left: '0px',
+          top: '0px',
+        },
+        computedTooltipStyle: {
+          left: '976px',
+          top: '655.5px',
+          transform: 'translate(-50%, -50%)',
+        },
+        dock: 'inside',
+      });
+    });
+
     describe('slice', () => {
       it('dock - auto, bottom', () => {
         size.width = 10;

--- a/packages/picasso.js/src/web/components/tooltip/placement.js
+++ b/packages/picasso.js/src/web/components/tooltip/placement.js
@@ -6,6 +6,7 @@ function getDockTransform(offset = 0) {
     right: `translate(${offset}px, -50%)`,
     top: `translate(-50%, -100%) translateY(${-offset}px)`,
     bottom: `translate(-50%, ${offset}px)`,
+    inside: `translate(-50%, -50%) translateX(${-offset}px) translateY(${-offset}px)`,
   };
 }
 
@@ -15,6 +16,7 @@ function getDockOffset(width, height, offset = 0) {
     right: { x: offset, y: -height / 2 },
     top: { x: -width / 2, y: -height - offset },
     bottom: { x: -width / 2, y: offset },
+    inside: { x: -width / 2, y: -height / 2 },
   };
 }
 
@@ -39,6 +41,11 @@ function getComputedArrowStyle(offset) {
       left: `calc(50% - ${offset}px)`,
       top: `${-offset * 2}px`,
       borderWidth: `${offset}px`,
+    },
+    inside: {
+      left: '0px',
+      top: '0px',
+      borderWidth: '0px',
     },
   };
 }
@@ -94,6 +101,7 @@ function alignToBounds({ resources, nodes, pointer, width: elmWidth, height: elm
     right: { x: x + width, y: y + height / 2 },
     top: { x: x + width / 2, y },
     bottom: { x: x + width / 2, y: y + height },
+    inside: { x: x + width / 2, y: y + height / 2 },
   };
 
   // Check if explicit dock
@@ -116,7 +124,7 @@ function alignToBounds({ resources, nodes, pointer, width: elmWidth, height: elm
     height: options.area === 'target' ? targetBounds.height : window.innerHeight,
   };
   const dockOffsets = getDockOffset(elmWidth, elmHeight, options.offset);
-  const dockOrder = ['top', 'left', 'right', 'bottom'];
+  const dockOrder = ['top', 'left', 'right', 'bottom', 'inside'];
 
   for (let i = 0; i < dockOrder.length; i += 1) {
     const dock = dockOrder[i];

--- a/packages/picasso.js/src/web/components/tooltip/placement.js
+++ b/packages/picasso.js/src/web/components/tooltip/placement.js
@@ -6,7 +6,7 @@ function getDockTransform(offset = 0) {
     right: `translate(${offset}px, -50%)`,
     top: `translate(-50%, -100%) translateY(${-offset}px)`,
     bottom: `translate(-50%, ${offset}px)`,
-    inside: `translate(-50%, -50%) translateX(${-offset}px) translateY(${-offset}px)`,
+    inside: `translate(-50%, -50%)`,
   };
 }
 


### PR DESCRIPTION
This is a special case for Treemaps as there as a branch could cover the whole area available and tooltip cannot be then docked in the available positions - top, bottom, left & right.

So a new dock position is added as "ínside" where the tooltip is shown in the center of the object. Also I have removed the arrow used to dock on particular positions as we are already in the object now.

Attached is a screenshot : 

![Screenshot 2023-08-28 at 09 21 33](https://github.com/qlik-oss/picasso.js/assets/30860406/1fceb0a9-3ad5-4109-bfd6-4bc1312a26cb)
