### PR TITLE
refactor(ref-line): use documented properties

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -4307,6 +4307,12 @@
               "defaultValue": "ComponentRefLine~LineLabelBackground",
               "type": "#/definitions/ComponentRefLine/definitions/LineLabelBackground"
             },
+            "show": {
+              "description": "Show label",
+              "optional": true,
+              "defaultValue": true,
+              "type": "boolean"
+            },
             "showValue": {
               "description": "Show value label",
               "optional": true,

--- a/packages/picasso.js/src/core/chart-components/ref-line/__tests__/refline.spec.js
+++ b/packages/picasso.js/src/core/chart-components/ref-line/__tests__/refline.spec.js
@@ -370,6 +370,66 @@ describe('reference lines', () => {
     ]);
   });
 
+  it('should render basic line without label on Y without scale', () => {
+    const config = {
+      shapeFn,
+      lines: {
+        y: [
+          {
+            value: 0.3,
+            line: {
+              stroke: 'green',
+              strokeWidth: 2,
+            },
+            label: {
+              text: 'asdftest',
+              show: false,
+              padding: 10,
+              fontSize: '20px',
+              vAlign: 1,
+              align: 0,
+            },
+          },
+        ],
+      },
+    };
+
+    const xScale = (v) => v;
+    xScale.min = () => 0;
+    xScale.max = () => 1;
+    chart.scale.withArgs({ scale: 'x' }).returns(xScale);
+
+    const yScale = (v) => v;
+    yScale.min = () => 0;
+    yScale.max = () => 1;
+    chart.scale.withArgs({ scale: 'y' }).returns(yScale);
+
+    createAndRenderComponent({
+      inner: {
+        x: 37,
+        y: 0,
+        width: 870,
+        height: 813,
+      },
+      config,
+    });
+
+    expect(rendererOutput).to.deep.equal([
+      {
+        flipXY: true,
+        stroke: 'green',
+        strokeDasharray: undefined,
+        strokeWidth: 2,
+        type: 'line',
+        value: 0.3,
+        x1: 0,
+        x2: 870,
+        y1: 244,
+        y2: 244,
+      },
+    ]);
+  });
+
   it('should render slope line with positive slope and no label on Y scale', () => {
     const config = {
       shapeFn,
@@ -381,10 +441,12 @@ describe('reference lines', () => {
               stroke: 'green',
               strokeWidth: 2,
             },
+            label: {
+              text: 'Threshold value',
+              show: false,
+              showValue: false,
+            },
             slope: 0.25,
-            showValue: false,
-            showLabel: false,
-            refLineLabel: 'Threshold value',
           },
         ],
         style: {
@@ -443,10 +505,12 @@ describe('reference lines', () => {
               stroke: 'green',
               strokeWidth: 2,
             },
+            label: {
+              text: 'Threshold value',
+              show: true,
+              showValue: true,
+            },
             slope: 0.25,
-            showValue: true,
-            showLabel: true,
-            refLineLabel: 'Threshold value',
           },
         ],
         style: {
@@ -519,10 +583,12 @@ describe('reference lines', () => {
               stroke: 'green',
               strokeWidth: 2,
             },
+            label: {
+              text: 'Threshold value',
+              show: true,
+              showValue: true,
+            },
             slope: -0.5,
-            showValue: true,
-            showLabel: true,
-            refLineLabel: 'Threshold value',
           },
         ],
         style: {
@@ -595,11 +661,13 @@ describe('reference lines', () => {
               stroke: 'green',
               strokeWidth: 2,
             },
+            label: {
+              text: 'Colored',
+              stroke: '#ffffff',
+              show: true,
+              showValue: false,
+            },
             slope: 0.5,
-            showValue: false,
-            showLabel: true,
-            refLineLabel: 'Colored',
-            labelStroke: '#ffffff',
           },
         ],
         style: {
@@ -683,10 +751,12 @@ describe('reference lines', () => {
               stroke: 'green',
               strokeWidth: 2,
             },
+            label: {
+              text: 'Threshold value',
+              show: true,
+              showValue: true,
+            },
             slope: 1,
-            showValue: true,
-            showLabel: true,
-            refLineLabel: 'Threshold value',
           },
         ],
         style: {
@@ -730,6 +800,7 @@ describe('reference lines', () => {
         opacity: 1,
         data: [
           {
+            label: 'Threshold value',
             value: 3,
           },
         ],

--- a/packages/picasso.js/src/core/chart-components/ref-line/lines-and-labels.js
+++ b/packages/picasso.js/src/core/chart-components/ref-line/lines-and-labels.js
@@ -190,7 +190,7 @@ export function createLineWithLabel({ chart, blueprint, renderer, p, settings, i
     });
   }
 
-  if (p.label) {
+  if (p.label && p.label.show !== false && !(slopeLine?.slope && slopeLine.slope !== 0)) {
     const item = extend(true, refLabelDefaultSettings(), settings.style.label || {}, { fill: style.stroke }, p.label);
     let formatter;
     let measuredValue = {
@@ -329,18 +329,18 @@ export function createLineWithLabel({ chart, blueprint, renderer, p, settings, i
     items.push(line);
   }
 
-  if (slopeLine?.slope !== 0 && (slopeLine?.showLabel || slopeLine?.showValue)) {
+  if (slopeLine && slopeLine.slope !== 0 && (slopeLine.label?.show !== false || slopeLine.label?.showValue !== false)) {
     // create data area labels for slope line
     let valueString;
     let labelBackground;
     const maxLabelWidth = 120;
 
-    let slopeLabelText = slopeLine.showLabel ? slopeLine.refLineLabel : '';
-    if (slopeLine.showValue) {
+    let slopeLabelText = slopeLine.label?.show !== false ? slopeLine.label?.text : '';
+    if (slopeLine.label?.showValue !== false) {
       const formatter = getFormatter(p, chart);
       const formattedValue = formatter ? formatter(slopeLine.value) : slopeLine.value;
       valueString = `(${slopeLine.slope}x + ${formattedValue})`;
-      slopeLabelText += slopeLine.refLineLabel ? ` ${valueString}` : valueString;
+      slopeLabelText += slopeLine.label?.text ? ` ${valueString}` : valueString;
     }
     if (slopeLabelText.length > 1) {
       // Measure the label text
@@ -358,7 +358,7 @@ export function createLineWithLabel({ chart, blueprint, renderer, p, settings, i
       const x = calculateX(slopeLine, line, maxX, measured, blueprint, slopeStyle);
       const y = Math.min(line.y1, line.y2);
       // if coloredBackground is true make a rect
-      if (slopeLine.labelStroke) {
+      if (slopeLine.label?.stroke) {
         labelBackground = {
           type: 'rect',
           x: slopeLine.isRtl ? Math.max(x, xPadding) - 2 : Math.max(x, xPadding) + 2,
@@ -374,7 +374,7 @@ export function createLineWithLabel({ chart, blueprint, renderer, p, settings, i
       const slopeLabel = {
         type: 'text',
         text: slopeLabelText,
-        fill: slopeLine.labelStroke ?? style.stroke,
+        fill: slopeLine.label?.stroke ?? style.stroke,
         opacity: slopeStyle.opacity,
         fontFamily: slopeStyle.fontFamily,
         fontSize: slopeStyle.fontSize,

--- a/packages/picasso.js/src/core/chart-components/ref-line/refline.js
+++ b/packages/picasso.js/src/core/chart-components/ref-line/refline.js
@@ -126,6 +126,7 @@ function removeDuplication(intersections) {
  * @property {number} [maxWidth=1] - The maximum relative width to the width of the rendering area (see maxWidthPx as well)
  * @property {number} [maxWidthPx=9999] - The maximum width in pixels. Labels will be rendered with the maximum size of the smallest value of maxWidth and maxWidthPx size, so you may specify maxWidth 0.8 but maxWidthPx 100 and will never be over 100px and never over 80% of the renderable area
  * @property {ComponentRefLine~LineLabelBackground} [background=ComponentRefLine~LineLabelBackground] - The background style (rect behind text)
+ * @property {boolean} [show=true ] - Show label
  * @property {boolean} [showValue=true] - Show value label
  */
 

--- a/packages/picasso.js/src/core/chart-components/ref-line/refline.js
+++ b/packages/picasso.js/src/core/chart-components/ref-line/refline.js
@@ -126,7 +126,7 @@ function removeDuplication(intersections) {
  * @property {number} [maxWidth=1] - The maximum relative width to the width of the rendering area (see maxWidthPx as well)
  * @property {number} [maxWidthPx=9999] - The maximum width in pixels. Labels will be rendered with the maximum size of the smallest value of maxWidth and maxWidthPx size, so you may specify maxWidth 0.8 but maxWidthPx 100 and will never be over 100px and never over 80% of the renderable area
  * @property {ComponentRefLine~LineLabelBackground} [background=ComponentRefLine~LineLabelBackground] - The background style (rect behind text)
- * @property {boolean} [show=true ] - Show label
+ * @property {boolean} [show=true] - Show label
  * @property {boolean} [showValue=true] - Show value label
  */
 

--- a/packages/picasso.js/types/index.d.ts
+++ b/packages/picasso.js/types/index.d.ts
@@ -1071,6 +1071,7 @@ declare namespace picassojs {
             maxWidth?: number;
             maxWidthPx?: number;
             background?: picassojs.ComponentRefLine.LineLabelBackground;
+            show?: boolean;
             showValue?: boolean;
         };
 


### PR DESCRIPTION
This PR changes so sloped ref-lines use the same documented label properties as normal ref-lines.

Before this PR sloped ref-lines used these undocumented properties:

```
{
  refLineLabel: 'label',
  showLabel: true,
  showValue: true,
  labelStroke: 'red',
}
```

Instead of the documented properties that already exist and are used by normal ref-lines:

```
  label: {
    text: 'label',
    show: true,
    showValue: true,
    stroke: 'red'
  }
```