### PR TITLE
fix: bar label strategy dock right

### DIFF
--- a/docs/scriptappy.json
+++ b/docs/scriptappy.json
@@ -2814,6 +2814,12 @@
                         "description": "Link data to the label",
                         "type": "function"
                       },
+                      "dock": {
+                        "description": "When orientation is vertical, the label can be docked to the left or right of the bar. 'left' | 'right'.",
+                        "optional": true,
+                        "defaultValue": "'left'",
+                        "type": "string"
+                      },
                       "placements": {
                         "kind": "array",
                         "items": {

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/__tests__/bars.spec.js
@@ -214,6 +214,27 @@ describe('labeling - bars', () => {
       );
       expect(label.transform).to.equal('rotate(-90, 17, 30)');
     });
+
+    it('should dock the label to the right if specified', () => {
+      const label = placeTextInRect(
+        {
+          x: 5,
+          y: 30,
+          width: 100,
+          height: 200,
+        },
+        'a',
+        {
+          rotate: true,
+          align: 0,
+          justify: 0.0,
+          fontSize: 12,
+          textMetrics: { height: 24, width: 40 },
+          dock: 'right',
+        }
+      );
+      expect(label.transform).to.equal('rotate(90, 17, 30) translate(40, 0)');
+    });
   });
 
   describe('findBestPlacement', () => {
@@ -550,6 +571,7 @@ describe('labeling - bars', () => {
             textMetrics: 2,
             rotate: false,
             overflow: false,
+            dock: 'left',
           },
         ],
       ]);
@@ -664,6 +686,7 @@ describe('labeling - bars', () => {
         textMetrics: 2,
         rotate: false,
         overflow: false,
+        dock: 'left',
       });
     });
   });

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -447,6 +447,7 @@ export function getOrientation({ orientation = 'auto', defaultOrientation = 'h' 
  * @property {Array<object>} labels
  * @property {string|function} labels[].label - The text value
  * @property {function} labels[].linkData - Link data to the label
+ * @property {string} [labels[].dock='left'] - When orientation is vertical, the label can be docked to the left or right of the bar. 'left' | 'right'.
  * @property {Array<object>} labels[].placements
  * @property {string} labels[].placements[].position - 'inside' | 'outside' | 'opposite'
  * @property {number} [labels[].placements[].justify=0] - Placement of the label along the direction of the bar

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -318,7 +318,7 @@ export function placeInBars(
           textMetrics: measured,
           rotate: isRotated,
           overflow: !!overflow,
-          dock: lblStngs.dock,
+          dock: lblStngs.dock ?? 'left',
         });
 
         if (label) {

--- a/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
+++ b/packages/picasso.js/src/core/chart-components/labels/strategies/bars.js
@@ -89,7 +89,11 @@ export function placeTextInRect(rect, text, opts) {
   if (opts.rotate) {
     label.x = placeSegmentInSegment(rect.x, rect.width, textMetrics.height, opts.align) + baseLineOffset;
     label.y = placeSegmentInSegment(rect.y, rect.height, textMetrics.width, opts.justify);
-    label.transform = `rotate(-90, ${label.x + label.dx}, ${label.y + label.dy})`;
+    if (opts.dock === 'right') {
+      label.transform = `rotate(90, ${label.x + label.dx}, ${label.y + label.dy}) translate(${textMetrics.width}, 0)`;
+    } else {
+      label.transform = `rotate(-90, ${label.x + label.dx}, ${label.y + label.dy})`;
+    }
   } else {
     label.x = placeSegmentInSegment(rect.x, rect.width, textMetrics.width, opts.align);
     label.y = placeSegmentInSegment(rect.y, rect.height, textMetrics.height, opts.justify) + baseLineOffset;
@@ -314,6 +318,7 @@ export function placeInBars(
           textMetrics: measured,
           rotate: isRotated,
           overflow: !!overflow,
+          dock: lblStngs.dock,
         });
 
         if (label) {


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

### Description

In current bar label strategy code, when the label is oriented vertically, it is assumed to dock left. In other words, if you have a vertical bar and you label it with a vertical label, the direction of the text is such that you can read it easily when you tilt your head to the left. However, there are cases where you want to dock the text to the right of the bar. This PR enables that option by adding a new property named `dock` to the label settings.

### Verification

Before: the text is difficult to read if it is docked to the right of the bar, since the text direction follows the assumption that it is docked left.
![image](https://github.com/user-attachments/assets/bdc9077b-dffd-4627-9909-b5d9b8640fe5)

After: 
![image](https://github.com/user-attachments/assets/16022d15-2325-4880-ac87-876333b9c419)


