### PR TITLE
fix(renderer): integer pixel alignment for edgeBleed translate

### DIFF
--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -225,8 +225,8 @@ export default function getSize({ isDiscrete, rect, formatter, measureText, scal
     }
 
     if (settings.labels.centerEndLabels && !isDiscrete && !horizontal) {
-      edgeBleed.top = h / 2;
-      edgeBleed.bottom = h / 2;
+      edgeBleed.top = Math.ceil(h / 2);
+      edgeBleed.bottom = Math.ceil(h / 2);
     }
 
     if (state.labels.activeMode === 'tilted') {

--- a/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
+++ b/packages/picasso.js/src/core/chart-components/axis/axis-label-size.js
@@ -225,8 +225,8 @@ export default function getSize({ isDiscrete, rect, formatter, measureText, scal
     }
 
     if (settings.labels.centerEndLabels && !isDiscrete && !horizontal) {
-      edgeBleed.top = Math.ceil(h / 2);
-      edgeBleed.bottom = Math.ceil(h / 2);
+      edgeBleed.top = h / 2;
+      edgeBleed.bottom = h / 2;
     }
 
     if (state.labels.activeMode === 'tilted') {

--- a/packages/picasso.js/src/web/renderer/__tests__/renderer-box.spec.js
+++ b/packages/picasso.js/src/web/renderer/__tests__/renderer-box.spec.js
@@ -176,6 +176,23 @@ describe('renderer-box', () => {
         expect(b.edgeBleed[prop]).to.equal(3);
       });
     });
+
+    it('should compute edgeBleedTranslate to align axis nodes with grid lines despite split-rounding', () => {
+      // y=50, edgeBleed.top=3 (ceiled from 2.5), scaleY=1.5
+      // computedPhysical.y = Math.round((50-3)*1.5) = Math.round(70.5) = 71
+      // T = Math.round((50+3)*1.5) - 3*1.5 - 71
+      //   = Math.round(79.5) - 4.5 - 71 = 80 - 4.5 - 71 = 4.5
+      const b = box({
+        x: 50,
+        y: 50,
+        width: 200,
+        height: 400,
+        scaleRatio: { x: 1.5, y: 1.5 },
+        edgeBleed: { left: 2.5, right: 0, top: 2.5, bottom: 0 },
+      });
+      expect(b.computedPhysical.edgeBleedTranslate.x).to.equal(4.5);
+      expect(b.computedPhysical.edgeBleedTranslate.y).to.equal(4.5);
+    });
   });
 
   describe('computed', () => {});

--- a/packages/picasso.js/src/web/renderer/__tests__/renderer-box.spec.js
+++ b/packages/picasso.js/src/web/renderer/__tests__/renderer-box.spec.js
@@ -168,6 +168,13 @@ describe('renderer-box', () => {
           },
         });
       });
+
+      it(`should ceil fractional ${prop} edgeBleed to nearest integer`, () => {
+        const edgeBleed = {};
+        edgeBleed[prop] = 2.5;
+        const b = box({ edgeBleed });
+        expect(b.edgeBleed[prop]).to.equal(3);
+      });
     });
   });
 

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
@@ -613,4 +613,27 @@ describe('canvas renderer', () => {
     expect(el.height).to.equal(size.height * scaleRatio.y * dpiScale);
     expect(sceneFn.args[0][0].items).to.deep.equal(expectedInputShapes.items);
   });
+
+  it('should round edgeBleed translate to integer device pixels', () => {
+    const div = element('div');
+    // edgeBleed.top = 2.5 (fractional), scaleRatio.y = 1.5 → 2.5*1.5 = 3.75 → Math.round = 4
+    // edgeBleed.left = 2.5 (fractional), scaleRatio.x = 1.5 → 2.5*1.5 = 3.75 → Math.round = 4
+    const size = {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 400,
+      scaleRatio: { x: 1.5, y: 1.5 },
+      edgeBleed: { left: 2.5, right: 0, top: 2.5, bottom: 0 },
+    };
+    const inputShapes = [{ type: 'container' }];
+    sceneFn.returns({ children: [] });
+    r.appendTo(div);
+    r.size(size);
+    r.render(inputShapes);
+
+    const sceneContainerTransform = sceneFn.args[0][0].items[0].transform;
+    // Math.ceil(2.5) = 3 stored in edgeBleed; 3 * 1 (dpiRatio) * 1.5 = 4.5 → Math.round = 5
+    expect(sceneContainerTransform).to.include('translate(5, 5)');
+  });
 });

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/__tests__/canvas-renderer.spec.js
@@ -264,6 +264,7 @@ describe('canvas renderer', () => {
         y: 0,
         width: 0,
         height: 0,
+        edgeBleedTranslate: { x: 0, y: 0 },
       },
     });
   });
@@ -302,6 +303,7 @@ describe('canvas renderer', () => {
         y: 370,
         width: 645,
         height: 1676,
+        edgeBleedTranslate: { x: 21, y: 36 },
       },
     });
   });
@@ -340,6 +342,7 @@ describe('canvas renderer', () => {
         y: 0,
         width: 0,
         height: 0,
+        edgeBleedTranslate: { x: 0, y: 0 },
       },
     });
   });
@@ -614,10 +617,12 @@ describe('canvas renderer', () => {
     expect(sceneFn.args[0][0].items).to.deep.equal(expectedInputShapes.items);
   });
 
-  it('should round edgeBleed translate to integer device pixels', () => {
+  it('should use edgeBleedTranslate for scene container to avoid split-rounding misalignment', () => {
     const div = element('div');
-    // edgeBleed.top = 2.5 (fractional), scaleRatio.y = 1.5 → 2.5*1.5 = 3.75 → Math.round = 4
-    // edgeBleed.left = 2.5 (fractional), scaleRatio.x = 1.5 → 2.5*1.5 = 3.75 → Math.round = 4
+    // edgeBleed.top=2.5 → ceiled to 3; y=0, scaleY=1.5
+    // computedPhysical.y = Math.round((0-3)*1.5) = Math.round(-4.5) = -4
+    // T = Math.round((0+3)*1.5) - 3*1.5 - (-4) = 5 - 4.5 + 4 = 4.5
+    // canvas translate = 4.5 * dpiRatio(1) = 4.5
     const size = {
       x: 0,
       y: 0,
@@ -633,7 +638,6 @@ describe('canvas renderer', () => {
     r.render(inputShapes);
 
     const sceneContainerTransform = sceneFn.args[0][0].items[0].transform;
-    // Math.ceil(2.5) = 3 stored in edgeBleed; 3 * 1 (dpiRatio) * 1.5 = 4.5 → Math.round = 5
-    expect(sceneContainerTransform).to.include('translate(5, 5)');
+    expect(sceneContainerTransform).to.include('translate(4.5, 4.5)');
   });
 });

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -209,7 +209,7 @@ export function renderer(sceneFn = sceneFactory) {
       type: 'container',
       children: shapes,
       transform: rect.edgeBleed.bool
-        ? `translate(${Math.round(rect.edgeBleed.left * dpiRatio * scaleX)}, ${Math.round(rect.edgeBleed.top * dpiRatio * scaleY)})`
+        ? `translate(${rect.computedPhysical.edgeBleedTranslate.x * dpiRatio}, ${rect.computedPhysical.edgeBleedTranslate.y * dpiRatio})`
         : '',
     };
 

--- a/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
+++ b/packages/picasso.js/src/web/renderer/canvas-renderer/canvas-renderer.js
@@ -209,7 +209,7 @@ export function renderer(sceneFn = sceneFactory) {
       type: 'container',
       children: shapes,
       transform: rect.edgeBleed.bool
-        ? `translate(${rect.edgeBleed.left * dpiRatio * scaleX}, ${rect.edgeBleed.top * dpiRatio * scaleY})`
+        ? `translate(${Math.round(rect.edgeBleed.left * dpiRatio * scaleX)}, ${Math.round(rect.edgeBleed.top * dpiRatio * scaleY)})`
         : '',
     };
 

--- a/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/dom-renderer/__tests__/dom-renderer.spec.js
@@ -184,6 +184,7 @@ describe('dom renderer', () => {
           y: 370,
           width: 645,
           height: 1676,
+          edgeBleedTranslate: { x: 21, y: 36 },
         },
       });
     });
@@ -222,6 +223,7 @@ describe('dom renderer', () => {
           y: 0,
           width: 0,
           height: 0,
+          edgeBleedTranslate: { x: 0, y: 0 },
         },
       });
     });

--- a/packages/picasso.js/src/web/renderer/renderer-box.js
+++ b/packages/picasso.js/src/web/renderer/renderer-box.js
@@ -58,7 +58,7 @@ export default function createRendererBox({ x, y, width, height, scaleRatio, mar
   if (typeof edgeBleed === 'object') {
     ['left', 'right', 'top', 'bottom'].forEach((prop) => {
       if (!isNaN(edgeBleed[prop]) && edgeBleed[prop] > 0) {
-        box.edgeBleed[prop] = edgeBleed[prop];
+        box.edgeBleed[prop] = Math.ceil(edgeBleed[prop]);
         box.edgeBleed.bool = true;
       }
     });

--- a/packages/picasso.js/src/web/renderer/renderer-box.js
+++ b/packages/picasso.js/src/web/renderer/renderer-box.js
@@ -71,5 +71,27 @@ export default function createRendererBox({ x, y, width, height, scaleRatio, mar
     height: Math.round((box.height + box.edgeBleed.top + box.edgeBleed.bottom) * box.scaleRatio.y),
   };
 
+  // The translate to apply inside the renderer scene so that axis nodes using the
+  // (innerRect - outerRect) offset land on the same CSS pixel as grid lines.
+  //
+  // Axis ticks/lines at position=0 are at scene y = edgeBleed.top (the innerRect
+  // offset). After the scene scale(s), that becomes edgeBleed.top*s which is
+  // unrounded. The grid SVG is positioned at Math.round(innerRect.y*s). To align:
+  //
+  //   computedPhysical.y + T + edgeBleed.top*s = Math.round((y + edgeBleed.top)*s)
+  //   T = Math.round((y + edgeBleed.top)*s) - edgeBleed.top*s - computedPhysical.y
+  //
+  // T may be fractional (SVG/canvas translate supports sub-pixel values).
+  box.computedPhysical.edgeBleedTranslate = {
+    x:
+      Math.round(box.margin.left + (box.x + box.edgeBleed.left) * box.scaleRatio.x) -
+      box.edgeBleed.left * box.scaleRatio.x -
+      box.computedPhysical.x,
+    y:
+      Math.round(box.margin.top + (box.y + box.edgeBleed.top) * box.scaleRatio.y) -
+      box.edgeBleed.top * box.scaleRatio.y -
+      box.computedPhysical.y,
+  };
+
   return box;
 }

--- a/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
@@ -163,6 +163,25 @@ describe('svg renderer', () => {
       expect(wrappedContainer[0].transform).to.deep.equal(expectedInputShapes[0].transform);
     });
 
+    it('should round edgeBleed translate to integer pixels', () => {
+      // edgeBleed.top = 2.5 (fractional), Math.ceil → 3 stored; 3 * scaleY 1.5 = 4.5 → Math.round = 5
+      const size = {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 400,
+        scaleRatio: { x: 1.5, y: 1.5 },
+        edgeBleed: { left: 2.5, right: 0, top: 2.5, bottom: 0 },
+      };
+      scene.returns(s);
+      svg.appendTo(element('div'));
+      svg.size(size);
+      svg.render([s]);
+
+      const sceneContainerTransform = scene.args[0][0].items[0].transform;
+      expect(sceneContainerTransform).to.include('translate(5, 5)');
+    });
+
     it('should handle call without arguments', () => {
       scene.returns(s);
       svg.appendTo(element('div'));

--- a/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/__tests__/svg-renderer.spec.js
@@ -163,8 +163,10 @@ describe('svg renderer', () => {
       expect(wrappedContainer[0].transform).to.deep.equal(expectedInputShapes[0].transform);
     });
 
-    it('should round edgeBleed translate to integer pixels', () => {
-      // edgeBleed.top = 2.5 (fractional), Math.ceil → 3 stored; 3 * scaleY 1.5 = 4.5 → Math.round = 5
+    it('should use edgeBleedTranslate for scene container to avoid split-rounding misalignment', () => {
+      // edgeBleed.top=2.5 → ceiled to 3; y=0, scaleY=1.5
+      // computedPhysical.y = Math.round((0-3)*1.5) = Math.round(-4.5) = -4
+      // T = Math.round((0+3)*1.5) - 3*1.5 - (-4) = 5 - 4.5 + 4 = 4.5
       const size = {
         x: 0,
         y: 0,
@@ -179,7 +181,7 @@ describe('svg renderer', () => {
       svg.render([s]);
 
       const sceneContainerTransform = scene.args[0][0].items[0].transform;
-      expect(sceneContainerTransform).to.include('translate(5, 5)');
+      expect(sceneContainerTransform).to.include('translate(4.5, 4.5)');
     });
 
     it('should handle call without arguments', () => {
@@ -372,6 +374,7 @@ describe('svg renderer', () => {
           y: 370,
           width: 645,
           height: 1676,
+          edgeBleedTranslate: { x: 21, y: 36 },
         },
       });
     });
@@ -410,6 +413,7 @@ describe('svg renderer', () => {
           y: 0,
           width: 0,
           height: 0,
+          edgeBleedTranslate: { x: 0, y: 0 },
         },
       });
     });

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -88,7 +88,7 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
       type: 'container',
       children: Array.isArray(nodes) ? [...nodes, defs] : nodes,
       transform: rect.edgeBleed.bool
-        ? `translate(${rect.edgeBleed.left * scaleX}, ${rect.edgeBleed.top * scaleY})`
+        ? `translate(${Math.round(rect.edgeBleed.left * scaleX)}, ${Math.round(rect.edgeBleed.top * scaleY)})`
         : '',
     };
 

--- a/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
+++ b/packages/picasso.js/src/web/renderer/svg-renderer/svg-renderer.js
@@ -88,7 +88,7 @@ export default function renderer(treeFn = treeFactory, ns = svgNs, sceneFn = sce
       type: 'container',
       children: Array.isArray(nodes) ? [...nodes, defs] : nodes,
       transform: rect.edgeBleed.bool
-        ? `translate(${Math.round(rect.edgeBleed.left * scaleX)}, ${Math.round(rect.edgeBleed.top * scaleY)})`
+        ? `translate(${rect.computedPhysical.edgeBleedTranslate.x}, ${rect.computedPhysical.edgeBleedTranslate.y})`
         : '',
     };
 


### PR DESCRIPTION
Here is the updated description with that section added:

---

**Problem**: When `centerEndLabels: true` is set on a continuous axis, axis ticks and grid lines are misaligned by up to 1px at non-integer `scaleRatio` values (e.g. on a device where the chart container is an odd number of physical pixels).

---

**Background: why the axis SVG is positioned differently from the grid SVG**

When `centerEndLabels` is on, the topmost label is centered on the axis end point and overhangs above the chart area. To make room, the axis SVG element is expanded upward by `edgeBleed.top = Math.ceil(labelHeight / 2)` pixels (e.g. 7px for a 13px font).

Because the SVG is now bigger and starts higher than the chart area, every axis node (ticks, lines) shifts its scene y-coordinate down by `edgeBleed.top` so it still draws in the right place inside the enlarged SVG.

The grid SVG has no such overhang — it starts exactly at the chart data area.

---

**Root cause**

Both SVGs are scaled by `scaleRatio` (a CSS transform `scale(s)`) when the physical pixel size is not 1:1 with the logical layout size. The element positions are `Math.round()`-ed to land on integer CSS pixels.

The problem is that the axis and grid SVG elements are positioned independently — each gets its own `Math.round()`. When the axis tick's unrounded y differs from the grid line's unrounded y by a fractional amount, those two separate `Math.round()` calls can round in opposite directions, producing a 1px gap.

Concretely, for a tick and grid line both at `position=0`:

| | Formula | Example (`e=6.5, s=1.5`) |
|---|---|---|
| Grid CSS y | `round((y + e) × s)` | `round(9.75)` = **10** |
| Axis tick CSS y (master) | `round((y − e) × s) + 2×e×s` | `round(−9.75) + 19.5` = **9.5** |
| **Δ** | | **−0.5 px** ← off by half a pixel |

The `2×e×s` term is added after rounding, so it can be fractional and throw the tick off from the grid.

---

**Fix**

The axis scene container gets a corrective translate `T` that shifts it so the tick's final CSS y equals exactly `round((y + e) × s)` — the same value the grid is already at:

```
T = round(m + (y + e) × s) − e×s − computedPhysical.y
```

The `−e×s` in `T` cancels the `+e×s` that axis nodes add to their scene coordinates, and `round(m + (y+e) × s)` is the exact integer CSS pixel where the grid already sits.

| | Formula | Example (`e=7, s=1.5`) |
|---|---|---|
| Grid CSS y | `round((y + e) × s)` | `round(10.5)` = **11** |
| Axis tick CSS y (fix) | `round((y + e) × s)` | `round(10.5)` = **11** |
| **Δ** | | **0 px** ✓ |

Note: `Math.ceil(edgeBleed)` is also applied so `e` is always an integer. This matters because on master `e = labelHeight / 2` could be fractional (e.g. 6.5), which made `2×e×s` even more likely to be non-integer.

---

**When `centerEndLabels: false`**

The fix is a complete no-op in this case. When there is no label overhang, `edgeBleed.top = 0`, which makes `T = 0` algebraically. In addition, the translate is gated on `edgeBleed.bool` in the renderer — when `centerEndLabels` is false that flag is `false` and the translate is never applied at all. The scene only gets `scale(sx, sy)`, which is identical to master behavior.

---

**Mathematical proof**

Variables: `m` = `margin.top`, `y` = `outerRect.y`, `e` = `edgeBleed.top`, `s` = `scaleRatio.y`.

$$y_{\text{tick}}^{\text{after}} = \underbrace{\text{round}(m+(y-e)s)}_{\text{computedPhysical.y}} + \underbrace{\text{round}(m+(y+e)s) - es - \text{round}(m+(y-e)s)}_{T} + \underbrace{es}_{\text{axis node offset}}$$

The `round(m+(y−e)s)` and `es` terms cancel exactly:

$$\boxed{y_{\text{tick}}^{\text{after}} = \text{round}(m + (y+e) \times s) = y_{\text{grid}}}$$

This holds for any values of `m`, `y`, `e`, `s` — no coincidental integer alignment required.

---

**Checklist**

- [ ] tests added
- [ ] commits conform to the commit guidelines
- [ ] documentation updated