### PR TITLE
fix: downgrade preact

### DIFF
--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -49,7 +49,7 @@
     "hammerjs": "2.0.8",
     "node-event-emitter": "0.0.1",
     "path2d-polyfill": "1.2.3",
-    "preact": "10.19.3",
+    "preact": "10.13.2",
     "test-utils": "^2.2.5"
   },
   "gitHead": "b6ca9d1ed11709ec18f227b7b7077ce34d61857b"

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["d3-shape"],
+      "matchPackageNames": ["d3-shape", "preact"],
       "enabled": false
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -13013,10 +13013,10 @@ postcss@^8.4.21:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-preact@10.19.3:
-  version "10.19.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.19.3.tgz#7a7107ed2598a60676c943709ea3efb8aaafa899"
-  integrity sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==
+preact@10.13.2:
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
+  integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
When using the latest version of `preact`, the tooltip component stopped working properly. It would only render once when hovering a node. The second time a node was hovered, the tooltip would not appear. Downgrading `preact` fixes that issue.