### PR TITLE
fix: doesn't display all the labels properly

### DIFF
--- a/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/rows.js
@@ -125,12 +125,11 @@ export function rows({ settings, chart, nodes, renderer, style }, placer = place
       continue;
     }
 
-    let totalHeight = 0;
+    let measuredHeight = 0;
     let measurements = [];
     let texts = [];
 
-    let maxHeight = type === 'circle' ? 2 * bounds.r * CIRCLE_FACTOR : bounds.height;
-    totalHeight += rowSettings.padding;
+    let boundHeight = type === 'circle' ? 2 * bounds.r * CIRCLE_FACTOR : bounds.height;
     let j;
     for (j = 0; j < labelSettings.length; j++) {
       let lblStngs = labelSettings[j];
@@ -140,8 +139,8 @@ export function rows({ settings, chart, nodes, renderer, style }, placer = place
       labelStruct.fontSize = `${lblStngs.fontSize}px`;
       labelStruct.text = text;
       let measured = renderer.measureText(labelStruct);
-      totalHeight += measured.height + lblStngs.padding;
-      if (totalHeight > maxHeight) {
+      measuredHeight += measured.height + lblStngs.padding;
+      if (measuredHeight > boundHeight) {
         break;
       }
       texts.push(text);
@@ -149,7 +148,7 @@ export function rows({ settings, chart, nodes, renderer, style }, placer = place
     }
 
     const labelCount = j;
-    const wiggleHeight = Math.max(0, maxHeight - totalHeight);
+    const wiggleHeight = Math.max(0, boundHeight - measuredHeight);
     let currentY;
     if (type === 'circle') {
       currentY = bounds.cy - bounds.r * CIRCLE_FACTOR;


### PR DESCRIPTION
**Issue:**
Some of labels are missing

**Solution:**
The labels are displayed based on a comparison between `measuredHeight` and `boundHeight` of each node, where the measured height is calculated regarding the label font style and the text + row's padding value. The result is very depends on the chart size, in smaller sizes the label might not be shown due to the `measureHeight` larger value than `boundHeight`.
In this case, there was a redundancy that resulted the row's padding value to be added twice, so for some nodes, it affected the height comparison outcome which in turn caused the label not to be shown.

An example of the result on a chart: 

**Before fixing the issue: **
![Before fix](https://github.com/qlik-oss/picasso.js/assets/20701546/9f6cbde1-53a0-42a5-8253-f2ab7014aa96)

**After fixing the issue: **
![image](https://github.com/qlik-oss/picasso.js/assets/20701546/f5a6f4ea-24ac-42bb-95a3-42928f015a72)
