### PR TITLE
chore(security): add explicit minimumReleaseAge for supply-chain hardening

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,5 +8,7 @@ allowBuilds:
   puppeteer: false
   unrs-resolver: false
 
+minimumReleaseAge: 10080
+
 minimumReleaseAgeExclude:
   - "@qlik/*"


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`, requiring packages to be at least 7 days old on npm before pnpm will install them.

**Change from the original submission:** `blockExoticSubdeps` and `trustPolicy: no-downgrade` have been dropped — those need proper vetting against the dependency tree and CI/contributor workflow before landing.

## Motivation

The original PR mislabeled this as a HIGH severity vulnerability. That framing was wrong — pnpm 11.x already defaults to a 1-day release age, so there's no unprotected gap. This is a **hardening recommendation**: making the policy explicit and raising it from 1 day to 7 days to match the existing Renovate policy.

The argument for `minimumReleaseAge: 10080` specifically:
- The pre-existing `minimumReleaseAgeExclude: ["@qlik/*"]` entry already anticipates this setting — someone set up the exclude list knowing `minimumReleaseAge` would be added
- The 7-day (10080 min) value aligns direct installs with the 7-day window Renovate already enforces for automated dependency updates
- This closes the consistency gap between automated and manual install paths

## What was dropped and why

| Setting | Status | Reason |
|---|---|---|
| `minimumReleaseAge: 10080` | **Kept** | Completes existing `minimumReleaseAgeExclude` setup; aligns with Renovate policy |
| `blockExoticSubdeps: true` | Dropped | Needs dep-tree audit first |
| `trustPolicy: no-downgrade` | Dropped | Needs CI/contributor impact assessment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)