### PR TITLE
feat: option to disable screenreader for axis

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -1703,6 +1703,12 @@
               "defaultValue": "auto",
               "type": "string"
             },
+            "disableScreenReader": {
+              "description": "If set to `true`, the axis will be hidden from screen readers.",
+              "optional": true,
+              "defaultValue": false,
+              "type": "boolean"
+            },
             "labels": {
               "kind": "object",
               "entries": {
@@ -1833,6 +1839,12 @@
               "optional": true,
               "defaultValue": "auto",
               "type": "string"
+            },
+            "disableScreenReader": {
+              "description": "If set to `true`, the axis will be hidden from screen readers.",
+              "optional": true,
+              "defaultValue": false,
+              "type": "boolean"
             },
             "labels": {
               "kind": "object",

--- a/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-default-settings.js
@@ -116,6 +116,10 @@ const DEFAULT_DISCRETE_SETTINGS = {
   /** Set the anchoring point of the axis. Available options are `auto/left/right/bottom/top`. In `auto` the axis determines the best option. The options are restricted based on the axis orientation, a vertical axis may only anchor on `left` or `right`
    * @type {string=} */
   align: 'auto',
+  /**
+   * If set to `true`, the axis will be hidden from screen readers.
+   * @type {boolean=} */
+  disableScreenReader: false,
 };
 
 /**
@@ -216,6 +220,10 @@ const DEFAULT_CONTINUOUS_SETTINGS = {
   /** Set the anchoring point of the axis. Available options are `auto/left/right/bottom/top`. In `auto` the axis determines the best option. The options are restricted based on the axis orientation, a vertical axis may only anchor on `left` or `right`
    * @type {string=} */
   align: 'auto',
+  /**
+   * If set to `true`, the axis will be hidden from screen readers.
+   * @type {boolean=} */
+  disableScreenReader: false,
 };
 
 export { DEFAULT_DISCRETE_SETTINGS, DEFAULT_CONTINUOUS_SETTINGS };

--- a/packages/picasso.js/src/core/chart-components/axis/axis.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis.js
@@ -175,9 +175,11 @@ const axisComponent = {
   },
   beforeRender() {
     const { scale, formatter } = this;
-
+    if (this.state.settings.disableScreenReader) {
+      const element = this.renderer.element();
+      element.setAttribute('aria-hidden', 'true');
+    }
     const distance = this.state.isHorizontal ? this.state.innerRect.width : this.state.innerRect.height;
-
     this.state.pxScale = scaleWithSize(scale, distance);
     this.state.ticks = this.state.pxScale
       .ticks({
@@ -188,7 +190,6 @@ const axisComponent = {
   },
   render() {
     const { state } = this;
-
     const nodes = [];
     nodes.push(
       ...this.state.concreteNodeBuilder.build({

--- a/packages/picasso.js/types/index.d.ts
+++ b/packages/picasso.js/types/index.d.ts
@@ -560,6 +560,7 @@ declare namespace picassojs {
         type ContinuousSettings = {
             arc?: picassojs.ArcSettings;
             align?: string;
+            disableScreenReader?: boolean;
             labels: {
                 align?: number;
                 filterOverlapping?: boolean;
@@ -588,6 +589,7 @@ declare namespace picassojs {
 
         type DiscreteSettings = {
             align?: string;
+            disableScreenReader?: boolean;
             labels: {
                 align?: number;
                 filterOverlapping?: boolean;


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

**Summary**
This PR implements the option to hide the axis-component from screen readers. If the user sets "disableScreenReader:true" in axis-settings, the axis wont be detected by a screen reader. 

disableScreenReader is not set in the axis component, so it defaults to false. The screen reader has access to the axis and reads the axis labels: 

https://github.com/user-attachments/assets/723b9faa-e57a-441e-a66d-22676dc5edb7

disableScreenReader is set to true in the axis component. The screen reader does not read the axis labels. 


https://github.com/user-attachments/assets/a342e6ba-88ef-4a9a-85cd-78937ebeddf3

