### PR TITLE
feat: support raw input

### DIFF
--- a/packages/picasso.js/src/core/data/extractor.js
+++ b/packages/picasso.js/src/core/data/extractor.js
@@ -32,7 +32,9 @@ export default function extract(dataConfig, data = {}, opts = {}) {
         extracted.root = source.hierarchy ? source.hierarchy(dataConfig.hierarchy) : null;
         extracted.fields = source.fields();
       } else if (dataConfig.items) {
-        extracted.items = dataConfig.items.map((v) => ({ value: valueFn(v), label: String(labelFn(v)) }));
+        extracted.items = dataConfig.skipNormalize
+          ? dataConfig.items
+          : dataConfig.items.map((v) => ({ value: valueFn(v), label: String(labelFn(v)) }));
       } else if (dataConfig.extract) {
         const extractionsConfigs = Array.isArray(dataConfig.extract) ? dataConfig.extract : [dataConfig.extract];
         extracted.items = [];


### PR DESCRIPTION
Currently if we use an array as data input like the following  
```
data: [
    { x: 'Jan', y: 365, lineId: 0 },
    { x: 'Feb', y: 372, lineId: 0 },
    { x: 'Jun', y: 380, lineId: 1 },
    { x: 'Sep', y: 370, lineId: 1 },
  ]
```
Then picasso will convert this to:
```
[
    { value: { x: 'Jan', y: 365, lineId: 0 }, label: '[object Object]' },
    { value: { x: 'Feb', y: 372, lineId: 0 }, label: '[object Object]' },
    { value: { x: 'Jun', y: 380, lineId: 1 }, label: '[object Object]' },
    { value: { x: 'Sep', y: 370, lineId: 1 }, label: '[object Object]' },
  ]
```

To keep the raw input we input as the following:
```
data: {
    items: [
      { x: 'Jan', y: 365, lineId: 0 },
      { x: 'Feb', y: 372, lineId: 0 },
      { x: 'Jun', y: 380, lineId: 1 },
      { x: 'Sep', y: 370, lineId: 1 },
   ],
   skipNormalize: true,
}  
```
  There is a need to keep raw input as it is and this PR is to support this need.
**Checklist**

- [ ] tests added
- [ ] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated
