### PR TITLE
fix: correct ellipsis property extraction logic

### DIFF
--- a/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
@@ -2,8 +2,8 @@ import { ELLIPSIS_CHAR } from './text-const';
 
 export default function ellipsText(label, measureText) {
   // eslint-disable-line import/prefer-default-export
-  const fontSize = label['font-family'] || label.fontFamily;
-  const fontFamily = label['font-size'] || label.fontSize;
+  const fontFamily = label['font-family'] || label.fontFamily;
+  const fontSize = label['font-size'] || label.fontSize;
   const text = typeof label.text === 'string' ? label.text : `${label.text}`;
   const { maxWidth } = label;
   if (maxWidth === undefined) {

--- a/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
@@ -5,13 +5,13 @@ export default function ellipsText(
   measureText
 ) {
   // eslint-disable-line import/prefer-default-export
-  const finalFontSize = fontSizeKebab || fontSize;
-  const finalFontFamily = fontFamilyKebab || fontFamily;
+  fontSize = fontSizeKebab || fontSize;
+  fontFamily = fontFamilyKebab || fontFamily;
   text = typeof text === 'string' ? text : `${text}`;
   if (maxWidth === undefined) {
     return text;
   }
-  let textWidth = measureText({ text, finalFontSize, finalFontFamily }).width;
+  let textWidth = measureText({ text, fontSize, fontFamily }).width;
   if (textWidth <= maxWidth) {
     return text;
   }
@@ -21,7 +21,7 @@ export default function ellipsText(
   while (min <= max) {
     let reduceIndex = Math.floor((min + max) / 2);
     let reduceText = text.substr(0, reduceIndex) + ELLIPSIS_CHAR;
-    textWidth = measureText({ text: reduceText, finalFontSize, finalFontFamily }).width;
+    textWidth = measureText({ text: reduceText, fontSize, fontFamily }).width;
     if (textWidth <= maxWidth) {
       min = reduceIndex + 1;
     } else {

--- a/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
@@ -1,13 +1,11 @@
 import { ELLIPSIS_CHAR } from './text-const';
 
-export default function ellipsText(
-  { text, 'font-size': fontSizeKebab, 'font-family': fontFamilyKebab, fontSize, fontFamily, maxWidth },
-  measureText
-) {
+export default function ellipsText(label, measureText) {
   // eslint-disable-line import/prefer-default-export
-  fontSize = fontSizeKebab || fontSize;
-  fontFamily = fontFamilyKebab || fontFamily;
-  text = typeof text === 'string' ? text : `${text}`;
+  const fontSize = label['font-family'] || label.fontFamily;
+  const fontFamily = label['font-size'] || label.fontSize;
+  const text = typeof label.text === 'string' ? label.text : `${label.text}`;
+  const { maxWidth } = label;
   if (maxWidth === undefined) {
     return text;
   }

--- a/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
+++ b/packages/picasso.js/src/web/text-manipulation/text-ellipsis.js
@@ -1,12 +1,17 @@
 import { ELLIPSIS_CHAR } from './text-const';
 
-export default function ellipsText({ text, 'font-size': fontSize, 'font-family': fontFamily, maxWidth }, measureText) {
+export default function ellipsText(
+  { text, 'font-size': fontSizeKebab, 'font-family': fontFamilyKebab, fontSize, fontFamily, maxWidth },
+  measureText
+) {
   // eslint-disable-line import/prefer-default-export
+  const finalFontSize = fontSizeKebab || fontSize;
+  const finalFontFamily = fontFamilyKebab || fontFamily;
   text = typeof text === 'string' ? text : `${text}`;
   if (maxWidth === undefined) {
     return text;
   }
-  let textWidth = measureText({ text, fontSize, fontFamily }).width;
+  let textWidth = measureText({ text, finalFontSize, finalFontFamily }).width;
   if (textWidth <= maxWidth) {
     return text;
   }
@@ -16,7 +21,7 @@ export default function ellipsText({ text, 'font-size': fontSize, 'font-family':
   while (min <= max) {
     let reduceIndex = Math.floor((min + max) / 2);
     let reduceText = text.substr(0, reduceIndex) + ELLIPSIS_CHAR;
-    textWidth = measureText({ text: reduceText, fontSize, fontFamily }).width;
+    textWidth = measureText({ text: reduceText, finalFontSize, finalFontFamily }).width;
     if (textWidth <= maxWidth) {
       min = reduceIndex + 1;
     } else {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
Problem description: 
The text-ellipsis function expects text-related properties such as font-size and font-family to be in kebab-case (e.g., font-size, font-family). However, the application sometimes (for example in rows.js) provides these properties in camelCase (e.g., fontSize, fontFamily), leading to errors in text measurement and rendering.

This PR resolves the issue by normalizing the font property names. A fallback mechanism has been added to allow the function to handle both kebab-case (preferred) and camelCase properties, ensuring proper text measurement and ellipsis functionality.

Before: 

https://github.com/user-attachments/assets/7033c5ad-fde7-4d95-a0a7-b1d996c1fe37

After: 

https://github.com/user-attachments/assets/9163521c-7067-498d-81f8-ad945a55811e


