### PR TITLE
refactor: stack offset diverging func

### DIFF
--- a/packages/picasso.js/package.json
+++ b/packages/picasso.js/package.json
@@ -43,7 +43,7 @@
     "d3-hierarchy": "3.1.2",
     "d3-interpolate": "3.0.1",
     "d3-scale": "4.0.2",
-    "d3-shape": "1.3.6",
+    "d3-shape": "3.2.0",
     "d3-time-format": "4.1.0",
     "extend": "3.0.2",
     "hammerjs": "2.0.8",

--- a/packages/picasso.js/src/core/data/__tests__/stack.spec.js
+++ b/packages/picasso.js/src/core/data/__tests__/stack.spec.js
@@ -1,4 +1,4 @@
-import stack from '../stack';
+import stack, { stackOffsetDiverging } from '../stack';
 
 describe('stack', () => {
   const valueField = { key: 'nyckel', field: 'sales' };
@@ -36,5 +36,68 @@ describe('stack', () => {
     });
     expect(data.items[8].start).to.eql({ value: 3 });
     expect(data.items[8].end).to.eql({ value: 12 });
+  });
+});
+
+describe('stackOffsetDiverging', () => {
+  it('should stack positive values above zero and negative values below zero', () => {
+    const series = [
+      [
+        [0, 1],
+        [0, -2],
+      ],
+      [
+        [0, 3],
+        [0, -4],
+      ],
+      [
+        [0, -6],
+        [0, 7],
+      ],
+    ];
+
+    stackOffsetDiverging(series, [0, 1, 2]);
+
+    expect(series).to.eql([
+      [
+        [0, 1],
+        [-2, 0],
+      ],
+      [
+        [1, 4],
+        [-6, -2],
+      ],
+      [
+        [-6, 0],
+        [0, 7],
+      ],
+    ]);
+  });
+
+  it('should keep zero-height segments at the current positive baseline', () => {
+    const series = [[[0, 5]], [[0, 0]], [[0, -2]]];
+
+    stackOffsetDiverging(series, [0, 1, 2]);
+
+    expect(series).to.eql([[[0, 5]], [[5, 5]], [[-2, 0]]]);
+  });
+
+  it('should anchor non-comparable segments at the current positive baseline', () => {
+    const series = [[[0, 2]], [[NaN, NaN]], [[0, -1]]];
+
+    stackOffsetDiverging(series, [0, 1, 2]);
+
+    expect(series[0]).to.eql([[0, 2]]);
+    expect(series[1][0][0]).to.equal(2);
+    expect(series[1][0][1]).to.be.NaN;
+    expect(series[2]).to.eql([[-1, 0]]);
+  });
+
+  it('should respect the provided order when applying offsets', () => {
+    const series = [[[0, 2]], [[0, 3]]];
+
+    stackOffsetDiverging(series, [1, 0]);
+
+    expect(series).to.eql([[[3, 5]], [[0, 3]]]);
   });
 });

--- a/packages/picasso.js/src/core/data/stack.js
+++ b/packages/picasso.js/src/core/data/stack.js
@@ -12,6 +12,7 @@ import {
 import fieldFn from './field';
 import { getMax, getMin } from './util';
 
+// Intentionally mirrors d3-shape@1.3.6 diverging offset behavior for zero values.
 export function stackOffsetDiverging(series, order) {
   const seriesCount = series.length;
   if (seriesCount <= 0) {

--- a/packages/picasso.js/src/core/data/stack.js
+++ b/packages/picasso.js/src/core/data/stack.js
@@ -4,7 +4,6 @@ import {
   stackOrderInsideOut,
   stackOrderNone,
   stackOrderReverse,
-  stackOffsetDiverging,
   stackOffsetNone,
   stackOffsetSilhouette,
   stackOffsetExpand,
@@ -12,6 +11,36 @@ import {
 } from 'd3-shape';
 import fieldFn from './field';
 import { getMax, getMin } from './util';
+
+export function stackOffsetDiverging(series, order) {
+  const seriesCount = series.length;
+  if (seriesCount <= 0) {
+    return;
+  }
+
+  const pointCount = series[order[0]].length;
+  for (let pointIndex = 0; pointIndex < pointCount; ++pointIndex) {
+    let positiveOffset = 0;
+    let negativeOffset = 0;
+
+    for (let seriesIndex = 0; seriesIndex < seriesCount; ++seriesIndex) {
+      const point = series[order[seriesIndex]][pointIndex];
+      const delta = point[1] - point[0];
+
+      if (delta >= 0) {
+        point[0] = positiveOffset;
+        positiveOffset += delta;
+        point[1] = positiveOffset;
+      } else if (delta < 0) {
+        point[1] = negativeOffset;
+        negativeOffset += delta;
+        point[0] = negativeOffset;
+      } else {
+        point[0] = positiveOffset;
+      }
+    }
+  }
+}
 
 const OFFSETS = {
   diverging: stackOffsetDiverging,

--- a/packages/picasso.js/src/core/scene-graph/display-objects/__tests__/path.spec.js
+++ b/packages/picasso.js/src/core/scene-graph/display-objects/__tests__/path.spec.js
@@ -28,7 +28,7 @@ describe('Path', () => {
       expect(path).to.be.an.instanceof(Path);
       const strokes = path.attrs.d.split(/[MALZ]/).map((arr) => (arr ? arr.split(',').map(Math.round) : []));
       expect(strokes[1]).to.eql([-35, 20]); // move to
-      expect(strokes[2]).to.eql([40, 40, 0, 0, 1, -0, -40]); // arc
+      expect(strokes[2]).to.eql([40, 40, 0, 0, 1, 0, -40]); // arc
       expect(strokes[3]).to.eql([0, 0]); // line to
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,8 +159,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       d3-shape:
-        specifier: 1.3.6
-        version: 1.3.6
+        specifier: 3.2.0
+        version: 3.2.0
       d3-time-format:
         specifier: 4.1.0
         version: 4.1.0
@@ -2839,15 +2839,17 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
-  d3-path@1.0.9:
-    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
 
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
-  d3-shape@1.3.6:
-    resolution: {integrity: sha512-vv247nPmyncoCRnCT5VYvAVPrrqTGml+GT79detw5IEuBfv2cfTnOtbPBFIIkmL0eg1EYz+ltmJ6lK384ttHcg==}
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
 
   d3-time-format@4.1.0:
     resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
@@ -9792,7 +9794,7 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
-  d3-path@1.0.9: {}
+  d3-path@3.1.0: {}
 
   d3-scale@4.0.2:
     dependencies:
@@ -9802,9 +9804,9 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
-  d3-shape@1.3.6:
+  d3-shape@3.2.0:
     dependencies:
-      d3-path: 1.0.9
+      d3-path: 3.1.0
 
   d3-time-format@4.1.0:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": ["local>qlik-oss/renovate-config", ":automergeMinor", ":automergeDigest"],
   "packageRules": [
     {
-      "matchPackageNames": ["d3-shape", "preact"],
+      "matchPackageNames": ["preact"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [commit guidelines](./CONTRIBUTING.md#commit)
- [ ] documentation updated

The stackOffsetDiverging function in `d3-shape` changed how it handles zero values (https://github.com/d3/d3-shape/commit/bf15db4a8db7ce393db6d6d77bdf953e4e78b13d). This PR creates a custom function with the same logic that the 1.3.6 version have.

This allows us to bump `d3-shape` to the latest version.