### PR TITLE
fix: animations improve tweening formatted label

### DIFF
--- a/packages/picasso.js/src/core/component/animations/__tests__/adjust-tweened-node.spec.js
+++ b/packages/picasso.js/src/core/component/animations/__tests__/adjust-tweened-node.spec.js
@@ -1,0 +1,32 @@
+import adjustTweenedNodes from '../adjust-tweened-nodes';
+
+describe('adjustTweenedNodes', () => {
+  const formatter = sinon.stub();
+  formatter.withArgs('si').returns((value) => `${value / 1000000}M`);
+
+  it('should format text nodes correctly', () => {
+    const tweenedNodes = [
+      { type: 'text', data: { value: '1234000', formatterKey: 'si' } },
+      { type: 'circle', data: { value: '56780', formatterKey: 'si' } },
+    ];
+
+    adjustTweenedNodes({ tweenedNodes, formatter });
+
+    expect(tweenedNodes[0].text).to.equal('1.234M');
+    expect(tweenedNodes[1].text).to.equal(undefined);
+  });
+
+  it('should not modify nodes without data or value or formatterKey', () => {
+    const tweenedNodes = [
+      { type: 'text', data: null },
+      { type: 'text', data: { value: '1234000' } },
+      { type: 'text', data: { formatterKey: 'si' } },
+    ];
+
+    adjustTweenedNodes({ tweenedNodes, formatter });
+
+    expect(tweenedNodes[0].text).to.equal(undefined);
+    expect(tweenedNodes[1].text).to.equal(undefined);
+    expect(tweenedNodes[2].text).to.equal(undefined);
+  });
+});

--- a/packages/picasso.js/src/core/component/animations/__tests__/adjust-tweened-node.spec.js
+++ b/packages/picasso.js/src/core/component/animations/__tests__/adjust-tweened-node.spec.js
@@ -6,8 +6,8 @@ describe('adjustTweenedNodes', () => {
 
   it('should format text nodes correctly', () => {
     const tweenedNodes = [
-      { type: 'text', data: { value: '1234000', formatterKey: 'si' } },
-      { type: 'circle', data: { value: '56780', formatterKey: 'si' } },
+      { type: 'text', data: { value: '1234000', formatter: 'si' } },
+      { type: 'circle', data: { value: '56780', formatter: 'si' } },
     ];
 
     adjustTweenedNodes({ tweenedNodes, formatter });
@@ -16,11 +16,11 @@ describe('adjustTweenedNodes', () => {
     expect(tweenedNodes[1].text).to.equal(undefined);
   });
 
-  it('should not modify nodes without data or value or formatterKey', () => {
+  it('should not modify nodes without data or value or formatter', () => {
     const tweenedNodes = [
       { type: 'text', data: null },
       { type: 'text', data: { value: '1234000' } },
-      { type: 'text', data: { formatterKey: 'si' } },
+      { type: 'text', data: { formatter: 'si' } },
     ];
 
     adjustTweenedNodes({ tweenedNodes, formatter });

--- a/packages/picasso.js/src/core/component/animations/adjust-tweened-nodes.js
+++ b/packages/picasso.js/src/core/component/animations/adjust-tweened-nodes.js
@@ -1,0 +1,9 @@
+export default function adjustTweenedNodes({ tweenedNodes, formatter }) {
+  tweenedNodes.forEach((node) => {
+    const { type, data } = node;
+    if (type === 'text' && data && data.value && data.formatterKey) {
+      const { value, formatterKey } = data;
+      node.text = formatter(formatterKey)(value);
+    }
+  });
+}

--- a/packages/picasso.js/src/core/component/animations/adjust-tweened-nodes.js
+++ b/packages/picasso.js/src/core/component/animations/adjust-tweened-nodes.js
@@ -1,9 +1,8 @@
 export default function adjustTweenedNodes({ tweenedNodes, formatter }) {
   tweenedNodes.forEach((node) => {
     const { type, data } = node;
-    if (type === 'text' && data && data.value && data.formatterKey) {
-      const { value, formatterKey } = data;
-      node.text = formatter(formatterKey)(value);
+    if (type === 'text' && data && data.value && data.formatter) {
+      node.text = formatter(data.formatter)(data.value);
     }
   });
 }

--- a/packages/picasso.js/src/core/component/component-factory.js
+++ b/packages/picasso.js/src/core/component/component-factory.js
@@ -545,7 +545,7 @@ function componentFactory(definition, context = {}) {
           old: currentNodes,
           current: nodes,
         },
-        { renderer: rend },
+        { renderer: rend, formatter: chart.formatter },
         animations,
         chart.storage
       );

--- a/packages/picasso.js/src/core/component/tween.js
+++ b/packages/picasso.js/src/core/component/tween.js
@@ -1,6 +1,7 @@
 import extend from 'extend';
 import { easeCubic, easeCubicIn, easeCubicOut } from 'd3-ease';
 import interpolateObject from './interpolate-object';
+import adjustTweenedNodes from './animations/adjust-tweened-nodes';
 
 /* globals window */
 
@@ -26,9 +27,8 @@ export function findCommonPointsFromTwoLines(oldLine, currentLine) {
   return { old: oldCommonPoints, current: currentCommonPoints };
 }
 
-export default function tween({ old, current }, { renderer }, config, chartStorage) {
+export default function tween({ old, current }, { renderer, formatter }, config, chartStorage) {
   let ticker;
-  // let staticNodes = [];
   let toBeUpdated = [];
   let entered = { nodes: [], ips: [] };
   let exited = { nodes: [], ips: [] };
@@ -131,13 +131,11 @@ export default function tween({ old, current }, { renderer }, config, chartStora
       let t = (Date.now() - currentStage.started) / currentStage.duration;
       let currentNodes = [];
       let tweenedNodes = currentStage.tweens.map((ip) => ip(currentStage.easing(Math.min(1, t))));
+      adjustTweenedNodes({ tweenedNodes, formatter });
       currentNodes.push(...tweenedNodes);
       currentNodes.push(...currentStage.nodes);
-      // currentNodes.push(...staticNodes);
-      // stages.slice(1).forEach(stage => currentNodes.push(...stage.nodes));
       renderer.render(currentNodes);
       if (t >= 1) {
-        // staticNodes.push(...currentStage.nodes);
         stages.shift();
         const { isInit, shouldBeRemoved } = chartStorage.getValue('animations.updatingStageMeta');
         if (!stages.length) {


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

### Description

**The issue:**

Considering animating a formatted numerical label, say from "4.5M" to "123k". The out-of-the-box d3 string interpolator produces wrong tweened results: super long strings with questionable values.

**The fix:**
  - Take advantage of the linkData properties to pass data into label nodes (the nodes are defined when creating picasso-definition for a chart)
  - Replace the wrongly interpolated text with the formatted tweened value from linkData. 
