### PR TITLE
fix: image position and preserving image aspect ratio

### DIFF
--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -30,9 +30,6 @@ export default class Circle extends DisplayObject {
     );
 
     super.set(v);
-    if (v.data.label === 'plugin') {
-      console.log('Circle without label');
-    }
     this.attrs.cx = cx;
     this.attrs.cy = cy;
     this.attrs.r = r;

--- a/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/circle.js
@@ -30,7 +30,9 @@ export default class Circle extends DisplayObject {
     );
 
     super.set(v);
-
+    if (v.data.label === 'plugin') {
+      console.log('Circle without label');
+    }
     this.attrs.cx = cx;
     this.attrs.cy = cy;
     this.attrs.r = r;

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -242,17 +242,14 @@ export function renderer(sceneFn = sceneFactory) {
       buffer.apply();
       return true;
     }
-    let containsImage = false;
     if (hasChangedRect) {
-      containsImage = Array.isArray(shapes) && shapes.length > 0 && shapes[0].type === 'image';
       el.style.left = `${rect.computedPhysical.x}px`;
       el.style.top = `${rect.computedPhysical.y}px`;
       el.style.width = `${rect.computedPhysical.width}px`;
       el.style.height = `${rect.computedPhysical.height}px`;
-      if (!containsImage) {
-        el.width = Math.round(rect.computedPhysical.width * dpiRatio);
-        el.height = Math.round(rect.computedPhysical.height * dpiRatio);
-      }
+      el.width = Math.round(rect.computedPhysical.width * dpiRatio);
+      el.height = Math.round(rect.computedPhysical.height * dpiRatio);
+
       if (buffer) {
         buffer.updateSize({ rect, dpiRatio, canvasBufferSize: settings.canvasBufferSize });
       }
@@ -267,7 +264,7 @@ export function renderer(sceneFn = sceneFactory) {
     const doRender = hasChangedRect || hasChangedScene;
     const progressive = typeof settings.progressive === 'function' && settings.progressive();
     if (doRender) {
-      if ((!progressive || progressive.isFirst) && !containsImage) {
+      if (!progressive || progressive.isFirst) {
         canvasRenderer.clear();
       }
       renderShapes(newScene.children, g, shapeToCanvasMap, {

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
@@ -37,6 +37,7 @@ describe('render()', () => {
       drawImage: sinon.spy(),
       save: sinon.spy(),
       restore: sinon.spy(),
+      getTransform: sinon.spy(),
     };
 
     // Create a mock canvas
@@ -53,6 +54,7 @@ describe('render()', () => {
       setTransform: sinon.spy(),
       clearRect: sinon.spy(),
       drawImage: sinon.spy(),
+      getTransform: sinon.spy(),
     };
 
     // Mock document if not defined (for Node.js test environments)

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
@@ -1,7 +1,7 @@
 import render, { positionImage } from '../image'; // adjust path as needed
 
 describe('render()', () => {
-  let canvas, g, ctx, createElementStub, lastCreatedImage;
+  let canvas, g, createElementStub, lastCreatedImage;
 
   beforeEach(() => {
     // Mock Image class
@@ -27,26 +27,12 @@ describe('render()', () => {
       naturalHeight = 50;
     };
 
-    // Create a mocked canvas context
-    ctx = {
-      setTransform: sinon.spy(),
-      clearRect: sinon.spy(),
-      beginPath: sinon.spy(),
-      arc: sinon.spy(),
-      clip: sinon.spy(),
-      drawImage: sinon.spy(),
-      save: sinon.spy(),
-      restore: sinon.spy(),
-      getTransform: sinon.spy(),
-    };
-
     // Create a mock canvas
     canvas = {
       clientWidth: 200,
       clientHeight: 100,
       width: 0,
       height: 0,
-      getContext: sinon.stub().returns(ctx),
     };
 
     g = {
@@ -55,6 +41,12 @@ describe('render()', () => {
       clearRect: sinon.spy(),
       drawImage: sinon.spy(),
       getTransform: sinon.spy(),
+      save: sinon.spy(),
+      beginPath: sinon.spy(),
+      arc: sinon.spy(),
+      clip: sinon.spy(),
+      restore: sinon.spy(),
+      globalAlpha: 1,
     };
 
     // Mock document if not defined (for Node.js test environments)
@@ -64,7 +56,6 @@ describe('render()', () => {
     const doc = global.document;
     // Stub document.createElement
     createElementStub = sinon.stub(doc, 'createElement').callsFake(() => ({
-      getContext: () => ctx,
       width: 0,
       height: 0,
     }));
@@ -92,8 +83,8 @@ describe('render()', () => {
     render(img, { g });
     lastCreatedImage.onload();
 
-    expect(ctx.arc.called).to.be.true;
-    expect(ctx.drawImage.called).to.be.true;
+    expect(g.arc.called).to.be.true;
+    expect(g.drawImage.called).to.be.true;
     expect(g.drawImage.called).to.be.true;
     done();
   });
@@ -109,8 +100,8 @@ describe('render()', () => {
 
     render(img, { g });
     lastCreatedImage.onload();
-    expect(ctx.drawImage.called).to.be.true;
-    expect(ctx.arc.called).to.be.false; // should not draw arc for square
+    expect(g.drawImage.called).to.be.true;
+    expect(g.arc.called).to.be.false; // should not draw arc for square
     expect(g.drawImage.called).to.be.true;
     done();
   });
@@ -128,7 +119,7 @@ describe('render()', () => {
     lastCreatedImage.onload();
     expect(canvas.width).to.equal(400); // 200 * 2
     expect(canvas.height).to.equal(200); // 100 * 2
-    expect(ctx.clearRect.called).to.be.true;
+    expect(g.clearRect.called).to.be.true;
     expect(g.clearRect.called).to.be.true;
     done();
   });

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/__tests__/image.spec.js
@@ -131,10 +131,10 @@ describe('render()', () => {
       expect(img.y).to.equal(90); // y - height/2
     });
 
-    it('scales image if symbol is circle', () => {
+    it('do not scale image if symbol is circle', () => {
       const img = { symbol: 'circle', width: 80, height: 60 };
       positionImage(img);
-      expect(img.width).to.equal(60);
+      expect(img.width).to.equal(80);
       expect(img.height).to.equal(60);
     });
   });

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
@@ -19,39 +19,41 @@ loadImage.cache = {};
 
 export function positionImage(img) {
   const position = img.imagePosition || 'center-center';
+  let width = img.width;
+  let height = img.height;
   if (img.symbol === 'circle') {
     const radius = Math.min(img.width, img.height) / 2;
-    img.width = radius * 2;
-    img.height = radius * 2;
+    width = radius * 2;
+    height = radius * 2;
   }
   switch (position) {
     case 'top-center':
-      img.y -= img.height / 2;
+      img.y -= height / 2;
       break;
     case 'center-left':
-      img.x -= img.width / 2;
+      img.x -= width / 2;
       break;
     case 'center-right':
-      img.x += img.width / 2;
+      img.x += width / 2;
       break;
     case 'top-left':
-      img.x -= img.width / 2;
-      img.y -= img.height / 2;
+      img.x -= width / 2;
+      img.y -= height / 2;
       break;
     case 'top-right':
-      img.x += img.width / 2;
-      img.y -= img.height / 2;
+      img.x += width / 2;
+      img.y -= height / 2;
       break;
     case 'bottom-left':
-      img.x -= img.width / 2;
-      img.y += img.height / 2;
+      img.x -= width / 2;
+      img.y += height / 2;
       break;
     case 'bottom-right':
-      img.x += img.width / 2;
-      img.y += img.height / 2;
+      img.x += width / 2;
+      img.y += height / 2;
       break;
     case 'bottom-center':
-      img.y += img.height / 2;
+      img.y += height / 2;
       break;
     default:
       break;
@@ -74,14 +76,11 @@ export default function render(img, { g }) {
 
   // Load and draw image
   loadImage(img.src, (image) => {
-    // Clear main canvas
-    g.setTransform(1, 0, 0, 1, 0, 0); // Reset transform before clearing
+    g.setTransform(1, 0, 0, 1, 0, 0);
     g.clearRect(0, 0, canvas.width, canvas.height);
-    g.setTransform(currentTransform); // Restore previous transform
-
+    g.setTransform(currentTransform);
     g.globalAlpha = img.opacity;
 
-    // Set default dimensions if not set
     if (!img.width && !img.height) {
       img.width = image.naturalWidth * img.imageScalingFactor;
       img.height = image.naturalHeight * img.imageScalingFactor;
@@ -90,17 +89,17 @@ export default function render(img, { g }) {
     positionImage(img);
 
     if (img.symbol === 'circle') {
+      const imgCenterX = img.x;
+      const imgCenterY = img.y;
       img.r = Math.min(img.width, img.height) / 2;
-      img.cx = img.x;
-      img.cy = img.y;
-      const drawX = img.cx - img.r;
-      const drawY = img.cy - img.r;
+      const drawX = imgCenterX - img.width / 2;
+      const drawY = imgCenterY - img.height / 2;
 
       g.save();
       g.beginPath();
-      g.arc(img.cx, img.cy, img.r, 0, Math.PI * 2);
+      g.arc(imgCenterX, imgCenterY, img.r, 0, Math.PI * 2);
       g.clip();
-      g.drawImage(image, drawX, drawY, img.r * 2, img.r * 2);
+      g.drawImage(image, drawX, drawY, img.width, img.height);
       g.restore();
     } else {
       img.x -= img.width / 2;
@@ -108,7 +107,7 @@ export default function render(img, { g }) {
       g.drawImage(image, img.x, img.y, img.width, img.height);
     }
 
-    g.globalAlpha = 1; // Reset alpha after draw
+    g.globalAlpha = 1;
 
     if (img.updateCollider) {
       img.updateCollider(img);

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
@@ -65,10 +65,13 @@ export default function render(img, { g }) {
   const ratio = window.devicePixelRatio || 1;
   const logicalWidth = canvas.clientWidth;
   const logicalHeight = canvas.clientHeight;
-
+  console.log('logicalWidth,', logicalWidth, 'Width', canvas.width);
   const renderWidth = logicalWidth * ratio;
   const renderHeight = logicalHeight * ratio;
-
+  if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
+    canvas.width = renderWidth;
+    canvas.height = renderHeight;
+  }
   if (!offscreenBuffer || offscreenBuffer.width !== renderWidth || offscreenBuffer.height !== renderHeight) {
     offscreenBuffer = document.createElement('canvas');
     offscreenBuffer.width = renderWidth;
@@ -104,11 +107,9 @@ export default function render(img, { g }) {
     }
 
     // Copy to visible canvas
-    if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
-      canvas.width = renderWidth;
-      canvas.height = renderHeight;
-    }
-    g.setTransform(1, 0, 0, 1, 0, 0);
+    // g.setTransform(1, 0, 0, 1, 0, 0);
+    // g.setTransform(ratio, 0, 0, ratio, 0, 0);
+
     g.clearRect(0, 0, canvas.width, canvas.height);
     g.drawImage(offscreenBuffer, 0, 0, renderWidth, renderHeight, 0, 0, canvas.width, canvas.height);
     if (img.updateCollider) {

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/shapes/image.js
@@ -61,11 +61,10 @@ export function positionImage(img) {
 }
 export default function render(img, { g }) {
   const canvas = g.canvas;
-
+  const currentTransform = g.getTransform();
   const ratio = window.devicePixelRatio || 1;
   const logicalWidth = canvas.clientWidth;
   const logicalHeight = canvas.clientHeight;
-  console.log('logicalWidth,', logicalWidth, 'Width', canvas.width);
   const renderWidth = logicalWidth * ratio;
   const renderHeight = logicalHeight * ratio;
   if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
@@ -79,7 +78,6 @@ export default function render(img, { g }) {
   }
   loadImage(img.src, (image) => {
     const ctx = offscreenBuffer.getContext('2d');
-    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
     ctx.clearRect(0, 0, offscreenBuffer.width, offscreenBuffer.height);
     ctx.globalAlpha = img.opacity;
     if (!img.width && !img.height) {
@@ -106,10 +104,7 @@ export default function render(img, { g }) {
       ctx.drawImage(image, img.x, img.y, img.width, img.height);
     }
 
-    // Copy to visible canvas
-    // g.setTransform(1, 0, 0, 1, 0, 0);
-    // g.setTransform(ratio, 0, 0, ratio, 0, 0);
-
+    g.setTransform(currentTransform);
     g.clearRect(0, 0, canvas.width, canvas.height);
     g.drawImage(offscreenBuffer, 0, 0, renderWidth, renderHeight, 0, 0, canvas.width, canvas.height);
     if (img.updateCollider) {


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [x] documentation updated

This PR fixes a number of bugs found when testing the image plugin. 
1. Image not positioning correctly. 
Before: 

https://github.com/user-attachments/assets/499b798f-51ac-4312-9e91-8a3803f38b30

After: 

https://github.com/user-attachments/assets/c2752a7d-1b6b-4005-878e-4a6f26d091e7

2. Keep aspect ratio when rendering the image as a circle. 
Before: 

https://github.com/user-attachments/assets/7cdb9df1-5d34-41f5-880b-f349e3c787aa

After: 

https://github.com/user-attachments/assets/56849684-fa06-46c9-bb5c-2bf18b93b3b1

3. Also removed rendering the image on an offscreen canvas before rendering it to the visible canvas. The reason for that is that it caused a bug where sometimes the image did not render on refresh, when having two objects with a rendered image in the same window. 



